### PR TITLE
Prepare manual history groundwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-06-04
+
+### Added
+
+- Source-aware History groundwork for future manual Console History.
+- History source filters and badges for MCP and future manual command records.
+- `source`, `tracking_reason`, and `output_truncated` command request fields for future not-tracked manual command records.
+
+### Security
+
+- MCP request list/detail APIs explicitly remain scoped to MCP-origin command requests so future manual History rows cannot leak through MCP tools.
+
+### Notes
+
+- This release does not install shell hooks, parse manual terminal input, or change normal Console terminal behavior.
+
 ## [0.1.3] - 2026-06-04
 
 ### Added

--- a/backend/internal/api/approvals.go
+++ b/backend/internal/api/approvals.go
@@ -14,10 +14,14 @@ import (
 const (
 	pendingApprovalAssistantHint = "Wait 3 seconds, then call get_request. Continue polling get_request until terminal status."
 	runningAssistantHint         = "Wait 3 seconds, then call get_request again. Use read_console to inspect live output before sending another command to this server."
+
+	commandRequestSourceMCP    = "mcp"
+	commandRequestSourceManual = "manual"
 )
 
 type commandRequestFilter struct {
 	TokenID  int64
+	Source   string
 	Status   string
 	ServerID int64
 	LabelID  int64
@@ -41,6 +45,11 @@ func (s approvalHandlers) listApprovals(w http.ResponseWriter, r *http.Request) 
 	}
 	filter := commandRequestFilter{
 		Status: strings.TrimSpace(r.URL.Query().Get("status")),
+		Source: strings.TrimSpace(r.URL.Query().Get("source")),
+	}
+	if filter.Source != "" && filter.Source != commandRequestSourceMCP && filter.Source != commandRequestSourceManual {
+		writeError(w, http.StatusBadRequest, "invalid source")
+		return
 	}
 	if rawServerID := strings.TrimSpace(r.URL.Query().Get("server_id")); rawServerID != "" {
 		id, ok := parseInt64Query(w, rawServerID, "server_id")
@@ -92,7 +101,7 @@ func (s approvalHandlers) getApproval(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	item, err := s.getCommandRequest(r.Context(), runtime, id, 0)
+	item, err := s.getCommandRequest(r.Context(), runtime, id, 0, "")
 	if errors.Is(err, sql.ErrNoRows) {
 		writeError(w, http.StatusNotFound, "command request not found")
 		return
@@ -124,7 +133,7 @@ func (s approvalHandlers) runApproval(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	item, err := s.getCommandRequest(r.Context(), runtime, id, 0)
+	item, err := s.getCommandRequest(r.Context(), runtime, id, 0, "")
 	if errors.Is(err, sql.ErrNoRows) {
 		writeError(w, http.StatusNotFound, "approval request not found")
 		return
@@ -197,7 +206,7 @@ func (s approvalHandlers) declineApproval(w http.ResponseWriter, r *http.Request
 	}
 	request.UserNote = strings.TrimSpace(request.UserNote)
 
-	item, err := s.getCommandRequest(r.Context(), runtime, id, 0)
+	item, err := s.getCommandRequest(r.Context(), runtime, id, 0, "")
 	if errors.Is(err, sql.ErrNoRows) {
 		writeError(w, http.StatusNotFound, "approval request not found")
 		return
@@ -292,20 +301,20 @@ func requireAffected(result sql.Result) error {
 }
 
 func (s *Server) listCommandRequests(ctx context.Context, runtime *databaseRuntime, filter commandRequestFilter) ([]commandRequestRecord, error) {
-	where := []string{"(? = 0 OR cr.token_id = ?)", "(? = 0 OR cr.server_id = ?)", "(? = '' OR cr.status = ?)"}
-	args := []any{filter.TokenID, filter.TokenID, filter.ServerID, filter.ServerID, filter.Status, filter.Status}
+	where := []string{"(? = '' OR cr.source = ?)", "(? = 0 OR cr.token_id = ?)", "(? = 0 OR cr.server_id = ?)", "(? = '' OR cr.status = ?)"}
+	args := []any{filter.Source, filter.Source, filter.TokenID, filter.TokenID, filter.ServerID, filter.ServerID, filter.Status, filter.Status}
 	if filter.LabelID != 0 {
 		where = append(where, `cr.id IN (SELECT command_request_id FROM command_request_labels WHERE label_id = ?)`)
 		args = append(args, filter.LabelID)
 	}
 	query := `
-		SELECT cr.id, cr.token_id, COALESCE(tok.name, ''), cr.server_id, srv.name, cr.command, cr.reason, cr.status,
-		       cr.stdout, cr.stderr, cr.exit_code, cr.session_id, cr.user_note, cr.error, cr.created_at, cr.completed_at
+		SELECT cr.id, cr.token_id, COALESCE(tok.name, ''), cr.server_id, srv.name, cr.source, cr.command, cr.reason, cr.status,
+		       cr.tracking_reason, cr.output_truncated, cr.stdout, cr.stderr, cr.exit_code, cr.session_id, cr.user_note, cr.error, cr.created_at, cr.completed_at
 		FROM command_requests cr
 		JOIN servers srv ON srv.id = cr.server_id
 		LEFT JOIN api_tokens tok ON tok.id = cr.token_id
 		WHERE ` + strings.Join(where, " AND ") + `
-		ORDER BY cr.created_at DESC
+		ORDER BY cr.created_at DESC, cr.id DESC
 		LIMIT 100`
 	rows, err := runtime.database.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -331,8 +340,8 @@ func (s *Server) listCommandRequests(ctx context.Context, runtime *databaseRunti
 }
 
 func (s *Server) listCommandRequestSummaries(ctx context.Context, runtime *databaseRuntime, filter commandRequestFilter) ([]commandRequestRecord, int, error) {
-	where := []string{"(? = 0 OR cr.token_id = ?)", "(? = 0 OR cr.server_id = ?)", "(? = '' OR cr.status = ?)"}
-	args := []any{filter.TokenID, filter.TokenID, filter.ServerID, filter.ServerID, filter.Status, filter.Status}
+	where := []string{"(? = '' OR cr.source = ?)", "(? = 0 OR cr.token_id = ?)", "(? = 0 OR cr.server_id = ?)", "(? = '' OR cr.status = ?)"}
+	args := []any{filter.Source, filter.Source, filter.TokenID, filter.TokenID, filter.ServerID, filter.ServerID, filter.Status, filter.Status}
 	if filter.LabelID != 0 {
 		where = append(where, `cr.id IN (SELECT command_request_id FROM command_request_labels WHERE label_id = ?)`)
 		args = append(args, filter.LabelID)
@@ -343,8 +352,8 @@ func (s *Server) listCommandRequestSummaries(ctx context.Context, runtime *datab
 			where = append(where, `(cr.id IN (SELECT rowid FROM command_requests_fts WHERE command_requests_fts MATCH ?) OR srv.name LIKE ? OR COALESCE(tok.name, '') LIKE ?)`)
 			args = append(args, ftsQuery, like, like)
 		} else {
-			where = append(where, `(cr.command LIKE ? OR cr.reason LIKE ? OR cr.status LIKE ? OR cr.stdout LIKE ? OR cr.stderr LIKE ? OR cr.error LIKE ? OR srv.name LIKE ? OR COALESCE(tok.name, '') LIKE ?)`)
-			args = append(args, like, like, like, like, like, like, like, like)
+			where = append(where, `(cr.command LIKE ? OR cr.reason LIKE ? OR cr.status LIKE ? OR cr.source LIKE ? OR cr.tracking_reason LIKE ? OR cr.stdout LIKE ? OR cr.stderr LIKE ? OR cr.error LIKE ? OR srv.name LIKE ? OR COALESCE(tok.name, '') LIKE ?)`)
+			args = append(args, like, like, like, like, like, like, like, like, like, like)
 		}
 	}
 	whereSQL := strings.Join(where, " AND ")
@@ -362,8 +371,8 @@ func (s *Server) listCommandRequestSummaries(ctx context.Context, runtime *datab
 
 	queryArgs := append(append([]any{}, args...), filter.Limit, filter.Offset)
 	rows, err := runtime.database.QueryContext(ctx, `
-		SELECT cr.id, cr.token_id, COALESCE(tok.name, ''), cr.server_id, srv.name, cr.command, cr.reason, cr.status,
-		       '' AS stdout, '' AS stderr, cr.exit_code, cr.session_id, cr.user_note, cr.error, cr.created_at, cr.completed_at
+		SELECT cr.id, cr.token_id, COALESCE(tok.name, ''), cr.server_id, srv.name, cr.source, cr.command, cr.reason, cr.status,
+		       cr.tracking_reason, cr.output_truncated, '' AS stdout, '' AS stderr, cr.exit_code, cr.session_id, cr.user_note, cr.error, cr.created_at, cr.completed_at
 		FROM command_requests cr
 		JOIN servers srv ON srv.id = cr.server_id
 		LEFT JOIN api_tokens tok ON tok.id = cr.token_id
@@ -394,15 +403,17 @@ func (s *Server) listCommandRequestSummaries(ctx context.Context, runtime *datab
 	return items, total, nil
 }
 
-func (s *Server) getCommandRequest(ctx context.Context, runtime *databaseRuntime, id int64, tokenID int64) (commandRequestRecord, error) {
+func (s *Server) getCommandRequest(ctx context.Context, runtime *databaseRuntime, id int64, tokenID int64, source string) (commandRequestRecord, error) {
 	row := runtime.database.QueryRowContext(ctx, `
-		SELECT cr.id, cr.token_id, COALESCE(tok.name, ''), cr.server_id, srv.name, cr.command, cr.reason, cr.status,
-		       cr.stdout, cr.stderr, cr.exit_code, cr.session_id, cr.user_note, cr.error, cr.created_at, cr.completed_at
+		SELECT cr.id, cr.token_id, COALESCE(tok.name, ''), cr.server_id, srv.name, cr.source, cr.command, cr.reason, cr.status,
+		       cr.tracking_reason, cr.output_truncated, cr.stdout, cr.stderr, cr.exit_code, cr.session_id, cr.user_note, cr.error, cr.created_at, cr.completed_at
 		FROM command_requests cr
 		JOIN servers srv ON srv.id = cr.server_id
 		LEFT JOIN api_tokens tok ON tok.id = cr.token_id
-		WHERE cr.id = ? AND (? = 0 OR cr.token_id = ?)`,
+		WHERE cr.id = ? AND (? = '' OR cr.source = ?) AND (? = 0 OR cr.token_id = ?)`,
 		id,
+		source,
+		source,
 		tokenID,
 		tokenID,
 	)
@@ -427,15 +438,19 @@ func scanCommandRequest(scanner interface {
 	var sessionID sql.NullInt64
 	var userNote sql.NullString
 	var completedAt sql.NullString
+	var outputTruncated int
 	err := scanner.Scan(
 		&item.ID,
 		&tokenID,
 		&item.TokenName,
 		&item.ServerID,
 		&item.ServerName,
+		&item.Source,
 		&item.Command,
 		&item.Reason,
 		&item.Status,
+		&item.TrackingReason,
+		&outputTruncated,
 		&item.Stdout,
 		&item.Stderr,
 		&exitCode,
@@ -448,6 +463,10 @@ func scanCommandRequest(scanner interface {
 	if err != nil {
 		return commandRequestRecord{}, err
 	}
+	if item.Source == "" {
+		item.Source = commandRequestSourceMCP
+	}
+	item.OutputTruncated = outputTruncated != 0
 	item.Stdout = console.PlainOutput(item.Stdout)
 	item.Stderr = console.PlainOutput(item.Stderr)
 	if tokenID.Valid {

--- a/backend/internal/api/mcp.go
+++ b/backend/internal/api/mcp.go
@@ -233,7 +233,7 @@ func (s mcpHandlers) mcpListRequests(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	status := strings.TrimSpace(r.URL.Query().Get("status"))
-	items, err := s.listCommandRequests(r.Context(), auth.runtime, commandRequestFilter{TokenID: auth.TokenID, Status: status})
+	items, err := s.listCommandRequests(r.Context(), auth.runtime, commandRequestFilter{TokenID: auth.TokenID, Source: commandRequestSourceMCP, Status: status})
 	if err != nil {
 		writeInternalError(w)
 		return
@@ -250,7 +250,7 @@ func (s mcpHandlers) mcpGetRequest(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	item, err := s.getCommandRequest(r.Context(), auth.runtime, id, auth.TokenID)
+	item, err := s.getCommandRequest(r.Context(), auth.runtime, id, auth.TokenID, commandRequestSourceMCP)
 	if errors.Is(err, sql.ErrNoRows) {
 		writeError(w, http.StatusNotFound, "request not found")
 		return

--- a/backend/internal/api/mcp_command_requests.go
+++ b/backend/internal/api/mcp_command_requests.go
@@ -20,10 +20,11 @@ func (s *Server) insertCommandRequest(ctx context.Context, runtime *databaseRunt
 	storedCommand := s.redactForPersistence(ctx, runtime, command)
 	storedReason := s.redactForPersistence(ctx, runtime, reason)
 	result, err := runtime.database.ExecContext(ctx, `
-		INSERT INTO command_requests (token_id, server_id, command, encrypted_command, reason, status, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO command_requests (token_id, server_id, source, command, encrypted_command, reason, status, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		tokenID,
 		serverID,
+		commandRequestSourceMCP,
 		storedCommand,
 		encryptedCommand,
 		storedReason,

--- a/backend/internal/api/mcp_test.go
+++ b/backend/internal/api/mcp_test.go
@@ -353,7 +353,7 @@ func TestMCPExecApprovalPendingCreatesAuditableRequestAndConsumesUserNote(t *tes
 		t.Fatalf("expected user note to be consumed, got %#v", body.UserNote)
 	}
 
-	record, err := fixture.server.getCommandRequest(ctx, runtime, body.RequestID, token.ID)
+	record, err := fixture.server.getCommandRequest(ctx, runtime, body.RequestID, token.ID, commandRequestSourceMCP)
 	if err != nil {
 		t.Fatalf("get command request: %v", err)
 	}
@@ -444,7 +444,7 @@ func TestMCPExecDoesNotAttachNewRequestToExistingActiveCommand(t *testing.T) {
 	if !strings.Contains(body.Error, "another command is already running") {
 		t.Fatalf("expected active command guidance, got %q", body.Error)
 	}
-	record, err := fixture.server.getCommandRequest(ctx, runtime, body.RequestID, token.ID)
+	record, err := fixture.server.getCommandRequest(ctx, runtime, body.RequestID, token.ID, commandRequestSourceMCP)
 	if err != nil {
 		t.Fatalf("get command request: %v", err)
 	}

--- a/backend/internal/api/mcp_types.go
+++ b/backend/internal/api/mcp_types.go
@@ -67,9 +67,12 @@ type commandRequestRecord struct {
 	TokenName         string               `json:"token_name,omitempty"`
 	ServerID          int64                `json:"server_id"`
 	ServerName        string               `json:"server_name"`
+	Source            string               `json:"source"`
 	Command           string               `json:"command"`
 	Reason            string               `json:"reason"`
 	Status            string               `json:"status"`
+	TrackingReason    string               `json:"tracking_reason,omitempty"`
+	OutputTruncated   bool                 `json:"output_truncated,omitempty"`
 	Stdout            string               `json:"stdout,omitempty"`
 	Stderr            string               `json:"stderr,omitempty"`
 	ExitCode          *int                 `json:"exit_code,omitempty"`

--- a/backend/internal/api/redaction_test.go
+++ b/backend/internal/api/redaction_test.go
@@ -94,7 +94,7 @@ func TestCommandRequestKeepsEncryptedRawCommandForExecution(t *testing.T) {
 		t.Fatalf("insert command request: %v", err)
 	}
 
-	record, err := fixture.server.getCommandRequest(ctx, runtime, id, token.ID)
+	record, err := fixture.server.getCommandRequest(ctx, runtime, id, token.ID, commandRequestSourceMCP)
 	if err != nil {
 		t.Fatalf("get command request: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestCommandRequestErrorsAreRedactedBeforePersistence(t *testing.T) {
 	if err := fixture.server.finishCommandRequest(ctx, runtime, id, "error", 0, "", "", 1, "ssh failed password=super-secret"); err != nil {
 		t.Fatalf("finish command request: %v", err)
 	}
-	record, err := fixture.server.getCommandRequest(ctx, runtime, id, token.ID)
+	record, err := fixture.server.getCommandRequest(ctx, runtime, id, token.ID, commandRequestSourceMCP)
 	if err != nil {
 		t.Fatalf("get command request: %v", err)
 	}

--- a/backend/internal/api/routes_test.go
+++ b/backend/internal/api/routes_test.go
@@ -281,12 +281,23 @@ func TestApprovalAndMCPRequestRoutes(t *testing.T) {
 	if response := performJSON(fixture.server.Handler(), http.MethodGet, "/api/mcp/requests/"+strconv.FormatInt(requestID, 10), token.TokenValue, nil); response.Code != http.StatusOK || !strings.Contains(response.Body.String(), pendingApprovalAssistantHint) {
 		t.Fatalf("mcp get request failed: %d %s", response.Code, response.Body.String())
 	}
+	manualID := insertManualRouteCommandRequest(t, fixture.db, server.ID, "nano /etc/hosts ...", "interactive_editor")
+	historyManualResponse := performJSON(fixture.server.Handler(), http.MethodGet, "/api/approvals?paginated=true&source=manual", "", nil)
+	if historyManualResponse.Code != http.StatusOK || !strings.Contains(historyManualResponse.Body.String(), `"source":"manual"`) || !strings.Contains(historyManualResponse.Body.String(), `"tracking_reason":"interactive_editor"`) {
+		t.Fatalf("manual history source filter failed: %d %s", historyManualResponse.Code, historyManualResponse.Body.String())
+	}
+	if response := performJSON(fixture.server.Handler(), http.MethodGet, "/api/mcp/requests", token.TokenValue, nil); response.Code != http.StatusOK || strings.Contains(response.Body.String(), `"source":"manual"`) || strings.Contains(response.Body.String(), "nano /etc/hosts") {
+		t.Fatalf("mcp list requests should not expose manual history rows: %d %s", response.Code, response.Body.String())
+	}
+	if response := performJSON(fixture.server.Handler(), http.MethodGet, "/api/mcp/requests/"+strconv.FormatInt(manualID, 10), token.TokenValue, nil); response.Code != http.StatusNotFound {
+		t.Fatalf("mcp get request should not expose manual history row, got %d %s", response.Code, response.Body.String())
+	}
 
 	declineResponse := performJSON(fixture.server.Handler(), http.MethodPost, "/api/approvals/"+strconv.FormatInt(requestID, 10)+"/decline", "", declineApprovalRequest{UserNote: "use another path"})
 	if declineResponse.Code != http.StatusOK || !strings.Contains(declineResponse.Body.String(), `"declined"`) {
 		t.Fatalf("decline approval failed: %d %s", declineResponse.Code, declineResponse.Body.String())
 	}
-	record, err := fixture.server.getCommandRequest(ctx, runtime, requestID, token.ID)
+	record, err := fixture.server.getCommandRequest(ctx, runtime, requestID, token.ID, commandRequestSourceMCP)
 	if err != nil {
 		t.Fatalf("get declined command request: %v", err)
 	}
@@ -605,6 +616,28 @@ func insertRouteCommandRequest(t *testing.T, database *sql.DB, tokenID int64, se
 	id, err := result.LastInsertId()
 	if err != nil {
 		t.Fatalf("command request id: %v", err)
+	}
+	return id
+}
+
+func insertManualRouteCommandRequest(t *testing.T, database *sql.DB, serverID int64, command string, reason string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	result, err := database.Exec(`
+		INSERT INTO command_requests (server_id, source, command, reason, status, tracking_reason, stdout, stderr, created_at, completed_at)
+		VALUES (?, 'manual', ?, 'manual command not tracked', 'untracked', ?, '', '', ?, ?)`,
+		serverID,
+		command,
+		reason,
+		now,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("insert manual command request: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("manual command request id: %v", err)
 	}
 	return id
 }

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -11,7 +11,7 @@ import (
 	_ "github.com/mutecomm/go-sqlcipher/v4"
 )
 
-const currentSchemaVersion = 3
+const currentSchemaVersion = 4
 
 func OpenEncrypted(path string, password string) (*sql.DB, error) {
 	return openEncrypted(path, password, true)

--- a/backend/internal/db/db_test.go
+++ b/backend/internal/db/db_test.go
@@ -48,6 +48,15 @@ func TestOpenEncryptedCreatesSchemaAndRejectsWrongPassword(t *testing.T) {
 	if !columnExists(t, database, "api_tokens", "expires_at") {
 		t.Fatalf("api_tokens.expires_at column was not created")
 	}
+	if !columnExists(t, database, "command_requests", "source") {
+		t.Fatalf("command_requests.source column was not created")
+	}
+	if !columnExists(t, database, "command_requests", "tracking_reason") {
+		t.Fatalf("command_requests.tracking_reason column was not created")
+	}
+	if !columnExists(t, database, "command_requests", "output_truncated") {
+		t.Fatalf("command_requests.output_truncated column was not created")
+	}
 	var foreignKeys int
 	if err := database.QueryRow(`PRAGMA foreign_keys`).Scan(&foreignKeys); err != nil {
 		t.Fatalf("query foreign keys pragma: %v", err)

--- a/backend/internal/db/migrations.go
+++ b/backend/internal/db/migrations.go
@@ -241,6 +241,15 @@ var ecdsaSSHKeyStatements = []string{
 	`CREATE INDEX IF NOT EXISTS idx_ssh_keys_name ON ssh_keys(name);`,
 }
 
+var manualHistoryGroundworkStatements = []string{
+	`ALTER TABLE command_requests ADD COLUMN source TEXT NOT NULL DEFAULT 'mcp';`,
+	`ALTER TABLE command_requests ADD COLUMN tracking_reason TEXT NOT NULL DEFAULT '';`,
+	`ALTER TABLE command_requests ADD COLUMN output_truncated INTEGER NOT NULL DEFAULT 0;`,
+	`CREATE INDEX IF NOT EXISTS idx_command_requests_source_created ON command_requests(source, created_at);`,
+	`CREATE INDEX IF NOT EXISTS idx_command_requests_server_source_created ON command_requests(server_id, source, created_at);`,
+	`CREATE INDEX IF NOT EXISTS idx_command_requests_token_source_status_created ON command_requests(token_id, source, status, created_at);`,
+}
+
 var migrations = []migration{
 	{
 		version:     1,
@@ -256,6 +265,11 @@ var migrations = []migration{
 		version:     3,
 		description: "allow imported ecdsa ssh keys",
 		statements:  ecdsaSSHKeyStatements,
+	},
+	{
+		version:     4,
+		description: "manual history groundwork",
+		statements:  manualHistoryGroundworkStatements,
 	},
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,6 +83,13 @@ AIPermission against real VPS maintenance tasks.
 - On-demand Docker quick checks from the Servers page.
 - Docker container details and tail-configurable Docker logs dialogs.
 
+`0.1.4` ships:
+
+- Source-aware History groundwork for future manual Console History.
+- History source filters and badges for MCP and future manual command records.
+- MCP request APIs explicitly scoped to MCP-origin command requests.
+- No shell hooks or manual terminal parsing yet; normal Console terminal behavior is unchanged.
+
 ## Early RC Follow-Ups
 
 These are good candidates for small follow-up releases after the first public
@@ -93,9 +100,10 @@ tag:
 - [ ] Add command policy/risk scoring primitives without turning the product
   into a DevOps platform.
 - [ ] Add optional deny/warn rules for common high-risk command patterns.
-- [ ] Add structured manual command event parsing for History, including busy
-  Console status dots for user-typed commands. Do this with a deliberate
-  terminal parsing model instead of a quick frontend-only guess.
+- [ ] Add structured manual command event parsing for History on top of the
+  source-aware History groundwork. Do this with a deliberate terminal parsing
+  model instead of a quick frontend-only guess, and preserve normal terminal
+  behavior as the first invariant.
 - [ ] Add optional safety backup before import.
 - [ ] Add more Playwright browser tests for Settings, import, token permission,
   and approval workflows.

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -231,6 +231,9 @@ declined
 error
 ```
 
+MCP request tools return only MCP-origin command requests for the calling token.
+They do not expose future manual Console History rows.
+
 ## send_message
 
 Allows the AI to write a short note to the web Console Messages panel. It is a coordination channel, not a place for credentials or large shell output.

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -417,13 +417,15 @@ POST /api/history-labels
 DELETE /api/history-labels/{id}
 ```
 
-`GET /api/approvals` returns recent command requests. Optional filters include `status`, `server_id`, and `label_id`.
+`GET /api/approvals` returns recent command requests. Optional filters include `status`, `source`, `server_id`, and `label_id`. `source` is `mcp` for MCP/approval command requests and `manual` for future manual Console History records.
 
 The History page uses paginated search. `q` searches command text, reason, status, captured output, error, server name, and token name. Command text and output fields use SQLCipher-backed FTS4 indexes; server and token names remain regular filtered fields:
 
 ```txt
-GET /api/approvals?paginated=true&limit=50&offset=0&q=docker&status=completed&server_id=3&label_id=4
+GET /api/approvals?paginated=true&limit=50&offset=0&q=docker&source=mcp&status=completed&server_id=3&label_id=4
 ```
+
+History response items include `source`, `tracking_reason`, and `output_truncated`. Manual Console History is groundwork only in this release; the Console does not yet install shell hooks or parse manual terminal input.
 
 The paginated response is an envelope:
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aipermission-frontend",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@xterm/addon-fit": "^0.11.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -61,8 +61,8 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.1\.3"/);
-  assert.match(releaseSource, /SSH key and host import/);
+  assert.match(releaseSource, /appVersion = "0\.1\.4"/);
+  assert.match(releaseSource, /Manual history groundwork/);
 });
 
 test("Sidebar exposes explicit MCP runtime start and stop controls", () => {
@@ -119,6 +119,9 @@ test("Settings database delete requires a confirmation dialog and current passwo
 test("History page exposes label filtering and item label endpoints", () => {
   assert.match(historySource, /\/api\/history-labels/);
   assert.match(historySource, /label_id/);
+  assert.match(historySource, /source/);
+  assert.match(historySource, /SourceBadge/);
+  assert.match(historySource, /Not tracked/);
   assert.match(historySource, /\/api\/approvals\/\$\{id\}\/labels/);
   assert.doesNotMatch(historySource, /setLabelDialogOpen/);
 });

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,26 @@
-export const appVersion = "0.1.3";
+export const appVersion = "0.1.4";
 
 export const changelogEntries = [
+  {
+    version: "0.1.4",
+    label: "Manual history groundwork",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Source-aware History groundwork for future manual Console History.",
+          "History source filters and badges for MCP and future manual command records.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "MCP request APIs now explicitly stay scoped to MCP-origin command requests.",
+          "Manual History groundwork does not install shell hooks or change terminal behavior.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.1.3",
     label: "SSH key and host import",

--- a/frontend/src/pages/history.jsx
+++ b/frontend/src/pages/history.jsx
@@ -330,8 +330,8 @@ function HistoryDialog({ item, labels = [], onClose, onAttachLabel, onDetachLabe
   const suggestions = labels
     .filter((label) => !attachedNames.has(label.name.toLowerCase()))
     .filter((label) => !labelQuery || label.name.toLowerCase().includes(labelQuery))
-    .slice(0, 8);
-  const showSuggestions = suggestionsOpen && labelQuery && suggestions.length > 0;
+    .slice(0, 10);
+  const showSuggestions = suggestionsOpen && suggestions.length > 0;
 
   function focusLabelInput() {
     window.setTimeout(() => labelInputRef.current?.focus(), 0);
@@ -360,13 +360,13 @@ function HistoryDialog({ item, labels = [], onClose, onAttachLabel, onDetachLabe
   }
 
   function handleLabelKeyDown(event) {
-    if (event.key === "ArrowDown" && labelQuery && suggestions.length > 0) {
+    if (event.key === "ArrowDown" && suggestions.length > 0) {
       event.preventDefault();
       setSuggestionsOpen(true);
       setActiveSuggestion((current) => Math.min(current + 1, suggestions.length - 1));
       return;
     }
-    if (event.key === "ArrowUp" && labelQuery && suggestions.length > 0) {
+    if (event.key === "ArrowUp" && suggestions.length > 0) {
       event.preventDefault();
       setSuggestionsOpen(true);
       setActiveSuggestion((current) => Math.max(current - 1, 0));
@@ -459,7 +459,10 @@ function HistoryDialog({ item, labels = [], onClose, onAttachLabel, onDetachLabe
                     setSuggestionsOpen(true);
                     setActiveSuggestion(0);
                   }}
-                  onFocus={() => setSuggestionsOpen(Boolean(labelName.trim()))}
+                  onFocus={() => {
+                    setSuggestionsOpen(true);
+                    setActiveSuggestion(0);
+                  }}
                   onBlur={() => window.setTimeout(() => setSuggestionsOpen(false), 120)}
                   onKeyDown={handleLabelKeyDown}
                   placeholder={attachedLabels.length === 0 ? "Type a label and press Enter" : "Add another label"}

--- a/frontend/src/pages/history.jsx
+++ b/frontend/src/pages/history.jsx
@@ -19,11 +19,18 @@ const statusOptions = [
   { value: "failed", label: "Failed" },
   { value: "declined", label: "Declined" },
   { value: "error", label: "Error" },
+  { value: "untracked", label: "Not tracked" },
+];
+
+const sourceOptions = [
+  { value: "", label: "All sources" },
+  { value: "mcp", label: "MCP" },
+  { value: "manual", label: "Manual" },
 ];
 
 export function HistoryPage() {
   const { servers, approvals, loadApprovals } = useGateway();
-  const [filters, setFilters] = useState({ query: "", status: "", serverID: "", labelID: "" });
+  const [filters, setFilters] = useState({ query: "", status: "", source: "", serverID: "", labelID: "" });
   const [state, setState] = useState({
     state: "idle",
     data: [],
@@ -55,7 +62,7 @@ export function HistoryPage() {
       void loadHistory(0);
     }, 250);
     return () => window.clearTimeout(timer);
-  }, [filters.query, filters.status, filters.serverID, filters.labelID]);
+  }, [filters.query, filters.status, filters.source, filters.serverID, filters.labelID]);
 
   async function loadLabels() {
     setLabels((current) => ({ ...current, state: "loading", error: null }));
@@ -76,6 +83,7 @@ export function HistoryPage() {
     });
     if (filters.query.trim()) params.set("q", filters.query.trim());
     if (filters.status) params.set("status", filters.status);
+    if (filters.source) params.set("source", filters.source);
     if (filters.serverID) params.set("server_id", filters.serverID);
     if (filters.labelID) params.set("label_id", filters.labelID);
     try {
@@ -154,7 +162,7 @@ export function HistoryPage() {
         <HistoryStat label="Failed/error" value={stats.failed} tone="bad" />
       </div>
 
-      <div className="grid gap-3 rounded-lg border border-stone-200 bg-white p-4 md:grid-cols-[minmax(0,1fr)_190px_190px_190px]">
+      <div className="grid gap-3 rounded-lg border border-stone-200 bg-white p-4 md:grid-cols-[minmax(0,1fr)_150px_180px_180px_180px]">
         <div className="relative">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-stone-400" />
           <Input
@@ -164,6 +172,16 @@ export function HistoryPage() {
             className="pl-9"
           />
         </div>
+        <Select
+          value={filters.source}
+          onChange={(event) => setFilters((current) => ({ ...current, source: event.target.value }))}
+        >
+          {sourceOptions.map((option) => (
+            <option key={option.value || "all"} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
         <Select
           value={filters.serverID}
           onChange={(event) => setFilters((current) => ({ ...current, serverID: event.target.value }))}
@@ -208,7 +226,7 @@ export function HistoryPage() {
             <tr>
               <th className="w-[12%] px-4 py-3 font-semibold">Status</th>
               <th className="w-[16%] px-4 py-3 font-semibold">Server</th>
-              <th className="w-[18%] px-4 py-3 font-semibold">Token</th>
+              <th className="w-[18%] px-4 py-3 font-semibold">Source</th>
               <th className="w-[26%] px-4 py-3 font-semibold">Command</th>
               <th className="w-[8%] px-4 py-3 font-semibold">Labels</th>
               <th className="w-[12%] px-4 py-3 font-semibold">Exit</th>
@@ -241,7 +259,9 @@ export function HistoryPage() {
                       <StatusBadge status={item.status} />
                     </td>
                     <td className="truncate px-4 py-3 font-medium text-stone-900">{item.server_name}</td>
-                    <td className="truncate px-4 py-3 text-stone-600">{item.token_name || "manual"}</td>
+                    <td className="px-4 py-3">
+                      <SourceCell item={item} />
+                    </td>
                     <td className="truncate px-4 py-3 font-mono text-xs text-stone-700">{oneLine(item.command)}</td>
                     <td className="px-4 py-3">
                       <LabelPreview labels={item.labels || []} />
@@ -398,10 +418,17 @@ function HistoryDialog({ item, labels = [], onClose, onAttachLabel, onDetachLabe
             <div className="flex min-w-0 flex-wrap items-center gap-2 md:justify-end">
               <StatusBadge status={item.status} />
               {item.token_name ? <Badge>{item.token_name}</Badge> : null}
+              <SourceBadge source={item.source} />
               {item.session_id ? <Badge>session {item.session_id}</Badge> : null}
               {item.exit_code !== undefined && item.exit_code !== null ? <Badge>exit {item.exit_code}</Badge> : null}
+              {item.output_truncated ? <Badge tone="warn">output truncated</Badge> : null}
             </div>
           </div>
+          {item.status === "untracked" ? (
+            <p className="truncate rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950">
+              <span className="font-semibold">Not tracked:</span> {trackingReasonLabel(item.tracking_reason)}
+            </p>
+          ) : null}
           {item.user_note ? (
             <p className="truncate rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950">
               <span className="font-semibold">User note:</span> {item.user_note}
@@ -496,6 +523,24 @@ function LabelPreview({ labels }) {
   );
 }
 
+function SourceCell({ item }) {
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <SourceBadge source={item.source} />
+      {item.source === "manual" ? (
+        <span className="truncate text-xs text-stone-500">local console</span>
+      ) : (
+        <span className="truncate text-xs text-stone-600">{item.token_name || "deleted token"}</span>
+      )}
+    </div>
+  );
+}
+
+function SourceBadge({ source }) {
+  const value = source || "mcp";
+  return <Badge tone={value === "manual" ? "warn" : "neutral"}>{value === "manual" ? "manual" : "mcp"}</Badge>;
+}
+
 function SectionHeader({ label, value }) {
   return (
     <div className="flex items-center justify-between gap-2">
@@ -511,6 +556,7 @@ function StatusBadge({ status }) {
     running: "neutral",
     pending_approval: "warn",
     declined: "warn",
+    untracked: "warn",
     failed: "bad",
     error: "bad",
   }[status] || "neutral";
@@ -527,7 +573,26 @@ function labelStyle(label) {
 
 function statusLabel(status) {
   if (status === "pending_approval") return "pending";
+  if (status === "untracked") return "not tracked";
   return status || "unknown";
+}
+
+function trackingReasonLabel(reason) {
+  const labels = {
+    interactive_editor: "interactive editor command",
+    interactive_repl: "interactive REPL command",
+    interactive_tui: "interactive terminal program",
+    nested_shell: "nested shell boundary",
+    multiline_or_heredoc: "multiline command preview only",
+    compound_command: "compound command shape",
+    unsupported_shell: "unsupported shell",
+    untrusted_command_text: "command text was not trusted",
+    marker_desync: "capture marker desynchronized",
+    active_exec_paused: "capture paused while an MCP command was running",
+    output_buffer_limit: "output exceeded the capture limit",
+    privacy_history_suppressed: "history privacy settings suppressed capture",
+  };
+  return labels[reason] || reason || "AIPermission did not capture output or lifecycle for this command.";
 }
 
 function oneLine(value) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
     },
     "frontend": {
       "name": "aipermission-frontend",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@xterm/addon-fit": "^0.11.0",


### PR DESCRIPTION
## Summary

- Add source-aware command history groundwork for future manual console records.
- Add History source filters and badges for MCP/manual records.
- Show history label suggestions when the label input is focused.

## Notes

- This does not tag or publish 0.1.4 yet.
- Manual console command capture is intentionally not enabled in this batch.

## Verification

- make test
- make build
- git diff --check
- node scripts/secret-scan.js
- Docker compose smoke on localhost