### PR TITLE
Release 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,33 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
-## [0.1.4] - 2026-06-04
+## [0.1.4] - 2026-06-05
 
 ### Added
 
-- Source-aware History groundwork for future manual Console History.
-- History source filters and badges for MCP and future manual command records.
-- `source`, `tracking_reason`, and `output_truncated` command request fields for future not-tracked manual command records.
+- Manual Console command logging for simple terminal input. Manually typed or
+  pasted commands are recorded as `source = manual` without changing normal
+  terminal behavior.
+- Best-effort output capture for simple manual commands. When the shell prompt
+  returns, History records captured output and marks the command `completed` or
+  `canceled`.
+- History source filters and badges for MCP and manual command records.
+- `source`, `tracking_reason`, and `output_truncated` command request fields for
+  manual command records.
 
 ### Security
 
-- MCP request list/detail APIs explicitly remain scoped to MCP-origin command requests so future manual History rows cannot leak through MCP tools.
+- MCP request list/detail APIs explicitly remain scoped to MCP-origin command requests so manual History rows cannot leak through MCP tools.
 
 ### Notes
 
-- This release does not install shell hooks, parse manual terminal input, or change normal Console terminal behavior.
+- Interactive commands, nested shells, heredocs, and unsafe control sequences are
+  stored as `untracked` best-effort records. Arrow/history recall is stored with
+  a placeholder command because the terminal does not send the recalled command
+  text; simple recalled commands may still capture output when the prompt
+  returns, while ambiguous interactive recalled commands are left `untracked`.
+- This release does not install shell hooks, append hidden command suffixes, or
+  infer shell history recall from arrow keys.
 
 ## [0.1.3] - 2026-06-04
 

--- a/backend/internal/console/console_exec.go
+++ b/backend/internal/console/console_exec.go
@@ -44,6 +44,8 @@ func (s *managedConsoleSession) execCommand(ctx context.Context, command string)
 		}, ErrCommandActive
 	}
 
+	s.closeManualOutputCapture(manualActiveExecPaused)
+
 	started := time.Now()
 	marker := fmt.Sprintf("__AIPERMISSION_EXIT_%d_%d__", s.id, started.UnixNano())
 	s.mu.Lock()

--- a/backend/internal/console/console_session_manager.go
+++ b/backend/internal/console/console_session_manager.go
@@ -191,7 +191,12 @@ func (m *Manager) Input(ctx context.Context, id int64, data string) error {
 	if session == nil {
 		return fmt.Errorf("console session is not active")
 	}
-	return session.writeInput(data)
+	manualCommands := session.prepareManualInput(data)
+	if err := session.writeInput(data); err != nil {
+		return err
+	}
+	session.persistManualInput(manualCommands)
+	return nil
 }
 
 func (m *Manager) Exec(ctx context.Context, serverID int64, command string) (ExecResult, error) {
@@ -331,7 +336,10 @@ func (m *Manager) Attach(w http.ResponseWriter, r *http.Request, id int64, upgra
 			if !inputLimiter.allow() {
 				continue
 			}
-			_ = session.writeInput(message.Data)
+			manualCommands := session.prepareManualInput(message.Data)
+			if err := session.writeInput(message.Data); err == nil {
+				session.persistManualInput(manualCommands)
+			}
 		case "resize":
 			if !resizeLimiter.allow() {
 				continue

--- a/backend/internal/console/console_session_runtime.go
+++ b/backend/internal/console/console_session_runtime.go
@@ -213,6 +213,7 @@ func (s *managedConsoleSession) fail(message string) {
 func (s *managedConsoleSession) finish(status string, message string) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	persistedMessage := s.manager.redactText(message)
+	s.closeManualOutputCapture(manualSessionClosed)
 	s.mu.Lock()
 	s.status = status
 	if persistedMessage != "" {
@@ -269,7 +270,12 @@ func (s *managedConsoleSession) appendOutput(data string) {
 	if s.manager != nil && s.manager.db != nil && s.persistTimer == nil {
 		s.persistTimer = time.AfterFunc(500*time.Millisecond, s.flushTranscript)
 	}
+	manualCompletion := s.manualOutputCompletionLocked()
+	s.clearManualPauseIfPromptReturnedLocked()
 	s.mu.Unlock()
+	if manualCompletion != nil {
+		go s.finishManualOutputCapture(manualCompletion)
+	}
 	if flushSoon {
 		go s.flushTranscript()
 	}

--- a/backend/internal/console/console_sessions.go
+++ b/backend/internal/console/console_sessions.go
@@ -90,6 +90,21 @@ type consoleSessionActiveExec struct {
 	Started     time.Time
 }
 
+type consoleSessionManualCapture struct {
+	RequestID                int64
+	Command                  string
+	StartOffset              int
+	ResumePrompt             string
+	Started                  time.Time
+	CompletionTrackingReason string
+}
+
+type consoleSessionManualPause struct {
+	Prompt      string
+	Reason      string
+	StartOffset int
+}
+
 type Manager struct {
 	db          *sql.DB
 	getMaterial func(context.Context, int64) (servers.Server, sshkeys.PrivateKey, error)
@@ -130,6 +145,9 @@ type managedConsoleSession struct {
 	sshSession    *ssh.Session
 	clients       map[*websocket.Conn]*sync.Mutex
 	activeExec    *consoleSessionActiveExec
+	manualInput   manualInputCapture
+	manualActive  *consoleSessionManualCapture
+	manualPause   *consoleSessionManualPause
 	filterUntil   time.Time
 	persistTimer  *time.Timer
 }

--- a/backend/internal/console/console_sessions_test.go
+++ b/backend/internal/console/console_sessions_test.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -95,6 +96,703 @@ func TestConsoleSessionInputLimit(t *testing.T) {
 	if err := manager.Input(context.Background(), 1, strings.Repeat("x", maxConsoleInputBytes+1)); !errors.Is(err, ErrInputTooLarge) {
 		t.Fatalf("expected input limit error, got %v", err)
 	}
+}
+
+func TestManualInputCreatesUntrackedHistoryRow(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	session.recordManualInput("nano /etc/hosts\r")
+
+	row := readManualHistoryRow(t, database)
+	if row.command != "nano /etc/hosts" || row.source != "manual" || row.status != "untracked" || row.trackingReason != "interactive_editor" || row.sessionID.Int64 != session.id {
+		t.Fatalf("unexpected manual row: %#v", row)
+	}
+}
+
+func TestManualInputHandlesBackspaceBeforeRecording(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	session.recordManualInput("node --versio\x7fon\r")
+
+	row := readManualHistoryRow(t, database)
+	if row.command != "node --version" {
+		t.Fatalf("expected backspace-adjusted command, got %q", row.command)
+	}
+}
+
+func TestManualInputIgnoresHistoryRecallUntilEnter(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	session.recordManualInput("\x1b[A")
+
+	assertManualHistoryCount(t, database, 0)
+}
+
+func TestManualInputRecordsUnknownHistoryRecallOnEnter(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	session.recordManualInput("\x1b[A\r")
+
+	row := readManualHistoryRow(t, database)
+	if row.command != "command recalled with arrow key" || row.status != "running" || row.trackingReason != "history_recall_untracked" {
+		t.Fatalf("expected unknown history recall row, got %#v", row)
+	}
+}
+
+func TestManualInputRecordsUntrustedPreviewWhenEscapeSequenceHasText(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	session.recordManualInput("\x1b[A")
+	session.recordManualInput(" --help\r")
+
+	row := readManualHistoryRow(t, database)
+	if row.command != "--help" || row.trackingReason != "untrusted_command_text" {
+		t.Fatalf("expected untrusted preview row, got %#v", row)
+	}
+}
+
+func TestManualInputRecordsBracketedPasteContent(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	session.recordManualInput("\x1b[200~apt update\x1b[201~\r")
+
+	row := readManualHistoryRow(t, database)
+	if row.command != "apt update" || row.trackingReason != "manual_output_not_tracked" {
+		t.Fatalf("expected bracketed paste command row, got %#v", row)
+	}
+}
+
+func TestManualInputRecordsHeredocPreviewAndIgnoresBody(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	session.recordManualInput("cat <<EOF\r\nsecret body\r\nEOF\r\n")
+
+	assertManualHistoryCount(t, database, 1)
+	row := readManualHistoryRow(t, database)
+	if row.command != "cat <<EOF ..." || row.trackingReason != "multiline_or_heredoc" {
+		t.Fatalf("unexpected heredoc row: %#v", row)
+	}
+}
+
+func TestManualInputResumesAfterSplitHeredocTerminator(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	session.recordManualInput("cat <<EOF\r")
+	session.recordManualInput("secret body\r")
+	session.recordManualInput("EOF\r")
+	session.recordManualInput("pwd\r")
+
+	assertManualHistoryCount(t, database, 2)
+	row := readManualHistoryRow(t, database)
+	if row.command != "pwd" || row.trackingReason != "manual_output_not_tracked" {
+		t.Fatalf("expected command after heredoc terminator, got %#v", row)
+	}
+}
+
+func TestManualInputResumesAfterCanceledHeredoc(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	session.recordManualInput("cat <<EOF\r")
+	session.recordManualInput("secret body\r")
+	session.recordManualInput("\x03")
+	session.recordManualInput("pwd\r")
+
+	assertManualHistoryCount(t, database, 2)
+	row := readManualHistoryRow(t, database)
+	if row.command != "pwd" || row.trackingReason != "manual_output_not_tracked" {
+		t.Fatalf("expected command after canceled heredoc, got %#v", row)
+	}
+}
+
+func TestManualInputResumesAfterEndedHeredoc(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	session.recordManualInput("cat <<EOF\r")
+	session.recordManualInput("secret body\r")
+	session.recordManualInput("\x04")
+	session.recordManualInput("pwd\r")
+
+	assertManualHistoryCount(t, database, 2)
+	row := readManualHistoryRow(t, database)
+	if row.command != "pwd" || row.trackingReason != "manual_output_not_tracked" {
+		t.Fatalf("expected command after ended heredoc, got %#v", row)
+	}
+}
+
+func TestManualInputPausesWhileAutomationCommandIsActive(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+	session.activeExec = &consoleSessionActiveExec{
+		Command:     "apt update",
+		Marker:      "__AIPERMISSION_EXIT_ACTIVE__",
+		StartOffset: 0,
+		Started:     time.Now(),
+	}
+
+	session.recordManualInput("ls\r")
+
+	assertManualHistoryCount(t, database, 0)
+}
+
+func TestManualInputRedactsPersistedCommand(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	manager.redact = func(value string) string {
+		return strings.ReplaceAll(value, "secret-token", "[REDACTED]")
+	}
+
+	session.recordManualInput("curl -H 'Authorization: Bearer secret-token' http://example.test\r")
+
+	row := readManualHistoryRow(t, database)
+	if strings.Contains(row.command, "secret-token") || !strings.Contains(row.command, "[REDACTED]") {
+		t.Fatalf("expected redacted command, got %q", row.command)
+	}
+}
+
+func TestConsoleManagerInputWritesPTYAndRecordsManualHistory(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "uptime\n"); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	if stdin.String() != "uptime\n" {
+		t.Fatalf("expected PTY input to be written unchanged, got %q", stdin.String())
+	}
+	row := readManualHistoryRow(t, database)
+	if row.command != "uptime" || row.source != "manual" || row.status != "running" {
+		t.Fatalf("unexpected manual history row: %#v", row)
+	}
+}
+
+func TestManualInputCapturesOutputWhenPromptReturns(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "node --version\n"); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	session.appendOutput("node --version\r\nv24.1.0\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+	row := readManualHistoryRow(t, database)
+	if row.command != "node --version" || row.stdout != "v24.1.0" || row.trackingReason != "exit_code_unavailable" {
+		t.Fatalf("expected captured manual output, got %#v", row)
+	}
+}
+
+func TestManualInputCapturesAptUpdateOutput(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "apt update\n"); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	session.appendOutput("apt update\r\nHit:1 https://download.docker.com/linux/ubuntu noble InRelease\r\nReading package lists... Done\r\n9 packages can be upgraded. Run 'apt list --upgradable' to see them.\r\nroot@candle-query-1:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+	row := readManualHistoryRow(t, database)
+	if row.command != "apt update" || row.status != "completed" || !strings.Contains(row.stdout, "9 packages can be upgraded") {
+		t.Fatalf("expected apt update to be captured as completed, got %#v", row)
+	}
+}
+
+func TestManualInputCapturesAptProgressOutput(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "apt update\n"); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	session.appendOutput("apt update\r\nHit:1 https://download.docker.com/linux/ubuntu noble InRelease\r\n")
+	session.appendOutput("Reading package lists... 85%\rReading package lists... 99%\rReading package lists... Done\r\n")
+	session.appendOutput("Building dependency tree... 50%\rBuilding dependency tree... Done\r\n")
+	session.appendOutput("Reading state information... Done\r\n9 packages can be upgraded. Run 'apt list --upgradable' to see them.\r\nroot@candle-query-1:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+	row := readManualHistoryRow(t, database)
+	if row.command != "apt update" || row.status != "completed" || !strings.Contains(row.stdout, "Reading package lists") || !strings.Contains(row.stdout, "9 packages can be upgraded") {
+		t.Fatalf("expected apt progress output to be captured as completed, got %#v", row)
+	}
+}
+
+func TestManualInputDoesNotInferHistoryRecallFromShellEcho(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "\x1b[A"); err != nil {
+		t.Fatalf("history recall input: %v", err)
+	}
+	if err := manager.Input(context.Background(), session.id, "\r"); err != nil {
+		t.Fatalf("enter input: %v", err)
+	}
+	session.appendOutput("apt update\r\nHit:1 https://download.docker.com/linux/ubuntu noble InRelease\r\n9 packages can be upgraded. Run 'apt list --upgradable' to see them.\r\nroot@candle-query-1:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+	assertManualHistoryCount(t, database, 1)
+	row := readManualHistoryRow(t, database)
+	if row.command != "command recalled with arrow key" || row.status != "completed" || row.trackingReason != "history_recall_untracked" || !strings.Contains(row.stdout, "9 packages can be upgraded") {
+		t.Fatalf("history recall should capture output without inferring command text, got %#v", row)
+	}
+}
+
+func TestManualInputPausesUnknownHistoryRecallWhenMoreInputArrives(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	session.rawTranscript = "root@worker:~# "
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "\x1b[A"); err != nil {
+		t.Fatalf("history recall input: %v", err)
+	}
+	if err := manager.Input(context.Background(), session.id, "\r"); err != nil {
+		t.Fatalf("enter input: %v", err)
+	}
+	session.appendOutput("root@worker:~# docker exec -it f6f sh\r\n/ # ")
+	if err := manager.Input(context.Background(), session.id, "test\n"); err != nil {
+		t.Fatalf("nested input: %v", err)
+	}
+	waitForManualHistoryStatus(t, database, "untracked")
+	assertManualHistoryCount(t, database, 1)
+
+	session.appendOutput("test\r\n/ # ")
+	if err := manager.Input(context.Background(), session.id, "exit\n"); err != nil {
+		t.Fatalf("nested exit input: %v", err)
+	}
+	assertManualHistoryCount(t, database, 1)
+
+	session.appendOutput("exit\r\nroot@worker:~# ")
+	if err := manager.Input(context.Background(), session.id, "pwd\n"); err != nil {
+		t.Fatalf("host input after nested recall: %v", err)
+	}
+	session.appendOutput("pwd\r\n/home/root\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+
+	rows := readManualHistoryRows(t, database)
+	if len(rows) != 2 {
+		t.Fatalf("expected recalled row plus host row, got %#v", rows)
+	}
+	if rows[1].command != "command recalled with arrow key" || rows[1].status != "untracked" || rows[1].trackingReason != "history_recall_untracked" {
+		t.Fatalf("expected unknown recall to become one untracked row, got %#v", rows[1])
+	}
+	if strings.Contains(rows[1].command, "test") || strings.Contains(rows[1].command, "exit") || strings.TrimSpace(rows[1].stdout) != "" {
+		t.Fatalf("unknown recall should not append nested input or nested output, got %#v", rows[1])
+	}
+	if rows[0].command != "pwd" || rows[0].status != "completed" || rows[0].stdout != "/home/root" {
+		t.Fatalf("expected host command after nested recall, got %#v", rows[0])
+	}
+}
+
+func TestManualInputClearsStaleRunningRowsWhenPromptReturns(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	insertStaleManualRunningRow(t, database, session, "old sleep")
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "node --version\n"); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	session.appendOutput("node --version\r\nv24.1.0\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+
+	if count := countManualRunningRows(t, database, session.id); count != 0 {
+		t.Fatalf("expected stale manual running rows to be closed, got %d", count)
+	}
+}
+
+func TestManualInputClearsStaleRunningRowsWhenCanceled(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	insertStaleManualRunningRow(t, database, session, "old apt update")
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "sleep 10\n"); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	session.appendOutput("sleep 10\r\n^C\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "canceled")
+
+	if count := countManualRunningRows(t, database, session.id); count != 0 {
+		t.Fatalf("expected canceled manual command to clear stale running rows, got %d", count)
+	}
+}
+
+func TestManualInputCompletesPreviousCommandBeforeRecordingNextInput(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "pwd\n"); err != nil {
+		t.Fatalf("first input: %v", err)
+	}
+	session.mu.Lock()
+	session.rawTranscript = "pwd\r\n/home/root\r\nroot@worker:~# "
+	session.mu.Unlock()
+
+	if err := manager.Input(context.Background(), session.id, "hostname\n"); err != nil {
+		t.Fatalf("second input: %v", err)
+	}
+	session.appendOutput("hostname\r\nworker-1\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+
+	rows := readManualHistoryRows(t, database)
+	if len(rows) != 2 {
+		t.Fatalf("expected two manual rows, got %#v", rows)
+	}
+	if rows[1].command != "pwd" || rows[1].stdout != "/home/root" || rows[1].status != "completed" {
+		t.Fatalf("expected first row to keep output, got %#v", rows[1])
+	}
+	if rows[0].command != "hostname" || rows[0].stdout != "worker-1" || rows[0].status != "completed" {
+		t.Fatalf("expected second row to complete, got %#v", rows[0])
+	}
+}
+
+func TestManualInputAppendsNextLineAfterOutputStartsBeforePromptReturns(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "sleep 1\n"); err != nil {
+		t.Fatalf("first input: %v", err)
+	}
+	session.appendOutput("sleep 1\r\npartial output\r\n")
+	if err := manager.Input(context.Background(), session.id, "pwd\n"); err != nil {
+		t.Fatalf("second input: %v", err)
+	}
+	session.appendOutput("pwd\r\n/home/root\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+
+	rows := readManualHistoryRows(t, database)
+	if len(rows) != 1 {
+		t.Fatalf("expected one manual batch row, got %#v", rows)
+	}
+	if rows[0].command != "sleep 1\npwd" || rows[0].status != "completed" || !strings.Contains(rows[0].stdout, "partial output") || !strings.Contains(rows[0].stdout, "/home/root") {
+		t.Fatalf("expected queued input to stay in one completed row, got %#v", rows[0])
+	}
+}
+
+func TestManualInputKeepsSplitHealthCheckPasteAsSingleRow(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	firstChunk := strings.Join([]string{
+		"set -e",
+		`echo "== system =="`,
+		"hostname",
+		"uname -a",
+		`echo "== disk =="`,
+		"df -h | head -20",
+		`echo "== memory =="`,
+		"free -h",
+		`echo "== docker containers =="`,
+		`docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' 2>&1 || true`,
+		`echo "== recent service errors =="`,
+		"",
+	}, "\n")
+	secondChunk := `journalctl -p warning..alert --since "30 min ago" --no-pager 2>&1 | tail -80 || true` + "\n"
+
+	if err := manager.Input(context.Background(), session.id, firstChunk); err != nil {
+		t.Fatalf("first chunk input: %v", err)
+	}
+	session.appendOutput("set -e\r\necho \"== system ==\"\r\n== system ==\r\nworker-1\r\n")
+	if err := manager.Input(context.Background(), session.id, secondChunk); err != nil {
+		t.Fatalf("second chunk input: %v", err)
+	}
+	session.appendOutput("journalctl -p warning..alert --since \"30 min ago\" --no-pager 2>&1 | tail -80 || true\r\nJun 05 warning\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+
+	rows := readManualHistoryRows(t, database)
+	if len(rows) != 1 {
+		t.Fatalf("expected one manual row for split health check paste, got %#v", rows)
+	}
+	if !strings.Contains(rows[0].command, "set -e") || !strings.Contains(rows[0].command, "journalctl -p warning..alert") {
+		t.Fatalf("expected combined health check command, got %#v", rows[0])
+	}
+	if rows[0].status != "completed" || !strings.Contains(rows[0].stdout, "== system ==") || !strings.Contains(rows[0].stdout, "Jun 05 warning") {
+		t.Fatalf("expected combined health check output, got %#v", rows[0])
+	}
+}
+
+func TestManualInputPausesInsideNestedShellUntilOriginalPromptReturns(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	session.rawTranscript = "root@worker:~# "
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "docker exec -it f6f sh\n"); err != nil {
+		t.Fatalf("nested shell input: %v", err)
+	}
+	row := readManualHistoryRow(t, database)
+	if row.command != "docker exec -it f6f sh" || row.status != "untracked" || row.trackingReason != "nested_shell" {
+		t.Fatalf("expected nested shell row, got %#v", row)
+	}
+
+	session.appendOutput("root@worker:~# docker exec -it f6f sh\r\n/ # ")
+	if err := manager.Input(context.Background(), session.id, "exit\n"); err != nil {
+		t.Fatalf("nested exit input: %v", err)
+	}
+	assertManualHistoryCount(t, database, 1)
+
+	session.appendOutput("exit\r\nroot@worker:~# ")
+	if err := manager.Input(context.Background(), session.id, "pwd\n"); err != nil {
+		t.Fatalf("host input after nested shell: %v", err)
+	}
+	session.appendOutput("pwd\r\n/home/root\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+
+	rows := readManualHistoryRows(t, database)
+	if len(rows) != 2 {
+		t.Fatalf("expected nested shell row plus later host row, got %#v", rows)
+	}
+	if rows[0].command != "pwd" || rows[0].status != "completed" || rows[0].stdout != "/home/root" {
+		t.Fatalf("expected host command after nested shell, got %#v", rows[0])
+	}
+	if rows[1].command != "docker exec -it f6f sh" || rows[1].trackingReason != "nested_shell" {
+		t.Fatalf("expected original nested shell row to remain, got %#v", rows[1])
+	}
+}
+
+func TestManualInputRecordsSplitNestedShellCommandAsOneRow(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	session.rawTranscript = "root@worker:~# "
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "docker exec -it f6f "); err != nil {
+		t.Fatalf("nested shell prefix input: %v", err)
+	}
+	if err := manager.Input(context.Background(), session.id, "sh\n"); err != nil {
+		t.Fatalf("nested shell suffix input: %v", err)
+	}
+
+	row := readManualHistoryRow(t, database)
+	if row.command != "docker exec -it f6f sh" || row.status != "untracked" || row.trackingReason != "nested_shell" {
+		t.Fatalf("expected split nested shell row, got %#v", row)
+	}
+}
+
+func TestManualInputPausesNestedShellEvenWithoutKnownResumePrompt(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "docker exec -it f6f sh\n"); err != nil {
+		t.Fatalf("nested shell input: %v", err)
+	}
+	if err := manager.Input(context.Background(), session.id, "exit\n"); err != nil {
+		t.Fatalf("nested exit input: %v", err)
+	}
+	assertManualHistoryCount(t, database, 1)
+
+	session.appendOutput("docker exec -it f6f sh\r\n/ # exit\r\nroot@worker:~# ")
+	if err := manager.Input(context.Background(), session.id, "pwd\n"); err != nil {
+		t.Fatalf("host input after nested shell: %v", err)
+	}
+	session.appendOutput("pwd\r\n/home/root\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+
+	rows := readManualHistoryRows(t, database)
+	if len(rows) != 2 || rows[0].command != "pwd" || rows[1].command != "docker exec -it f6f sh" {
+		t.Fatalf("expected nested row plus resumed host row, got %#v", rows)
+	}
+}
+
+func TestManualPromptPrefixUsesCommandEchoLineForResumePrompt(t *testing.T) {
+	transcript := "root@worker:~# docker exec -it f6f sh"
+	if prompt := lastManualShellPrompt(transcript); prompt != "root@worker:~#" {
+		t.Fatalf("expected prompt prefix from echo line, got %q", prompt)
+	}
+	if manualTranscriptEndsWithPrompt(transcript, "root@worker:~#") {
+		t.Fatalf("command echo line must not count as returned prompt")
+	}
+}
+
+func TestManualInputCloseSessionFinalizesRunningCapture(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "sleep 60\n"); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	session.finish("closed", "")
+
+	row := readManualHistoryRow(t, database)
+	if row.status != "untracked" || row.trackingReason != manualSessionClosed {
+		t.Fatalf("expected session close to finalize manual capture, got %#v", row)
+	}
+	if count := countManualRunningRows(t, database, session.id); count != 0 {
+		t.Fatalf("expected no running manual rows after session close, got %d", count)
+	}
+}
+
+func TestManualInputAutomationFinalizesRunningCapture(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	session.ctx = context.Background()
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "sleep 60\n"); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	_, _ = session.execCommand(ctx, "echo ai")
+
+	row := readManualHistoryRow(t, database)
+	if row.command != "sleep 60" || row.status != "untracked" || row.trackingReason != manualActiveExecPaused {
+		t.Fatalf("expected automation to pause manual capture, got %#v", row)
+	}
+}
+
+func TestManualCapturedOutputDoesNotDropLinesEndingWithCommandText(t *testing.T) {
+	output, _ := manualCapturedOutput("ls\r\ntools\r\nlogs\r\nroot@worker:~# ", "ls")
+	if output != "tools\nlogs" {
+		t.Fatalf("expected output lines ending with command text to survive, got %q", output)
+	}
+}
+
+func TestManualInputCapturesMultilinePasteAsSingleRow(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	input := "echo hello\npwd\ntrue\n"
+	if err := manager.Input(context.Background(), session.id, input); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	session.appendOutput("echo hello\r\nhello\r\npwd\r\n/home/root\r\ntrue\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+
+	rows := readManualHistoryRows(t, database)
+	if len(rows) != 1 {
+		t.Fatalf("expected one manual row for multiline paste, got %#v", rows)
+	}
+	if rows[0].command != "echo hello\npwd\ntrue" || rows[0].stdout != "hello\n/home/root" {
+		t.Fatalf("expected combined command and output, got %#v", rows[0])
+	}
+}
+
+func TestManualInputCapturesSplitMultilinePasteAsSingleRow(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	for _, input := range []string{"echo hello\n", "pwd\n", "true\n"} {
+		if err := manager.Input(context.Background(), session.id, input); err != nil {
+			t.Fatalf("input %q: %v", input, err)
+		}
+	}
+	session.appendOutput("echo hello\r\nhello\r\npwd\r\n/home/root\r\ntrue\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+
+	rows := readManualHistoryRows(t, database)
+	if len(rows) != 1 {
+		t.Fatalf("expected one manual row for split multiline paste, got %#v", rows)
+	}
+	if rows[0].command != "echo hello\npwd\ntrue" || rows[0].stdout != "hello\n/home/root" {
+		t.Fatalf("expected combined command and output, got %#v", rows[0])
+	}
+}
+
+func TestManualInputKeepsUnsafeMultilinePasteUntracked(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "nano test.txt\npwd\n"); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+
+	row := readManualHistoryRow(t, database)
+	if row.command != "nano test.txt\npwd" || row.status != "untracked" || row.trackingReason != "compound_command" {
+		t.Fatalf("expected unsafe multiline paste to be one untracked row, got %#v", row)
+	}
+}
+
+func TestManualInputKeepsSplitUnsafeMultilinePasteUntracked(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "echo hello\n"); err != nil {
+		t.Fatalf("safe input: %v", err)
+	}
+	if err := manager.Input(context.Background(), session.id, "nano test.txt\n"); err != nil {
+		t.Fatalf("unsafe input: %v", err)
+	}
+
+	waitForManualHistoryStatus(t, database, "untracked")
+	row := readManualHistoryRow(t, database)
+	if row.command != "echo hello\nnano test.txt" || row.trackingReason != "compound_command" {
+		t.Fatalf("expected split unsafe paste to downgrade one row, got %#v", row)
+	}
+}
+
+func TestManualInputCapturesOutputIfPromptReturnedBeforePersist(t *testing.T) {
+	database, _, session := newManualHistoryTestSession(t)
+
+	commands := session.prepareManualInput("pwd\n")
+	session.appendOutput("pwd\r\n/home/root\r\nroot@worker:~# ")
+	session.persistManualInput(commands)
+
+	waitForManualHistoryStatus(t, database, "completed")
+	row := readManualHistoryRow(t, database)
+	if row.command != "pwd" || row.stdout != "/home/root" {
+		t.Fatalf("expected delayed persist to capture existing output, got %#v", row)
+	}
+}
+
+func TestManualInputAppendsNextLineBeforePromptReturns(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "ls /root/nope\n"); err != nil {
+		t.Fatalf("first input: %v", err)
+	}
+	if err := manager.Input(context.Background(), session.id, "docker ps\n"); err != nil {
+		t.Fatalf("second input: %v", err)
+	}
+	session.appendOutput("ls /root/nope\r\nls: cannot access '/root/nope': Permission denied\r\ndocker ps\r\nCONTAINER ID   IMAGE\r\nroot@worker:~# ")
+	waitForManualHistoryStatus(t, database, "completed")
+
+	rows := readManualHistoryRows(t, database)
+	if len(rows) != 1 {
+		t.Fatalf("expected one manual row, got %#v", rows)
+	}
+	if rows[0].command != "ls /root/nope\ndocker ps" || rows[0].status != "completed" || !strings.Contains(rows[0].stdout, "CONTAINER ID") || !strings.Contains(rows[0].stdout, "Permission denied") {
+		t.Fatalf("queued lines should complete as one batch, got %#v", rows[0])
+	}
+}
+
+type recordingWriteCloser struct {
+	strings.Builder
+}
+
+func (r *recordingWriteCloser) Close() error {
+	return nil
 }
 
 func TestManagedConsoleSessionExecRejectsConcurrentAutomationCommand(t *testing.T) {
@@ -487,4 +1185,164 @@ func TestConsoleTranscriptPersistsAppendOnlyChunksAndBoundedSnapshot(t *testing.
 	if chunks != 0 {
 		t.Fatalf("expected console transcript chunks to cascade delete, got %d", chunks)
 	}
+}
+
+type manualHistoryRow struct {
+	source         string
+	command        string
+	status         string
+	trackingReason string
+	stdout         string
+	sessionID      sql.NullInt64
+}
+
+func newManualHistoryTestSession(t *testing.T) (*sql.DB, *Manager, *managedConsoleSession) {
+	t.Helper()
+	database, err := dbpkg.OpenEncrypted(filepath.Join(t.TempDir(), "console.db"), "ConsolePassword123")
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	now := time.Now().UTC().Format(time.RFC3339)
+	result, err := database.Exec(`
+		INSERT INTO servers (name, host, port, username, ssh_key_id, created_at, updated_at)
+		VALUES ('worker-1', '127.0.0.1', 22, 'root', 0, ?, ?)`,
+		now,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("insert server: %v", err)
+	}
+	serverID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("read server id: %v", err)
+	}
+	sessionResult, err := database.Exec(`
+		INSERT INTO console_sessions (server_id, name, status, cols, rows, created_at, updated_at)
+		VALUES (?, 'manual', 'connected', 120, 32, ?, ?)`,
+		serverID,
+		now,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("insert console session: %v", err)
+	}
+	sessionID, err := sessionResult.LastInsertId()
+	if err != nil {
+		t.Fatalf("read session id: %v", err)
+	}
+	manager := NewManager(database, nil, "", nil)
+	session := &managedConsoleSession{
+		id:       sessionID,
+		serverID: serverID,
+		manager:  manager,
+		status:   "connected",
+		clients:  map[*websocket.Conn]*sync.Mutex{},
+	}
+	return database, manager, session
+}
+
+func readManualHistoryRow(t *testing.T, database *sql.DB) manualHistoryRow {
+	t.Helper()
+	var row manualHistoryRow
+	if err := database.QueryRow(`
+		SELECT source, command, status, tracking_reason, stdout, session_id
+		FROM command_requests
+		ORDER BY id DESC
+		LIMIT 1`,
+	).Scan(&row.source, &row.command, &row.status, &row.trackingReason, &row.stdout, &row.sessionID); err != nil {
+		t.Fatalf("read manual history row: %v", err)
+	}
+	return row
+}
+
+func readManualHistoryRows(t *testing.T, database *sql.DB) []manualHistoryRow {
+	t.Helper()
+	rows, err := database.Query(`
+		SELECT source, command, status, tracking_reason, stdout, session_id
+		FROM command_requests
+		WHERE source = 'manual'
+		ORDER BY id DESC`)
+	if err != nil {
+		t.Fatalf("read manual history rows: %v", err)
+	}
+	defer rows.Close()
+
+	items := []manualHistoryRow{}
+	for rows.Next() {
+		var row manualHistoryRow
+		if err := rows.Scan(&row.source, &row.command, &row.status, &row.trackingReason, &row.stdout, &row.sessionID); err != nil {
+			t.Fatalf("scan manual history row: %v", err)
+		}
+		items = append(items, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate manual history rows: %v", err)
+	}
+	return items
+}
+
+func waitForManualHistoryStatus(t *testing.T, database *sql.DB, status string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		var row manualHistoryRow
+		err := database.QueryRow(`
+			SELECT source, command, status, tracking_reason, stdout, session_id
+			FROM command_requests
+			WHERE source = 'manual'
+			ORDER BY id DESC
+			LIMIT 1`,
+		).Scan(&row.source, &row.command, &row.status, &row.trackingReason, &row.stdout, &row.sessionID)
+		if err == nil && row.status == status {
+			return
+		}
+		if time.Now().After(deadline) {
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				t.Fatalf("read manual history status: %v", err)
+			}
+			t.Fatalf("manual history status did not become %q, latest row %#v", status, row)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func assertManualHistoryCount(t *testing.T, database *sql.DB, expected int) {
+	t.Helper()
+	var count int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM command_requests WHERE source = 'manual'`).Scan(&count); err != nil {
+		t.Fatalf("count manual history rows: %v", err)
+	}
+	if count != expected {
+		t.Fatalf("expected %d manual history rows, got %d", expected, count)
+	}
+}
+
+func insertStaleManualRunningRow(t *testing.T, database *sql.DB, session *managedConsoleSession, command string) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := database.Exec(`
+		INSERT INTO command_requests (server_id, source, command, reason, status, tracking_reason, session_id, created_at)
+		VALUES (?, 'manual', ?, 'manual console command', 'running', 'manual_output_not_tracked', ?, ?)`,
+		session.serverID,
+		command,
+		session.id,
+		now,
+	); err != nil {
+		t.Fatalf("insert stale manual running row: %v", err)
+	}
+}
+
+func countManualRunningRows(t *testing.T, database *sql.DB, sessionID int64) int {
+	t.Helper()
+	var count int
+	if err := database.QueryRow(`
+		SELECT COUNT(*)
+		FROM command_requests
+		WHERE source = 'manual' AND status = 'running' AND session_id = ?`,
+		sessionID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count manual running rows: %v", err)
+	}
+	return count
 }

--- a/backend/internal/console/manual_history.go
+++ b/backend/internal/console/manual_history.go
@@ -1,0 +1,912 @@
+package console
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	maxManualCommandBufferBytes  = 8192
+	maxManualCommandPreviewBytes = 2000
+	maxManualCapturedOutputBytes = 1 << 20
+	manualCommandReason          = "manual console command not tracked"
+	manualTrackedCommandReason   = "manual console command"
+	manualCaptureSuperseded      = "manual_capture_superseded"
+	manualPromptNotDetected      = "prompt_not_detected"
+	manualSessionClosed          = "session_closed"
+	manualActiveExecPaused       = "active_exec_paused"
+)
+
+type manualInputCapture struct {
+	line              string
+	initialized       bool
+	trusted           bool
+	escapePending     bool
+	escapeIntro       bool
+	escapeOSC         bool
+	lastWasCR         bool
+	truncated         bool
+	heredocTerminator string
+	historyRecall     bool
+}
+
+func (s *managedConsoleSession) prepareManualInput(data string) []manualCommandRecord {
+	if data == "" || s == nil || s.manager == nil || s.manager.db == nil {
+		return nil
+	}
+	if s.activeCommand() != nil {
+		s.mu.Lock()
+		s.manualInput.reset()
+		s.mu.Unlock()
+		return nil
+	}
+
+	commands := []manualCommandRecord{}
+	var completion *manualOutputCompletion
+	var activeUpdate *manualActiveCommandUpdate
+	s.mu.Lock()
+	s.clearManualPauseIfPromptReturnedLocked()
+	if s.manualPause != nil {
+		s.manualInput.reset()
+		s.mu.Unlock()
+		return nil
+	}
+	if strings.ContainsAny(data, "\r\n") && s.manualActive != nil {
+		completion = s.manualOutputCompletionLocked()
+	}
+	if activeUpdate == nil {
+		startOffset := len(s.rawTranscript)
+		resumePrompt := lastManualShellPrompt(s.rawTranscript)
+		for _, command := range s.manualInput.consume(data) {
+			if command.Command != "" {
+				command.StartOffset = startOffset
+				command.ResumePrompt = resumePrompt
+				commands = append(commands, command)
+			}
+		}
+		commands = collapseManualCommandRecords(commands)
+		if completion == nil && s.manualActive != nil && len(commands) > 0 {
+			if manualActiveIsHistoryRecall(s.manualActive) {
+				active := *s.manualActive
+				completion = s.downgradeManualOutputCaptureLocked("history_recall_untracked", false)
+				s.pauseManualCaptureAfterActiveLocked(active)
+				s.manualInput.reset()
+			} else {
+				activeUpdate = s.appendManualActiveCommandsLocked(commands)
+			}
+			commands = nil
+		}
+	}
+	s.mu.Unlock()
+	if completion != nil {
+		s.finishManualOutputCapture(completion)
+	}
+	if activeUpdate != nil {
+		s.updateManualActiveCommand(activeUpdate)
+	}
+	return commands
+}
+
+func (s *managedConsoleSession) persistManualInput(commands []manualCommandRecord) {
+	for _, command := range commands {
+		if err := s.insertManualCommand(command); err != nil {
+			logConsolePersistError("manual_history", s.id, err)
+		}
+	}
+}
+
+func (s *managedConsoleSession) recordManualInput(data string) {
+	s.persistManualInput(s.prepareManualInput(data))
+}
+
+func (c *manualInputCapture) consume(data string) []manualCommandRecord {
+	data = stripBracketedPasteMarkers(data)
+	if !c.initialized {
+		c.initialized = true
+		c.trusted = true
+	}
+	records := []manualCommandRecord{}
+	for _, r := range data {
+		if c.consumeEscape(r) {
+			continue
+		}
+		switch r {
+		case '\x1b':
+			c.trusted = false
+			c.escapePending = true
+			c.escapeIntro = true
+			c.escapeOSC = false
+		case '\r':
+			records = append(records, c.finishLine()...)
+			c.lastWasCR = true
+		case '\n':
+			if c.lastWasCR {
+				c.lastWasCR = false
+				continue
+			}
+			records = append(records, c.finishLine()...)
+		case '\x03', '\x04':
+			c.reset()
+		case '\b', '\x7f':
+			c.line = trimLastRune(c.line)
+			c.lastWasCR = false
+		case '\t':
+			c.appendRune(r)
+			c.lastWasCR = false
+		default:
+			c.lastWasCR = false
+			if r < 0x20 || r == 0x7f {
+				c.trusted = false
+				continue
+			}
+			c.appendRune(r)
+		}
+	}
+	return records
+}
+
+func (c *manualInputCapture) consumeEscape(r rune) bool {
+	if !c.escapePending {
+		return false
+	}
+	if c.escapeIntro {
+		c.escapeIntro = false
+		if r == ']' {
+			c.escapeOSC = true
+		}
+		if r != '[' && r != ']' {
+			c.escapePending = false
+		}
+		return true
+	}
+	if c.escapeOSC {
+		if r == '\a' {
+			c.escapePending = false
+			c.escapeOSC = false
+		}
+		return true
+	}
+	if r >= '@' && r <= '~' {
+		if r == 'A' || r == 'B' {
+			c.historyRecall = true
+		}
+		c.escapePending = false
+	}
+	return true
+}
+
+func (c *manualInputCapture) appendRune(r rune) {
+	if len(c.line) >= maxManualCommandBufferBytes {
+		c.truncated = true
+		return
+	}
+	c.line += string(r)
+	if len(c.line) > maxManualCommandBufferBytes {
+		c.line = c.line[:maxManualCommandBufferBytes]
+		for len(c.line) > 0 && !utf8.ValidString(c.line) {
+			c.line = c.line[:len(c.line)-1]
+		}
+		c.truncated = true
+	}
+}
+
+func (c *manualInputCapture) finishLine() []manualCommandRecord {
+	line := c.line
+	trusted := c.trusted
+	truncated := c.truncated
+	c.line = ""
+	c.initialized = true
+	c.trusted = true
+	c.truncated = false
+	c.escapePending = false
+	c.escapeIntro = false
+	c.escapeOSC = false
+	historyRecall := c.historyRecall
+	c.historyRecall = false
+
+	if c.heredocTerminator != "" {
+		if strings.TrimSpace(line) == c.heredocTerminator {
+			c.heredocTerminator = ""
+		}
+		return nil
+	}
+
+	command := strings.TrimSpace(line)
+	if command == "" {
+		if historyRecall {
+			return []manualCommandRecord{{
+				Command:                  "command recalled with arrow key",
+				TrackingReason:           "history_recall_untracked",
+				TrackOutput:              true,
+				CompletionTrackingReason: "history_recall_untracked",
+			}}
+		}
+		return nil
+	}
+	if !trusted {
+		return []manualCommandRecord{{
+			Command:        manualCommandPreview(command, len(command) > maxManualCommandPreviewBytes),
+			TrackingReason: "untrusted_command_text",
+		}}
+	}
+
+	record := classifyManualCommand(command, truncated)
+	if terminator := heredocTerminator(command); terminator != "" {
+		c.heredocTerminator = terminator
+	}
+	return []manualCommandRecord{record}
+}
+
+func stripBracketedPasteMarkers(data string) string {
+	if !strings.Contains(data, "\x1b[") {
+		return data
+	}
+	data = strings.ReplaceAll(data, "\x1b[200~", "")
+	data = strings.ReplaceAll(data, "\x1b[201~", "")
+	return data
+}
+
+func (c *manualInputCapture) reset() {
+	c.line = ""
+	c.initialized = true
+	c.trusted = true
+	c.escapePending = false
+	c.escapeIntro = false
+	c.escapeOSC = false
+	c.lastWasCR = false
+	c.truncated = false
+	c.heredocTerminator = ""
+	c.historyRecall = false
+}
+
+type manualCommandRecord struct {
+	Command                  string
+	TrackingReason           string
+	TrackOutput              bool
+	StartOffset              int
+	ResumePrompt             string
+	CompletionTrackingReason string
+}
+
+func collapseManualCommandRecords(commands []manualCommandRecord) []manualCommandRecord {
+	if len(commands) <= 1 {
+		return commands
+	}
+	trackOutput := true
+	startOffset := commands[0].StartOffset
+	parts := make([]string, 0, len(commands))
+	for _, command := range commands {
+		parts = append(parts, command.Command)
+		if !command.TrackOutput {
+			trackOutput = false
+		}
+	}
+	joined := strings.Join(parts, "\n")
+	reason := "manual_output_not_tracked"
+	if !trackOutput {
+		reason = "compound_command"
+	}
+	if len(joined) > maxManualCommandPreviewBytes {
+		reason = "command_preview_truncated"
+		trackOutput = false
+	}
+	return []manualCommandRecord{{
+		Command:                  manualCommandPreview(joined, reason == "command_preview_truncated"),
+		TrackingReason:           reason,
+		TrackOutput:              trackOutput,
+		StartOffset:              startOffset,
+		ResumePrompt:             commands[0].ResumePrompt,
+		CompletionTrackingReason: commands[0].CompletionTrackingReason,
+	}}
+}
+
+type manualOutputCompletion struct {
+	RequestID       int64
+	Status          string
+	Stdout          string
+	OutputTruncated bool
+	TrackingReason  string
+	Error           string
+}
+
+type manualActiveCommandUpdate struct {
+	RequestID      int64
+	Command        string
+	TrackingReason string
+	Downgrade      bool
+}
+
+func (s *managedConsoleSession) appendManualActiveCommandsLocked(commands []manualCommandRecord) *manualActiveCommandUpdate {
+	if s.manualActive == nil || len(commands) == 0 {
+		return nil
+	}
+	active := *s.manualActive
+	parts := []string{strings.TrimSpace(active.Command)}
+	trackOutput := true
+	reason := "manual_output_not_tracked"
+	for _, command := range commands {
+		if command.Command == "" {
+			continue
+		}
+		parts = append(parts, command.Command)
+		if !command.TrackOutput {
+			trackOutput = false
+			reason = "compound_command"
+		}
+	}
+	combined := strings.TrimSpace(strings.Join(parts, "\n"))
+	if combined == "" {
+		return nil
+	}
+	if len(combined) > maxManualCommandPreviewBytes {
+		combined = manualCommandPreview(combined, true)
+		trackOutput = false
+		reason = "command_preview_truncated"
+	}
+	active.Command = combined
+	if trackOutput {
+		s.manualActive = &active
+	} else {
+		s.manualActive = nil
+	}
+	return &manualActiveCommandUpdate{
+		RequestID:      active.RequestID,
+		Command:        combined,
+		TrackingReason: reason,
+		Downgrade:      !trackOutput,
+	}
+}
+
+func classifyManualCommand(command string, truncated bool) manualCommandRecord {
+	reason := "manual_output_not_tracked"
+	if truncated || len(command) > maxManualCommandPreviewBytes {
+		reason = "command_preview_truncated"
+	}
+	if heredocTerminator(command) != "" {
+		reason = "multiline_or_heredoc"
+	}
+	if reason == "manual_output_not_tracked" {
+		reason = classifyManualCommandReason(command)
+	}
+	return manualCommandRecord{
+		Command:        manualCommandPreview(command, reason == "command_preview_truncated" || reason == "multiline_or_heredoc"),
+		TrackingReason: reason,
+		TrackOutput:    reason == "manual_output_not_tracked",
+	}
+}
+
+func classifyManualCommandReason(command string) string {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return "manual_output_not_tracked"
+	}
+	base := fields[0]
+	if slash := strings.LastIndex(base, "/"); slash >= 0 {
+		base = base[slash+1:]
+	}
+	switch base {
+	case "nano", "vi", "vim", "nvim", "emacs":
+		return "interactive_editor"
+	case "psql", "mysql", "redis-cli", "sqlite3", "python", "python3", "node", "irb", "rails", "php":
+		if len(fields) == 1 || strings.HasPrefix(command, base+" -i") {
+			return "interactive_repl"
+		}
+	case "top", "htop", "btop", "less", "more", "man", "watch":
+		return "interactive_tui"
+	case "ssh", "sftp", "ftp", "telnet", "mosh", "tmux", "screen":
+		return "nested_shell"
+	case "tail":
+		if containsField(fields[1:], "-f") || containsField(fields[1:], "--follow") {
+			return "long_running_stream"
+		}
+	case "docker", "kubectl":
+		if commandContainsInteractiveFlag(fields[1:]) {
+			return "nested_shell"
+		}
+	case "sudo":
+		return "may_prompt"
+	}
+	if strings.HasSuffix(strings.TrimSpace(command), "&") {
+		return "background_job"
+	}
+	return "manual_output_not_tracked"
+}
+
+func containsField(fields []string, value string) bool {
+	for _, field := range fields {
+		if field == value {
+			return true
+		}
+	}
+	return false
+}
+
+func commandContainsInteractiveFlag(fields []string) bool {
+	for _, field := range fields {
+		if field == "-it" || field == "-ti" || field == "-i" || field == "-t" || field == "--tty" || field == "--stdin" {
+			return true
+		}
+	}
+	return false
+}
+
+func manualCommandPreview(command string, incomplete bool) string {
+	command = strings.TrimSpace(command)
+	limit := maxManualCommandPreviewBytes
+	if incomplete && limit > 4 {
+		limit -= 4
+	}
+	if len(command) > limit {
+		command = command[:limit]
+		for len(command) > 0 && !utf8.ValidString(command) {
+			command = command[:len(command)-1]
+		}
+		incomplete = true
+	}
+	if incomplete && !strings.HasSuffix(command, "...") {
+		command = strings.TrimRight(command, " \t") + " ..."
+	}
+	return command
+}
+
+func heredocTerminator(command string) string {
+	index := strings.Index(command, "<<")
+	if index < 0 {
+		return ""
+	}
+	rest := strings.TrimSpace(command[index+2:])
+	if strings.HasPrefix(rest, "-") {
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, "-"))
+	}
+	if rest == "" {
+		return ""
+	}
+	token := strings.Fields(rest)[0]
+	token = strings.Trim(token, `"'`)
+	if token == "" || strings.ContainsAny(token, `/\`) {
+		return ""
+	}
+	return token
+}
+
+func trimLastRune(value string) string {
+	if value == "" {
+		return ""
+	}
+	_, size := utf8.DecodeLastRuneInString(value)
+	if size <= 0 {
+		return ""
+	}
+	return value[:len(value)-size]
+}
+
+func (s *managedConsoleSession) insertManualCommand(command manualCommandRecord) error {
+	if command.Command == "" {
+		return nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	storedCommand := s.manager.redactText(command.Command)
+	storedReason := s.manager.redactText(manualCommandReason)
+	status := "untracked"
+	completedAt := sql.NullString{String: now, Valid: true}
+	if command.TrackOutput {
+		storedReason = s.manager.redactText(manualTrackedCommandReason)
+		status = "running"
+		completedAt = sql.NullString{}
+		s.closeStaleManualRunningRows(0, manualCaptureSuperseded)
+	}
+	trackingReason := s.manager.redactText(command.TrackingReason)
+	result, err := s.manager.db.ExecContext(context.Background(), `
+		INSERT INTO command_requests (server_id, source, command, encrypted_command, reason, status, tracking_reason, stdout, stderr, session_id, created_at, completed_at)
+		VALUES (?, 'manual', ?, '', ?, ?, ?, '', '', ?, ?, ?)`,
+		s.serverID,
+		storedCommand,
+		storedReason,
+		status,
+		trackingReason,
+		s.id,
+		now,
+		completedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert manual command history: %w", err)
+	}
+	if command.TrackOutput {
+		requestID, err := result.LastInsertId()
+		if err != nil {
+			return fmt.Errorf("read manual command history id: %w", err)
+		}
+		completion := s.setManualOutputCapture(consoleSessionManualCapture{
+			RequestID:                requestID,
+			Command:                  command.Command,
+			StartOffset:              command.StartOffset,
+			ResumePrompt:             command.ResumePrompt,
+			Started:                  time.Now(),
+			CompletionTrackingReason: command.CompletionTrackingReason,
+		})
+		if completion != nil {
+			go s.finishManualOutputCapture(completion)
+		}
+	} else {
+		s.pauseManualCaptureAfterCommand(command)
+	}
+	return nil
+}
+
+func (s *managedConsoleSession) pauseManualCaptureAfterCommand(command manualCommandRecord) {
+	if !manualReasonPausesCapture(command.TrackingReason) {
+		return
+	}
+	s.mu.Lock()
+	s.manualPause = &consoleSessionManualPause{
+		Prompt:      command.ResumePrompt,
+		Reason:      command.TrackingReason,
+		StartOffset: command.StartOffset,
+	}
+	s.manualInput.reset()
+	s.mu.Unlock()
+}
+
+func (s *managedConsoleSession) pauseManualCaptureAfterActiveLocked(active consoleSessionManualCapture) {
+	s.manualPause = &consoleSessionManualPause{
+		Prompt:      active.ResumePrompt,
+		Reason:      active.CompletionTrackingReason,
+		StartOffset: active.StartOffset,
+	}
+}
+
+func (s *managedConsoleSession) setManualOutputCapture(capture consoleSessionManualCapture) *manualOutputCompletion {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.manualActive = &capture
+	return s.manualOutputCompletionLocked()
+}
+
+func (s *managedConsoleSession) updateManualActiveCommand(update *manualActiveCommandUpdate) {
+	if update == nil || s == nil || s.manager == nil || s.manager.db == nil {
+		return
+	}
+	command := s.manager.redactText(update.Command)
+	trackingReason := s.manager.redactText(update.TrackingReason)
+	if update.Downgrade {
+		now := time.Now().UTC().Format(time.RFC3339)
+		_, err := s.manager.db.ExecContext(context.Background(), `
+			UPDATE command_requests
+			SET command = ?, status = 'untracked', tracking_reason = ?, completed_at = COALESCE(completed_at, ?)
+			WHERE id = ? AND status = 'running'`,
+			command,
+			trackingReason,
+			now,
+			update.RequestID,
+		)
+		if err != nil {
+			logConsolePersistError("manual_history_update", s.id, err)
+		}
+		s.closeStaleManualRunningRows(update.RequestID, update.TrackingReason)
+		return
+	}
+	_, err := s.manager.db.ExecContext(context.Background(), `
+		UPDATE command_requests
+		SET command = ?
+		WHERE id = ? AND status = 'running'`,
+		command,
+		update.RequestID,
+	)
+	if err != nil {
+		logConsolePersistError("manual_history_update", s.id, err)
+	}
+}
+
+func (s *managedConsoleSession) manualOutputCompletionLocked() *manualOutputCompletion {
+	if s.manualActive == nil {
+		return nil
+	}
+	active := *s.manualActive
+	startOffset := active.StartOffset
+	truncated := false
+	if startOffset > len(s.rawTranscript) {
+		startOffset = 0
+		truncated = true
+	}
+	segment := s.rawTranscript[startOffset:]
+	if !manualSegmentHasPrompt(segment) {
+		return nil
+	}
+	stdout, outputTruncated := manualCapturedOutput(segment, active.Command)
+	truncated = truncated || outputTruncated
+	status := "completed"
+	errorText := ""
+	if strings.Contains(segment, "^C") {
+		status = "canceled"
+		errorText = "manual command interrupted"
+	}
+	trackingReason := active.CompletionTrackingReason
+	if strings.TrimSpace(trackingReason) == "" {
+		trackingReason = "exit_code_unavailable"
+	}
+	s.manualActive = nil
+	return &manualOutputCompletion{
+		RequestID:       active.RequestID,
+		Status:          status,
+		Stdout:          stdout,
+		OutputTruncated: truncated,
+		TrackingReason:  trackingReason,
+		Error:           errorText,
+	}
+}
+
+func (s *managedConsoleSession) manualActiveHasOutputLocked() bool {
+	if s.manualActive == nil {
+		return false
+	}
+	active := *s.manualActive
+	startOffset := active.StartOffset
+	if startOffset > len(s.rawTranscript) {
+		startOffset = 0
+	}
+	stdout, _ := manualCapturedOutput(s.rawTranscript[startOffset:], active.Command)
+	return strings.TrimSpace(PlainOutput(stdout)) != ""
+}
+
+func (s *managedConsoleSession) downgradeManualOutputCaptureLocked(reason string, captureOutput bool) *manualOutputCompletion {
+	if s.manualActive == nil {
+		return nil
+	}
+	active := *s.manualActive
+	startOffset := active.StartOffset
+	truncated := false
+	if startOffset > len(s.rawTranscript) {
+		startOffset = 0
+		truncated = true
+	}
+	stdout := ""
+	outputTruncated := false
+	if captureOutput {
+		stdout, outputTruncated = manualCapturedOutput(s.rawTranscript[startOffset:], active.Command)
+	}
+	s.manualActive = nil
+	return &manualOutputCompletion{
+		RequestID:       active.RequestID,
+		Status:          "untracked",
+		Stdout:          stdout,
+		OutputTruncated: truncated || outputTruncated,
+		TrackingReason:  reason,
+	}
+}
+
+func (s *managedConsoleSession) finishManualOutputCapture(completion *manualOutputCompletion) {
+	if completion == nil || s == nil || s.manager == nil || s.manager.db == nil {
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	stdout := s.manager.redactText(PlainOutput(completion.Stdout))
+	errorText := s.manager.redactText(completion.Error)
+	trackingReason := s.manager.redactText(completion.TrackingReason)
+	outputTruncated := 0
+	if completion.OutputTruncated {
+		outputTruncated = 1
+	}
+	_, err := s.manager.db.ExecContext(context.Background(), `
+		UPDATE command_requests
+		SET status = ?, stdout = ?, stderr = '', tracking_reason = ?, output_truncated = ?, error = ?, completed_at = ?
+		WHERE id = ? AND source = 'manual'`,
+		completion.Status,
+		stdout,
+		trackingReason,
+		outputTruncated,
+		errorText,
+		now,
+		completion.RequestID,
+	)
+	if err != nil {
+		logConsolePersistError("manual_history_finish", s.id, err)
+	}
+	s.closeStaleManualRunningRows(completion.RequestID, manualCaptureSuperseded)
+}
+
+func (s *managedConsoleSession) closeManualOutputCapture(reason string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.manualPause = nil
+	completion := s.manualOutputCompletionLocked()
+	if completion == nil {
+		completion = s.downgradeManualOutputCaptureLocked(reason, true)
+	}
+	s.mu.Unlock()
+	s.finishManualOutputCapture(completion)
+}
+
+func (s *managedConsoleSession) closeStaleManualRunningRows(exceptID int64, reason string) {
+	if s == nil || s.manager == nil || s.manager.db == nil || s.id < 1 {
+		return
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = manualCaptureSuperseded
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	query := `
+		UPDATE command_requests
+		SET status = 'untracked', tracking_reason = ?, completed_at = COALESCE(completed_at, ?)
+		WHERE source = 'manual'
+			AND session_id = ?
+			AND status = 'running'
+			AND (? = 0 OR id <> ?)`
+	if _, err := s.manager.db.ExecContext(context.Background(), query, s.manager.redactText(reason), now, s.id, exceptID, exceptID); err != nil {
+		logConsolePersistError("manual_history_stale", s.id, err)
+	}
+}
+
+func (s *managedConsoleSession) clearManualPauseIfPromptReturnedLocked() {
+	if s == nil || s.manualPause == nil {
+		return
+	}
+	startOffset := s.manualPause.StartOffset
+	if startOffset < 0 || startOffset > len(s.rawTranscript) {
+		startOffset = 0
+	}
+	if startOffset < len(s.rawTranscript) && manualTranscriptEndsWithPrompt(s.rawTranscript[startOffset:], s.manualPause.Prompt) {
+		s.manualPause = nil
+		s.manualInput.reset()
+	}
+}
+
+func manualReasonPausesCapture(reason string) bool {
+	switch reason {
+	case "interactive_editor", "interactive_repl", "interactive_tui", "nested_shell", "long_running_stream", "may_prompt":
+		return true
+	default:
+		return false
+	}
+}
+
+func manualActiveIsHistoryRecall(active *consoleSessionManualCapture) bool {
+	if active == nil {
+		return false
+	}
+	return active.CompletionTrackingReason == "history_recall_untracked" || active.Command == "command recalled with arrow key"
+}
+
+func manualSegmentHasPrompt(segment string) bool {
+	plain := ansiSequencePattern.ReplaceAllString(segment, "")
+	plain = strings.ReplaceAll(plain, "\r\n", "\n")
+	plain = strings.ReplaceAll(plain, "\r", "\n")
+	plain = strings.TrimRight(plain, " \t\n")
+	if plain == "" {
+		return false
+	}
+	lines := strings.Split(plain, "\n")
+	last := strings.TrimRight(lines[len(lines)-1], " \t")
+	return bareShellPromptPattern.MatchString(last)
+}
+
+func lastManualShellPrompt(transcript string) string {
+	plain := normalizedPlainTerminalText(transcript)
+	plain = strings.TrimRight(plain, " \t\n")
+	if plain == "" {
+		return ""
+	}
+	lines := strings.Split(plain, "\n")
+	for index := len(lines) - 1; index >= 0; index-- {
+		if prompt := manualPromptPrefix(lines[index]); prompt != "" {
+			return prompt
+		}
+	}
+	return ""
+}
+
+func manualTranscriptEndsWithPrompt(transcript string, prompt string) bool {
+	prompt = strings.TrimRight(normalizedPlainTerminalText(prompt), " \t\n")
+	plain := strings.TrimRight(normalizedPlainTerminalText(transcript), " \t\n")
+	if plain == "" {
+		return false
+	}
+	lines := strings.Split(plain, "\n")
+	last := strings.TrimRight(lines[len(lines)-1], " \t")
+	if !bareShellPromptPattern.MatchString(last) {
+		return false
+	}
+	return prompt == "" || last == prompt
+}
+
+func manualPromptPrefix(line string) string {
+	line = strings.TrimRight(normalizedPlainTerminalText(line), " \t\n")
+	if line == "" {
+		return ""
+	}
+	if bareShellPromptPattern.MatchString(line) {
+		return line
+	}
+	if !shellPromptPattern.MatchString(line) {
+		return ""
+	}
+	hashIndex := strings.LastIndex(line, "# ")
+	dollarIndex := strings.LastIndex(line, "$ ")
+	index := hashIndex
+	if dollarIndex > index {
+		index = dollarIndex
+	}
+	if index < 0 {
+		return ""
+	}
+	return strings.TrimRight(line[:index+1], " \t")
+}
+
+func manualCapturedOutput(segment string, command string) (string, bool) {
+	plain := normalizedPlainTerminalText(segment)
+	lines := strings.Split(plain, "\n")
+	commandLines := manualCommandLines(command)
+	cleaned := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if lineContainsAnyCommandEcho(line, commandLines) {
+			continue
+		}
+		cleaned = append(cleaned, line)
+	}
+	lines = cleaned
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) > 0 && bareShellPromptPattern.MatchString(strings.TrimRight(lines[len(lines)-1], " \t")) {
+		lines = lines[:len(lines)-1]
+	}
+	output := strings.Join(lines, "\n")
+	truncated := false
+	if len(output) > maxManualCapturedOutputBytes {
+		output = TailStringByBytes(output, maxManualCapturedOutputBytes)
+		truncated = true
+	}
+	return output, truncated
+}
+
+func normalizedPlainTerminalText(value string) string {
+	value = ansiSequencePattern.ReplaceAllString(value, "")
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	return value
+}
+
+func manualCommandLines(command string) []string {
+	lines := strings.Split(strings.ReplaceAll(command, "\r\n", "\n"), "\n")
+	values := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			values = append(values, line)
+		}
+	}
+	return values
+}
+
+func lineContainsAnyCommandEcho(line string, commands []string) bool {
+	for _, command := range commands {
+		if lineContainsCommandEcho(line, command) {
+			return true
+		}
+	}
+	return false
+}
+
+func lineContainsCommandEcho(line string, command string) bool {
+	line = strings.TrimSpace(line)
+	command = strings.TrimSpace(command)
+	if line == command {
+		return true
+	}
+	if bareShellPromptPattern.MatchString(line) || !shellPromptPattern.MatchString(line) {
+		return false
+	}
+	if index := strings.LastIndex(line, "# "); index >= 0 {
+		return strings.TrimSpace(line[index+2:]) == command
+	}
+	if index := strings.LastIndex(line, "$ "); index >= 0 {
+		return strings.TrimSpace(line[index+2:]) == command
+	}
+	return false
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,10 +85,15 @@ AIPermission against real VPS maintenance tasks.
 
 `0.1.4` ships:
 
-- Source-aware History groundwork for future manual Console History.
-- History source filters and badges for MCP and future manual command records.
+- Manual Console command logging for simple terminal input.
+- Best-effort manual command output capture for simple typed or pasted commands.
+- History source filters and badges for MCP and manual command records.
 - MCP request APIs explicitly scoped to MCP-origin command requests.
-- No shell hooks or manual terminal parsing yet; normal Console terminal behavior is unchanged.
+- No shell hooks or hidden command suffixes; normal Console terminal behavior is unchanged.
+- Interactive commands, nested shells, heredocs, and unsafe control sequences
+  remain untracked best-effort rows. Arrow/history recall uses a placeholder
+  command because the terminal does not send the recalled command text; simple
+  recalled commands may still capture output when the prompt returns.
 
 ## Early RC Follow-Ups
 
@@ -100,10 +105,10 @@ tag:
 - [ ] Add command policy/risk scoring primitives without turning the product
   into a DevOps platform.
 - [ ] Add optional deny/warn rules for common high-risk command patterns.
-- [ ] Add structured manual command event parsing for History on top of the
-  source-aware History groundwork. Do this with a deliberate terminal parsing
-  model instead of a quick frontend-only guess, and preserve normal terminal
-  behavior as the first invariant.
+- [ ] Add stronger manual command capture for shell history recall, arrow keys,
+  and cursor-edited commands. Do this with a deliberate frontend submitted-line
+  signal or shell-assisted marker model instead of backend escape-sequence
+  guessing, and preserve normal terminal behavior as the first invariant.
 - [ ] Add optional safety backup before import.
 - [ ] Add more Playwright browser tests for Settings, import, token permission,
   and approval workflows.

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -232,7 +232,7 @@ error
 ```
 
 MCP request tools return only MCP-origin command requests for the calling token.
-They do not expose future manual Console History rows.
+They do not expose manual Console History rows.
 
 ## send_message
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -417,7 +417,7 @@ POST /api/history-labels
 DELETE /api/history-labels/{id}
 ```
 
-`GET /api/approvals` returns recent command requests. Optional filters include `status`, `source`, `server_id`, and `label_id`. `source` is `mcp` for MCP/approval command requests and `manual` for future manual Console History records.
+`GET /api/approvals` returns recent command requests. Optional filters include `status`, `source`, `server_id`, and `label_id`. `source` is `mcp` for MCP/approval command requests and `manual` for manually typed Console commands.
 
 The History page uses paginated search. `q` searches command text, reason, status, captured output, error, server name, and token name. Command text and output fields use SQLCipher-backed FTS4 indexes; server and token names remain regular filtered fields:
 
@@ -425,7 +425,7 @@ The History page uses paginated search. `q` searches command text, reason, statu
 GET /api/approvals?paginated=true&limit=50&offset=0&q=docker&source=mcp&status=completed&server_id=3&label_id=4
 ```
 
-History response items include `source`, `tracking_reason`, and `output_truncated`. Manual Console History is groundwork only in this release; the Console does not yet install shell hooks or parse manual terminal input.
+History response items include `source`, `tracking_reason`, and `output_truncated`. Manual Console command logging records typed or pasted terminal input as `source = manual`. For simple commands, AIPermission uses the normal PTY transcript to capture output when the shell prompt returns, then marks the row `completed` or `canceled`. Because the gateway does not install shell hooks or append hidden command suffixes, it cannot reliably infer every interactive shell state. Interactive commands, nested shells, heredocs, and unsafe control sequences are stored as `untracked` best-effort rows, with output still available in the Console transcript. Arrow/history recall uses a placeholder command because the terminal does not send the recalled command text; simple recalled commands may still capture output when the prompt returns, while ambiguous interactive recalled commands are left `untracked`.
 
 The paginated response is an envelope:
 

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -62,7 +62,7 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
   assert.match(releaseSource, /appVersion = "0\.1\.4"/);
-  assert.match(releaseSource, /Manual history groundwork/);
+  assert.match(releaseSource, /Manual console history/);
 });
 
 test("Sidebar exposes explicit MCP runtime start and stop controls", () => {

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -3,20 +3,22 @@ export const appVersion = "0.1.4";
 export const changelogEntries = [
   {
     version: "0.1.4",
-    label: "Manual history groundwork",
+    label: "Manual console history",
     sections: [
       {
         title: "Added",
         items: [
-          "Source-aware History groundwork for future manual Console History.",
-          "History source filters and badges for MCP and future manual command records.",
+          "Manual Console command logging for typed or pasted terminal input.",
+          "Best-effort output capture for simple manual commands when the shell prompt returns.",
+          "History source filters and badges for MCP and manual command records.",
         ],
       },
       {
         title: "Security",
         items: [
           "MCP request APIs now explicitly stay scoped to MCP-origin command requests.",
-          "Manual History groundwork does not install shell hooks or change terminal behavior.",
+          "Manual Console History does not install shell hooks or hidden command suffixes.",
+          "Interactive commands, nested shells, and unsafe control sequences stay untracked; arrow/history recall uses a placeholder command when output can be captured.",
         ],
       },
     ],

--- a/frontend/src/pages/history.jsx
+++ b/frontend/src/pages/history.jsx
@@ -16,6 +16,7 @@ const statusOptions = [
   { value: "pending_approval", label: "Pending" },
   { value: "running", label: "Running" },
   { value: "completed", label: "Completed" },
+  { value: "canceled", label: "Canceled" },
   { value: "failed", label: "Failed" },
   { value: "declined", label: "Declined" },
   { value: "error", label: "Error" },
@@ -556,6 +557,7 @@ function SectionHeader({ label, value }) {
 function StatusBadge({ status }) {
   const tone = {
     completed: "good",
+    canceled: "warn",
     running: "neutral",
     pending_approval: "warn",
     declined: "warn",
@@ -577,6 +579,7 @@ function labelStyle(label) {
 function statusLabel(status) {
   if (status === "pending_approval") return "pending";
   if (status === "untracked") return "not tracked";
+  if (status === "canceled") return "canceled";
   return status || "unknown";
 }
 
@@ -586,12 +589,22 @@ function trackingReasonLabel(reason) {
     interactive_repl: "interactive REPL command",
     interactive_tui: "interactive terminal program",
     nested_shell: "nested shell boundary",
+    long_running_stream: "long-running stream command",
+    background_job: "background job command",
+    may_prompt: "command may prompt interactively",
     multiline_or_heredoc: "multiline command preview only",
     compound_command: "compound command shape",
+    command_preview_truncated: "command preview was truncated",
+    manual_output_not_tracked: "manual command output is available only in the console transcript",
+    exit_code_unavailable: "manual command completed; shell exit code was not captured",
     unsupported_shell: "unsupported shell",
     untrusted_command_text: "command text was not trusted",
+    history_recall_untracked: "command was recalled with an arrow key; command text was not captured",
     marker_desync: "capture marker desynchronized",
     active_exec_paused: "capture paused while an MCP command was running",
+    manual_capture_superseded: "manual capture was superseded by a newer command",
+    prompt_not_detected: "shell prompt was not detected before the next command",
+    session_closed: "console session closed before command output could be completed",
     output_buffer_limit: "output exceeded the capture limit",
     privacy_history_suppressed: "history privacy settings suppressed capture",
   };


### PR DESCRIPTION
## Summary

- Add best-effort Manual Console History output capture for typed and pasted terminal input.
- Keep terminal behavior unchanged: no shell hooks, no hidden suffixes, and no inferred shell-history text.
- Document the 0.1.4 behavior in the public API docs, roadmap, changelog, and in-app changelog.

## Notes

- Interactive commands, nested shells, heredocs, unsafe control sequences, and ambiguous arrow/history recall stay best-effort `untracked` rows.
- Simple arrow/history recall can capture output, but the command text remains a placeholder because the terminal does not send the recalled command text.
- This PR does not create the tag or publish npm packages.
- MCP package version remains 0.1.1 because this release does not change the MCP package.

## Verification

- `node scripts/secret-scan.js`
- `make test`
- `make build`
- `make audit`
- `make backend-vet`
- `cd backend && go test -race ./...`
- `cd backend && govulncheck ./...`
- `docker compose config --quiet`
- `cd packages/mcp && npm pack --dry-run`
- `cd packages/npm-placeholder && npm pack --dry-run`