### PR TITLE
Add MCP file transfer tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-06-06
+
+### Added
+
+- MCP file transfer status tools for token-scoped transfer and batch metadata.
+- MCP remote directory browsing and remote download queue start tools for
+  `always_run` server permissions.
+- MCP pause, resume, and cancel tools for active transfer queues.
+
+### Security
+
+- MCP transfer responses never include local temporary paths, local upload
+  paths, archive staging paths, or downloaded file contents.
+- MCP local file upload remains intentionally unavailable while local path scope
+  and approval semantics are designed separately.
+
 ## [0.1.6] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Implemented:
 - execution rules: `always_run`, `approval_required`, `blocked`
 - global MCP Started/Stopped switch that preserves permissions while blocking live execution
 - persistent web console with live PTY streaming
-- MCP bridge with `list_servers`, `exec`, `get_request`, `list_requests`, `read_console`, `send_message`
+- MCP bridge with command, console, message, and conservative remote download transfer tools
 - approval dialog with Run / Decline / note
 - unread message badges and AI-to-user/user-to-AI notes
 - SQLCipher FTS4-backed searchable command history and audit log pages
@@ -142,7 +142,7 @@ Out of scope for the current MVP:
 
 - SQL query tools
 - advanced command risk analysis
-- MCP file transfer tools
+- MCP local upload tools and MCP access to downloaded file contents
 - directory transfer, recursive copy, remote glob expansion, and restart-surviving resumable file transfers
 
 ## Quick Start
@@ -309,7 +309,7 @@ Important boundaries:
 - The database password can be changed from Settings while the current password is known.
 - The database password is escaped before SQLCipher key/rekey handling, so quotes or semicolons in the password cannot change PRAGMA SQL parsing.
 - Command text, command output, notes, console transcripts, and audit payloads may be stored in the encrypted local database. Basic redaction is enabled by default for common secret patterns, and Security can add custom regex rules that are stored inside the encrypted database. Redaction is best-effort. Approval execution keeps the raw command in an encrypted internal payload so redaction never changes the command that runs, while UI, MCP response fields, messages, and audit display fields stay redacted. Do not put secrets directly in commands, and use judgment when asking AI to inspect files or environment values.
-- File transfer contents are not stored in SQLCipher. Uploads and downloads use private short-lived temporary files under the local data directory; transfer history stores metadata, status, progress, speed, ETA, checksum, and errors only. Uploads are staged to a temporary remote file and moved into place only after completion, so canceled uploads do not leave partial target files behind. Download queues are capped at 1 GiB total remote file size. Pause/resume works for the active local gateway process; if the gateway, Docker container, or computer restarts, unfinished transfer queues should be started again.
+- File transfer contents are not stored in SQLCipher. Uploads and downloads use private short-lived temporary files under the local data directory; transfer history stores metadata, status, progress, speed, ETA, checksum, and errors only. Uploads are staged to a temporary remote file and moved into place only after completion, so canceled uploads do not leave partial target files behind. Download queues are capped at 1 GiB total remote file size. Pause/resume works for the active local gateway process; if the gateway, Docker container, or computer restarts, unfinished transfer queues should be started again. MCP can browse remote directories, start remote download queues, and manage transfer queues only for `always_run` server permissions; MCP cannot upload local files or receive downloaded file contents.
 - Secret fields are also encrypted with the gateway vault secret inside the SQLCipher database.
 - The gateway vault secret is sensitive. Losing it prevents vault payload decryption; exposing it together with unlocked database contents compromises vault-protected payloads.
 - `AIPERMISSION_GATEWAY_SECRET` is optional and should be left unset for normal local installs. The gateway auto-generates a high-entropy local vault secret at startup. If it is set explicitly for advanced local testing, use at least 32 random characters.

--- a/backend/internal/api/file_transfer_handlers.go
+++ b/backend/internal/api/file_transfer_handlers.go
@@ -77,6 +77,19 @@ type remoteFileConflictsResponse struct {
 	Conflicts []remoteFileConflict `json:"conflicts"`
 }
 
+type fileTransferStartError struct {
+	Status  int
+	Message string
+}
+
+func (err *fileTransferStartError) Error() string {
+	return err.Message
+}
+
+func newFileTransferStartError(status int, message string) error {
+	return &fileTransferStartError{Status: status, Message: message}
+}
+
 func (s fileTransferHandlers) listFileTransfers(w http.ResponseWriter, r *http.Request) {
 	runtime, ok := s.activeRuntimeOrLocked(w)
 	if !ok {
@@ -675,94 +688,13 @@ func (s fileTransferHandlers) startDownloadBatch(w http.ResponseWriter, r *http.
 		writeError(w, http.StatusBadRequest, "invalid json body")
 		return
 	}
-	if request.ServerID < 1 {
-		writeError(w, http.StatusBadRequest, "server_id is required")
-		return
-	}
-	if len(request.RemotePaths) == 0 {
-		writeError(w, http.StatusBadRequest, "remote_paths is required")
-		return
-	}
-	if len(request.RemotePaths) > 100 {
-		writeError(w, http.StatusBadRequest, "cannot download more than 100 files at once")
-		return
-	}
 	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 	defer cancel()
-	server, privateKey, err := s.serverSSHMaterialFromRuntime(ctx, runtime, request.ServerID)
+	batch, err := s.createDownloadBatch(ctx, runtime, request.ServerID, request.RemotePaths, request.ArchiveName, filetransfer.SourceUI)
 	if err != nil {
-		handleServerSSHMaterialError(w, err)
-		return
-	}
-	target := s.executionTarget(server, privateKey)
-	items := make([]filetransfer.CreateRequest, 0, len(request.RemotePaths))
-	tempPaths := []string{}
-	seenRemotePaths := map[string]bool{}
-	var totalSize int64
-	for _, raw := range request.RemotePaths {
-		remotePath, err := normalizeRemoteFilePath(raw)
-		if err != nil {
-			cleanupTempPaths(tempPaths)
-			writeError(w, http.StatusBadRequest, err.Error())
+		if s.writeFileTransferStartError(w, err) {
 			return
 		}
-		if seenRemotePaths[remotePath] {
-			cleanupTempPaths(tempPaths)
-			writeError(w, http.StatusBadRequest, "download queue contains duplicate remote paths")
-			return
-		}
-		seenRemotePaths[remotePath] = true
-		status, err := execution.StatRemotePath(ctx, target, remotePath)
-		if err != nil {
-			cleanupTempPaths(tempPaths)
-			if writeUnknownHostKeyError(w, err) {
-				return
-			}
-			writeError(w, http.StatusBadGateway, sshConnectionFailureMessage(err))
-			return
-		}
-		if !status.Exists || status.Type != "file" {
-			cleanupTempPaths(tempPaths)
-			writeError(w, http.StatusBadRequest, "remote path must be an existing regular file")
-			return
-		}
-		totalSize += status.Size
-		if totalSize > maxFileTransferBatchBytes {
-			cleanupTempPaths(tempPaths)
-			writeError(w, http.StatusRequestEntityTooLarge, "download batch cannot exceed 1 GiB total size")
-			return
-		}
-		tempPath, err := s.reserveDownloadTempFile()
-		if err != nil {
-			cleanupTempPaths(tempPaths)
-			writeInternalError(w)
-			return
-		}
-		tempPaths = append(tempPaths, tempPath)
-		fileName := safeFileName(path.Base(remotePath))
-		items = append(items, filetransfer.CreateRequest{
-			RemotePath: remotePath,
-			FileName:   fileName,
-			SizeBytes:  status.Size,
-			TempPath:   tempPath,
-		})
-	}
-	archiveName := ""
-	if strings.TrimSpace(request.ArchiveName) != "" {
-		archiveName = safeFileName(request.ArchiveName)
-	}
-	if archiveName == "" && len(items) > 1 {
-		archiveName = fmt.Sprintf("aipermission-download-%s.zip", time.Now().UTC().Format("20060102-150405"))
-	}
-	batch, err := runtime.fileTransfers.CreateBatch(r.Context(), filetransfer.CreateBatchRequest{
-		ServerID:    request.ServerID,
-		Direction:   filetransfer.DirectionDownload,
-		Source:      filetransfer.SourceUI,
-		ArchiveName: archiveName,
-		Items:       items,
-	})
-	if err != nil {
-		cleanupTempPaths(tempPaths)
 		writeInternalError(w)
 		return
 	}
@@ -773,6 +705,101 @@ func (s fileTransferHandlers) startDownloadBatch(w http.ResponseWriter, r *http.
 	})
 	go s.runTransferBatch(runtime, batch.ID, false)
 	writeJSON(w, http.StatusAccepted, batch)
+}
+
+func (s fileTransferHandlers) createDownloadBatch(ctx context.Context, runtime *databaseRuntime, serverID int64, remotePaths []string, archiveName string, source string) (filetransfer.BatchRecord, error) {
+	if serverID < 1 {
+		return filetransfer.BatchRecord{}, newFileTransferStartError(http.StatusBadRequest, "server_id is required")
+	}
+	if len(remotePaths) == 0 {
+		return filetransfer.BatchRecord{}, newFileTransferStartError(http.StatusBadRequest, "remote_paths is required")
+	}
+	if len(remotePaths) > 100 {
+		return filetransfer.BatchRecord{}, newFileTransferStartError(http.StatusBadRequest, "cannot download more than 100 files at once")
+	}
+	server, privateKey, err := s.serverSSHMaterialFromRuntime(ctx, runtime, serverID)
+	if err != nil {
+		return filetransfer.BatchRecord{}, err
+	}
+	target := s.executionTarget(server, privateKey)
+	items := make([]filetransfer.CreateRequest, 0, len(remotePaths))
+	tempPaths := []string{}
+	seenRemotePaths := map[string]bool{}
+	var totalSize int64
+	for _, raw := range remotePaths {
+		remotePath, err := normalizeRemoteFilePath(raw)
+		if err != nil {
+			cleanupTempPaths(tempPaths)
+			return filetransfer.BatchRecord{}, newFileTransferStartError(http.StatusBadRequest, err.Error())
+		}
+		if seenRemotePaths[remotePath] {
+			cleanupTempPaths(tempPaths)
+			return filetransfer.BatchRecord{}, newFileTransferStartError(http.StatusBadRequest, "download queue contains duplicate remote paths")
+		}
+		seenRemotePaths[remotePath] = true
+		status, err := execution.StatRemotePath(ctx, target, remotePath)
+		if err != nil {
+			cleanupTempPaths(tempPaths)
+			return filetransfer.BatchRecord{}, err
+		}
+		if !status.Exists || status.Type != "file" {
+			cleanupTempPaths(tempPaths)
+			return filetransfer.BatchRecord{}, newFileTransferStartError(http.StatusBadRequest, "remote path must be an existing regular file")
+		}
+		totalSize += status.Size
+		if totalSize > maxFileTransferBatchBytes {
+			cleanupTempPaths(tempPaths)
+			return filetransfer.BatchRecord{}, newFileTransferStartError(http.StatusRequestEntityTooLarge, "download batch cannot exceed 1 GiB total size")
+		}
+		tempPath, err := s.reserveDownloadTempFile()
+		if err != nil {
+			cleanupTempPaths(tempPaths)
+			return filetransfer.BatchRecord{}, err
+		}
+		tempPaths = append(tempPaths, tempPath)
+		fileName := safeFileName(path.Base(remotePath))
+		items = append(items, filetransfer.CreateRequest{
+			RemotePath: remotePath,
+			FileName:   fileName,
+			SizeBytes:  status.Size,
+			TempPath:   tempPath,
+		})
+	}
+	cleanArchiveName := ""
+	if strings.TrimSpace(archiveName) != "" {
+		cleanArchiveName = safeFileName(archiveName)
+	}
+	if cleanArchiveName == "" && len(items) > 1 {
+		cleanArchiveName = fmt.Sprintf("aipermission-download-%s.zip", time.Now().UTC().Format("20060102-150405"))
+	}
+	batch, err := runtime.fileTransfers.CreateBatch(ctx, filetransfer.CreateBatchRequest{
+		ServerID:    serverID,
+		Direction:   filetransfer.DirectionDownload,
+		Source:      source,
+		ArchiveName: cleanArchiveName,
+		Items:       items,
+	})
+	if err != nil {
+		cleanupTempPaths(tempPaths)
+		return filetransfer.BatchRecord{}, err
+	}
+	return batch, nil
+}
+
+func (s fileTransferHandlers) writeFileTransferStartError(w http.ResponseWriter, err error) bool {
+	if errors.Is(err, servers.ErrNotFound) || errors.Is(err, sshkeys.ErrNotFound) {
+		handleServerSSHMaterialError(w, err)
+		return true
+	}
+	var startErr *fileTransferStartError
+	if errors.As(err, &startErr) {
+		writeError(w, startErr.Status, startErr.Message)
+		return true
+	}
+	if writeUnknownHostKeyError(w, err) {
+		return true
+	}
+	return false
 }
 
 func (s fileTransferHandlers) downloadTransferredFile(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/api/mcp_file_transfers.go
+++ b/backend/internal/api/mcp_file_transfers.go
@@ -1,0 +1,651 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/execution"
+	"github.com/aipermission/aipermission/backend/internal/filetransfer"
+	"github.com/aipermission/aipermission/backend/internal/tokens"
+)
+
+const (
+	defaultMCPFileTransferLimit = 20
+	maxMCPFileTransferLimit     = 100
+)
+
+type mcpFileTransferItem struct {
+	ID               int64  `json:"id"`
+	BatchID          int64  `json:"batch_id,omitempty"`
+	QueueIndex       int    `json:"queue_index,omitempty"`
+	ServerID         int64  `json:"server_id"`
+	ServerName       string `json:"server_name,omitempty"`
+	Direction        string `json:"direction"`
+	Source           string `json:"source"`
+	Status           string `json:"status"`
+	RemotePath       string `json:"remote_path"`
+	FileName         string `json:"file_name"`
+	SizeBytes        int64  `json:"size_bytes"`
+	TransferredBytes int64  `json:"transferred_bytes"`
+	BytesPerSecond   int64  `json:"bytes_per_second"`
+	ETASeconds       int64  `json:"eta_seconds"`
+	ChecksumSHA256   string `json:"checksum_sha256,omitempty"`
+	Error            string `json:"error,omitempty"`
+	CreatedAt        string `json:"created_at"`
+	StartedAt        string `json:"started_at,omitempty"`
+	CompletedAt      string `json:"completed_at,omitempty"`
+	UpdatedAt        string `json:"updated_at"`
+}
+
+type mcpFileTransferBatchItem struct {
+	ID               int64                 `json:"id"`
+	ServerID         int64                 `json:"server_id"`
+	ServerName       string                `json:"server_name,omitempty"`
+	Direction        string                `json:"direction"`
+	Source           string                `json:"source"`
+	Status           string                `json:"status"`
+	ArchiveName      string                `json:"archive_name,omitempty"`
+	TotalItems       int                   `json:"total_items"`
+	CompletedItems   int                   `json:"completed_items"`
+	FailedItems      int                   `json:"failed_items"`
+	CanceledItems    int                   `json:"canceled_items"`
+	SizeBytes        int64                 `json:"size_bytes"`
+	TransferredBytes int64                 `json:"transferred_bytes"`
+	BytesPerSecond   int64                 `json:"bytes_per_second"`
+	ETASeconds       int64                 `json:"eta_seconds"`
+	Error            string                `json:"error,omitempty"`
+	CreatedAt        string                `json:"created_at"`
+	StartedAt        string                `json:"started_at,omitempty"`
+	CompletedAt      string                `json:"completed_at,omitempty"`
+	UpdatedAt        string                `json:"updated_at"`
+	Items            []mcpFileTransferItem `json:"items,omitempty"`
+}
+
+type mcpFileTransferPage struct {
+	Items  []mcpFileTransferItem `json:"items"`
+	Total  int                   `json:"total"`
+	Limit  int                   `json:"limit"`
+	Offset int                   `json:"offset"`
+}
+
+type mcpFileTransferBatchPage struct {
+	Items  []mcpFileTransferBatchItem `json:"items"`
+	Total  int                        `json:"total"`
+	Limit  int                        `json:"limit"`
+	Offset int                        `json:"offset"`
+}
+
+type mcpFileTransferActionResponse struct {
+	Status            string                    `json:"status"`
+	ServerID          int64                     `json:"server_id,omitempty"`
+	ServerName        string                    `json:"server_name,omitempty"`
+	Batch             *mcpFileTransferBatchItem `json:"batch,omitempty"`
+	Error             string                    `json:"error,omitempty"`
+	RetryAfterSeconds int                       `json:"retry_after_seconds,omitempty"`
+	AssistantHint     string                    `json:"assistant_hint,omitempty"`
+}
+
+type mcpStartFileDownloadRequest struct {
+	ServerID    int64    `json:"server_id"`
+	RemotePaths []string `json:"remote_paths"`
+	ArchiveName string   `json:"archive_name,omitempty"`
+}
+
+func (s mcpHandlers) mcpListFileTransfers(w http.ResponseWriter, r *http.Request) {
+	auth, ok := s.authenticateMCP(w, r)
+	if !ok {
+		return
+	}
+	limit, offset, ok := parseMCPTransferListPagination(w, r)
+	if !ok {
+		return
+	}
+	filter := filetransfer.ListFilter{
+		Direction: strings.TrimSpace(r.URL.Query().Get("direction")),
+		Status:    strings.TrimSpace(r.URL.Query().Get("status")),
+		Limit:     limit,
+		Offset:    offset,
+	}
+	if !validMCPTransferFilter(w, filter.Direction, filter.Status) {
+		return
+	}
+	if rawServerID := strings.TrimSpace(r.URL.Query().Get("server_id")); rawServerID != "" {
+		serverID, ok := parseInt64Query(w, rawServerID, "server_id")
+		if !ok {
+			return
+		}
+		canSee, err := s.mcpCanSeeServer(r.Context(), auth.runtime, auth.TokenID, serverID)
+		if err != nil {
+			writeInternalError(w)
+			return
+		}
+		if !canSee {
+			writeJSON(w, http.StatusOK, mcpFileTransferPage{Items: []mcpFileTransferItem{}, Limit: limit, Offset: offset})
+			return
+		}
+		filter.ServerID = serverID
+	} else {
+		serverIDs, err := s.mcpAllowedServerIDs(r.Context(), auth.runtime, auth.TokenID)
+		if err != nil {
+			writeInternalError(w)
+			return
+		}
+		if len(serverIDs) == 0 {
+			writeJSON(w, http.StatusOK, mcpFileTransferPage{Items: []mcpFileTransferItem{}, Limit: limit, Offset: offset})
+			return
+		}
+		filter.ServerIDs = serverIDs
+	}
+
+	items, total, err := auth.runtime.fileTransfers.List(r.Context(), filter)
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	writeJSON(w, http.StatusOK, mcpFileTransferPage{
+		Items:  sanitizeMCPFileTransferItems(items),
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
+}
+
+func (s mcpHandlers) mcpGetFileTransfer(w http.ResponseWriter, r *http.Request) {
+	auth, ok := s.authenticateMCP(w, r)
+	if !ok {
+		return
+	}
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	item, err := auth.runtime.fileTransfers.Get(r.Context(), id)
+	if errors.Is(err, filetransfer.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "file transfer not found")
+		return
+	}
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	canSee, err := s.mcpCanSeeServer(r.Context(), auth.runtime, auth.TokenID, item.ServerID)
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	if !canSee {
+		writeError(w, http.StatusNotFound, "file transfer not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, sanitizeMCPFileTransferItem(item))
+}
+
+func (s mcpHandlers) mcpListFileTransferBatches(w http.ResponseWriter, r *http.Request) {
+	auth, ok := s.authenticateMCP(w, r)
+	if !ok {
+		return
+	}
+	limit, offset, ok := parseMCPTransferListPagination(w, r)
+	if !ok {
+		return
+	}
+	filter := filetransfer.BatchListFilter{
+		Direction: strings.TrimSpace(r.URL.Query().Get("direction")),
+		Status:    strings.TrimSpace(r.URL.Query().Get("status")),
+		Limit:     limit,
+		Offset:    offset,
+	}
+	if !validMCPTransferFilter(w, filter.Direction, filter.Status) {
+		return
+	}
+	if rawServerID := strings.TrimSpace(r.URL.Query().Get("server_id")); rawServerID != "" {
+		serverID, ok := parseInt64Query(w, rawServerID, "server_id")
+		if !ok {
+			return
+		}
+		canSee, err := s.mcpCanSeeServer(r.Context(), auth.runtime, auth.TokenID, serverID)
+		if err != nil {
+			writeInternalError(w)
+			return
+		}
+		if !canSee {
+			writeJSON(w, http.StatusOK, mcpFileTransferBatchPage{Items: []mcpFileTransferBatchItem{}, Limit: limit, Offset: offset})
+			return
+		}
+		filter.ServerID = serverID
+	} else {
+		serverIDs, err := s.mcpAllowedServerIDs(r.Context(), auth.runtime, auth.TokenID)
+		if err != nil {
+			writeInternalError(w)
+			return
+		}
+		if len(serverIDs) == 0 {
+			writeJSON(w, http.StatusOK, mcpFileTransferBatchPage{Items: []mcpFileTransferBatchItem{}, Limit: limit, Offset: offset})
+			return
+		}
+		filter.ServerIDs = serverIDs
+	}
+
+	items, total, err := auth.runtime.fileTransfers.ListBatches(r.Context(), filter)
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	writeJSON(w, http.StatusOK, mcpFileTransferBatchPage{
+		Items:  sanitizeMCPFileTransferBatches(items, false),
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
+}
+
+func (s mcpHandlers) mcpGetFileTransferBatch(w http.ResponseWriter, r *http.Request) {
+	auth, ok := s.authenticateMCP(w, r)
+	if !ok {
+		return
+	}
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	batch, err := auth.runtime.fileTransfers.GetBatch(r.Context(), id)
+	if errors.Is(err, filetransfer.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "file transfer batch not found")
+		return
+	}
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	canSee, err := s.mcpCanSeeServer(r.Context(), auth.runtime, auth.TokenID, batch.ServerID)
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	if !canSee {
+		writeError(w, http.StatusNotFound, "file transfer batch not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, sanitizeMCPFileTransferBatch(batch, true))
+}
+
+func (s mcpHandlers) mcpBrowseRemoteFiles(w http.ResponseWriter, r *http.Request) {
+	auth, ok := s.authenticateMCP(w, r)
+	if !ok {
+		return
+	}
+	if s.rejectStoppedMCP(w, auth.runtime) {
+		return
+	}
+	var request browseRemoteFilesRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	serverName, ok := s.requireMCPTransferControl(w, r.Context(), auth.runtime, auth.TokenID, request.ServerID)
+	if !ok {
+		return
+	}
+	remotePath, err := normalizeRemoteDirectoryPath(request.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	server, privateKey, err := fileTransferHandlers{s.Server}.serverSSHMaterialFromRuntime(ctx, auth.runtime, request.ServerID)
+	if err != nil {
+		handleServerSSHMaterialError(w, err)
+		return
+	}
+	entries, err := execution.ListRemoteDirectory(ctx, s.executionTarget(server, privateKey), remotePath)
+	if err != nil {
+		if writeUnknownHostKeyError(w, err) {
+			return
+		}
+		writeError(w, http.StatusBadGateway, sshConnectionFailureMessage(err))
+		return
+	}
+	parent := pathDirForMCPBrowse(remotePath)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"server_id":   request.ServerID,
+		"server_name": serverName,
+		"path":        remotePath,
+		"parent":      parent,
+		"entries":     entries,
+	})
+}
+
+func (s mcpHandlers) mcpStartFileDownload(w http.ResponseWriter, r *http.Request) {
+	auth, ok := s.authenticateMCP(w, r)
+	if !ok {
+		return
+	}
+	if s.rejectStoppedMCP(w, auth.runtime) {
+		return
+	}
+	var request mcpStartFileDownloadRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	serverName, ok := s.requireMCPTransferControl(w, r.Context(), auth.runtime, auth.TokenID, request.ServerID)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+	transfers := fileTransferHandlers{s.Server}
+	batch, err := transfers.createDownloadBatch(ctx, auth.runtime, request.ServerID, request.RemotePaths, request.ArchiveName, filetransfer.SourceMCP)
+	if err != nil {
+		if transfers.writeFileTransferStartError(w, err) {
+			return
+		}
+		writeInternalError(w)
+		return
+	}
+	s.writeAudit(r.Context(), auth.runtime, "mcp", int64Ptr(auth.TokenID), request.ServerID, "mcp.file_transfer.batch.download.started", map[string]any{
+		"batch_id":   batch.ID,
+		"items":      len(batch.Items),
+		"size_bytes": batch.SizeBytes,
+	})
+	go transfers.runTransferBatch(auth.runtime, batch.ID, false)
+	sanitized := sanitizeMCPFileTransferBatch(batch, true)
+	writeJSON(w, http.StatusAccepted, mcpFileTransferActionResponse{
+		Status:            sanitized.Status,
+		ServerID:          request.ServerID,
+		ServerName:        serverName,
+		Batch:             &sanitized,
+		RetryAfterSeconds: 3,
+		AssistantHint:     "Poll get_file_transfer_batch for progress. The completed archive or file is staged locally for the human operator to save from the AIPermission UI.",
+	})
+}
+
+func (s mcpHandlers) mcpPauseFileTransferBatch(w http.ResponseWriter, r *http.Request) {
+	s.mcpControlFileTransferBatch(w, r, "pause")
+}
+
+func (s mcpHandlers) mcpResumeFileTransferBatch(w http.ResponseWriter, r *http.Request) {
+	s.mcpControlFileTransferBatch(w, r, "resume")
+}
+
+func (s mcpHandlers) mcpCancelFileTransferBatch(w http.ResponseWriter, r *http.Request) {
+	s.mcpControlFileTransferBatch(w, r, "cancel")
+}
+
+func (s mcpHandlers) mcpControlFileTransferBatch(w http.ResponseWriter, r *http.Request, action string) {
+	auth, ok := s.authenticateMCP(w, r)
+	if !ok {
+		return
+	}
+	if s.rejectStoppedMCP(w, auth.runtime) {
+		return
+	}
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	batch, err := auth.runtime.fileTransfers.GetBatch(r.Context(), id)
+	if errors.Is(err, filetransfer.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "file transfer batch not found")
+		return
+	}
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	serverName, ok := s.requireMCPTransferControl(w, r.Context(), auth.runtime, auth.TokenID, batch.ServerID)
+	if !ok {
+		return
+	}
+
+	switch action {
+	case "pause":
+		control := auth.runtime.batchControl(id)
+		if control == nil {
+			writeError(w, http.StatusConflict, "file transfer batch is not active")
+			return
+		}
+		if !control.Pause() {
+			writeError(w, http.StatusConflict, "file transfer batch is already paused")
+			return
+		}
+		changed, err := auth.runtime.fileTransfers.PauseBatch(context.Background(), id)
+		if err != nil {
+			control.Resume()
+			writeInternalError(w)
+			return
+		}
+		if !changed {
+			control.Resume()
+			writeError(w, http.StatusConflict, "file transfer batch is not running")
+			return
+		}
+	case "resume":
+		control := auth.runtime.batchControl(id)
+		if control == nil {
+			writeError(w, http.StatusConflict, "file transfer batch is not active")
+			return
+		}
+		changed, err := auth.runtime.fileTransfers.ResumeBatch(context.Background(), id)
+		if err != nil {
+			writeInternalError(w)
+			return
+		}
+		if !changed {
+			writeError(w, http.StatusConflict, "file transfer batch is not paused")
+			return
+		}
+		control.Resume()
+	case "cancel":
+		auth.runtime.cancelBatch(id)
+		if control := auth.runtime.batchControl(id); control != nil {
+			control.Resume()
+		}
+		changed, err := auth.runtime.fileTransfers.CancelBatch(context.Background(), id, "canceled by MCP token")
+		if err != nil {
+			writeInternalError(w)
+			return
+		}
+		if changed {
+			fileTransferHandlers{s.Server}.cleanupBatchTemps(auth.runtime, id)
+		}
+	default:
+		writeInternalError(w)
+		return
+	}
+	s.writeAudit(context.Background(), auth.runtime, "mcp", int64Ptr(auth.TokenID), batch.ServerID, "mcp.file_transfer.batch."+action, map[string]any{"batch_id": id})
+	updated, err := auth.runtime.fileTransfers.GetBatch(r.Context(), id)
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	sanitized := sanitizeMCPFileTransferBatch(updated, true)
+	writeJSON(w, http.StatusOK, mcpFileTransferActionResponse{
+		Status:     sanitized.Status,
+		ServerID:   batch.ServerID,
+		ServerName: serverName,
+		Batch:      &sanitized,
+	})
+}
+
+func (s mcpHandlers) mcpAllowedServerIDs(ctx context.Context, runtime *databaseRuntime, tokenID int64) ([]int64, error) {
+	rows, err := runtime.database.QueryContext(ctx, `
+		SELECT server_id
+		FROM token_server_permissions
+		WHERE token_id = ? AND execution_rule != ?
+		ORDER BY server_id`,
+		tokenID,
+		tokens.RuleBlocked,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (s mcpHandlers) mcpCanSeeServer(ctx context.Context, runtime *databaseRuntime, tokenID int64, serverID int64) (bool, error) {
+	_, rule, allowed, err := s.mcpPermission(ctx, runtime, tokenID, serverID)
+	if err != nil {
+		return false, err
+	}
+	return allowed && rule != tokens.RuleBlocked, nil
+}
+
+func (s mcpHandlers) requireMCPTransferControl(w http.ResponseWriter, ctx context.Context, runtime *databaseRuntime, tokenID int64, serverID int64) (string, bool) {
+	if serverID < 1 {
+		writeError(w, http.StatusBadRequest, "server_id is required")
+		return "", false
+	}
+	serverName, rule, allowed, err := s.mcpPermission(ctx, runtime, tokenID, serverID)
+	if err != nil {
+		writeInternalError(w)
+		return "", false
+	}
+	if !allowed || rule == tokens.RuleBlocked {
+		writeJSON(w, http.StatusOK, mcpFileTransferActionResponse{
+			Status:   "blocked",
+			ServerID: serverID,
+			Error:    "This token is blocked from managing file transfers on this server",
+		})
+		return "", false
+	}
+	if rule != tokens.RuleAlwaysRun {
+		writeJSON(w, http.StatusOK, mcpFileTransferActionResponse{
+			Status:   "blocked",
+			ServerID: serverID,
+			Error:    "MCP file transfer management requires always_run permission for this server. Use the local UI for prompt-required transfer decisions.",
+		})
+		return "", false
+	}
+	return serverName, true
+}
+
+func parseMCPTransferListPagination(w http.ResponseWriter, r *http.Request) (int, int, bool) {
+	limit := defaultMCPFileTransferLimit
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value < 1 {
+			writeError(w, http.StatusBadRequest, "invalid limit")
+			return 0, 0, false
+		}
+		limit = value
+	}
+	if limit > maxMCPFileTransferLimit {
+		limit = maxMCPFileTransferLimit
+	}
+	offset := 0
+	if raw := strings.TrimSpace(r.URL.Query().Get("offset")); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value < 0 {
+			writeError(w, http.StatusBadRequest, "invalid offset")
+			return 0, 0, false
+		}
+		offset = value
+	}
+	return limit, offset, true
+}
+
+func validMCPTransferFilter(w http.ResponseWriter, direction string, status string) bool {
+	if direction != "" && direction != filetransfer.DirectionUpload && direction != filetransfer.DirectionDownload {
+		writeError(w, http.StatusBadRequest, "invalid direction")
+		return false
+	}
+	if status != "" && !validFileTransferStatus(status) {
+		writeError(w, http.StatusBadRequest, "invalid status")
+		return false
+	}
+	return true
+}
+
+func sanitizeMCPFileTransferItems(items []filetransfer.Record) []mcpFileTransferItem {
+	result := make([]mcpFileTransferItem, 0, len(items))
+	for _, item := range items {
+		result = append(result, sanitizeMCPFileTransferItem(item))
+	}
+	return result
+}
+
+func sanitizeMCPFileTransferItem(item filetransfer.Record) mcpFileTransferItem {
+	return mcpFileTransferItem{
+		ID:               item.ID,
+		BatchID:          item.BatchID,
+		QueueIndex:       item.QueueIndex,
+		ServerID:         item.ServerID,
+		ServerName:       item.ServerName,
+		Direction:        item.Direction,
+		Source:           item.Source,
+		Status:           item.Status,
+		RemotePath:       item.RemotePath,
+		FileName:         item.FileName,
+		SizeBytes:        item.SizeBytes,
+		TransferredBytes: item.TransferredBytes,
+		BytesPerSecond:   item.BytesPerSecond,
+		ETASeconds:       item.ETASeconds,
+		ChecksumSHA256:   item.ChecksumSHA256,
+		Error:            item.Error,
+		CreatedAt:        item.CreatedAt,
+		StartedAt:        item.StartedAt,
+		CompletedAt:      item.CompletedAt,
+		UpdatedAt:        item.UpdatedAt,
+	}
+}
+
+func sanitizeMCPFileTransferBatches(items []filetransfer.BatchRecord, includeItems bool) []mcpFileTransferBatchItem {
+	result := make([]mcpFileTransferBatchItem, 0, len(items))
+	for _, item := range items {
+		result = append(result, sanitizeMCPFileTransferBatch(item, includeItems))
+	}
+	return result
+}
+
+func sanitizeMCPFileTransferBatch(item filetransfer.BatchRecord, includeItems bool) mcpFileTransferBatchItem {
+	result := mcpFileTransferBatchItem{
+		ID:               item.ID,
+		ServerID:         item.ServerID,
+		ServerName:       item.ServerName,
+		Direction:        item.Direction,
+		Source:           item.Source,
+		Status:           item.Status,
+		ArchiveName:      item.ArchiveName,
+		TotalItems:       item.TotalItems,
+		CompletedItems:   item.CompletedItems,
+		FailedItems:      item.FailedItems,
+		CanceledItems:    item.CanceledItems,
+		SizeBytes:        item.SizeBytes,
+		TransferredBytes: item.TransferredBytes,
+		BytesPerSecond:   item.BytesPerSecond,
+		ETASeconds:       item.ETASeconds,
+		Error:            item.Error,
+		CreatedAt:        item.CreatedAt,
+		StartedAt:        item.StartedAt,
+		CompletedAt:      item.CompletedAt,
+		UpdatedAt:        item.UpdatedAt,
+	}
+	if includeItems {
+		result.Items = sanitizeMCPFileTransferItems(item.Items)
+	}
+	return result
+}
+
+func pathDirForMCPBrowse(remotePath string) string {
+	parent := path.Dir(remotePath)
+	if parent == "." || parent == remotePath {
+		return "/"
+	}
+	return parent
+}

--- a/backend/internal/api/mcp_test.go
+++ b/backend/internal/api/mcp_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/aipermission/aipermission/backend/internal/config"
 	dbpkg "github.com/aipermission/aipermission/backend/internal/db"
+	"github.com/aipermission/aipermission/backend/internal/filetransfer"
 	"github.com/aipermission/aipermission/backend/internal/servers"
 	"github.com/aipermission/aipermission/backend/internal/sshkeys"
 	"github.com/aipermission/aipermission/backend/internal/tokens"
@@ -486,5 +487,115 @@ func TestMCPExecValidatesInputAndBlocksMissingPermission(t *testing.T) {
 	}
 	if !strings.Contains(response.Body.String(), `"status":"blocked"`) {
 		t.Fatalf("expected blocked response, got %s", response.Body.String())
+	}
+}
+
+func TestMCPFileTransferStatusIsTokenScopedAndSanitized(t *testing.T) {
+	fixture := newAPITestFixture(t)
+	ctx := context.Background()
+	token, err := fixture.tokens.Create(ctx, tokens.CreateRequest{Name: "agent"})
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	allowed := fixture.createKeyAndServer(t, "allowed-transfer")
+	blocked := fixture.createKeyAndServer(t, "blocked-transfer")
+	if _, err := fixture.tokens.UpdatePermissions(ctx, token.ID, tokens.UpdatePermissionsRequest{Permissions: []tokens.PermissionInput{
+		{ServerID: allowed.ID, ExecutionRule: tokens.RuleAlwaysRun},
+		{ServerID: blocked.ID, ExecutionRule: tokens.RuleBlocked},
+	}}); err != nil {
+		t.Fatalf("update permissions: %v", err)
+	}
+	runtime := fixture.server.activeRuntime()
+	allowedTransfer, err := runtime.fileTransfers.Create(ctx, filetransfer.CreateRequest{
+		ServerID:   allowed.ID,
+		Direction:  filetransfer.DirectionDownload,
+		Source:     filetransfer.SourceMCP,
+		LocalPath:  "/local/should-not-leak",
+		RemotePath: "/var/log/app.log",
+		FileName:   "app.log",
+		SizeBytes:  20,
+		TempPath:   "/tmp/aipermission-secret-download",
+	})
+	if err != nil {
+		t.Fatalf("create allowed transfer: %v", err)
+	}
+	blockedTransfer, err := runtime.fileTransfers.Create(ctx, filetransfer.CreateRequest{
+		ServerID:   blocked.ID,
+		Direction:  filetransfer.DirectionDownload,
+		Source:     filetransfer.SourceMCP,
+		RemotePath: "/var/log/blocked.log",
+		FileName:   "blocked.log",
+		TempPath:   "/tmp/blocked-secret",
+	})
+	if err != nil {
+		t.Fatalf("create blocked transfer: %v", err)
+	}
+	batch, err := runtime.fileTransfers.CreateBatch(ctx, filetransfer.CreateBatchRequest{
+		ServerID:    allowed.ID,
+		Direction:   filetransfer.DirectionDownload,
+		Source:      filetransfer.SourceMCP,
+		ArchiveName: "logs.zip",
+		Items: []filetransfer.CreateRequest{
+			{RemotePath: "/var/log/app.log", FileName: "app.log", SizeBytes: 20, TempPath: "/tmp/aipermission-secret-item"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create batch: %v", err)
+	}
+	if err := runtime.fileTransfers.SetBatchArchive(ctx, batch.ID, "/tmp/aipermission-secret-archive.zip"); err != nil {
+		t.Fatalf("set archive path: %v", err)
+	}
+
+	listResponse := performJSON(fixture.server.Handler(), http.MethodGet, "/api/mcp/file-transfers?limit=10", token.TokenValue, nil)
+	if listResponse.Code != http.StatusOK {
+		t.Fatalf("list transfers failed: %d %s", listResponse.Code, listResponse.Body.String())
+	}
+	body := listResponse.Body.String()
+	if !strings.Contains(body, `"id":`+strconv.FormatInt(allowedTransfer.ID, 10)) || strings.Contains(body, "/var/log/blocked.log") || strings.Contains(body, "blocked-transfer") {
+		t.Fatalf("transfer list should include only allowed transfer: %s", body)
+	}
+	if strings.Contains(body, "should-not-leak") || strings.Contains(body, "aipermission-secret") || strings.Contains(body, "local_path") || strings.Contains(body, "temp_path") {
+		t.Fatalf("transfer list leaked local metadata: %s", body)
+	}
+
+	getBlocked := performJSON(fixture.server.Handler(), http.MethodGet, "/api/mcp/file-transfers/"+strconv.FormatInt(blockedTransfer.ID, 10), token.TokenValue, nil)
+	if getBlocked.Code != http.StatusNotFound {
+		t.Fatalf("blocked transfer detail should look not found, got %d %s", getBlocked.Code, getBlocked.Body.String())
+	}
+
+	batchResponse := performJSON(fixture.server.Handler(), http.MethodGet, "/api/mcp/file-transfer-batches/"+strconv.FormatInt(batch.ID, 10), token.TokenValue, nil)
+	if batchResponse.Code != http.StatusOK {
+		t.Fatalf("get batch failed: %d %s", batchResponse.Code, batchResponse.Body.String())
+	}
+	batchBody := batchResponse.Body.String()
+	if !strings.Contains(batchBody, `"archive_name":"logs.zip"`) || !strings.Contains(batchBody, `"remote_path":"/var/log/app.log"`) {
+		t.Fatalf("batch detail should include safe transfer metadata: %s", batchBody)
+	}
+	if strings.Contains(batchBody, "aipermission-secret") || strings.Contains(batchBody, "archive_path") || strings.Contains(batchBody, "temp_path") || strings.Contains(batchBody, "local_path") {
+		t.Fatalf("batch detail leaked local metadata: %s", batchBody)
+	}
+}
+
+func TestMCPFileTransferManagementRequiresAlwaysRun(t *testing.T) {
+	fixture := newAPITestFixture(t)
+	ctx := context.Background()
+	token, err := fixture.tokens.Create(ctx, tokens.CreateRequest{Name: "agent"})
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	server := fixture.createKeyAndServer(t, "worker-transfer")
+	if _, err := fixture.tokens.UpdatePermissions(ctx, token.ID, tokens.UpdatePermissionsRequest{Permissions: []tokens.PermissionInput{
+		{ServerID: server.ID, ExecutionRule: tokens.RuleApprovalRequired},
+	}}); err != nil {
+		t.Fatalf("update permissions: %v", err)
+	}
+
+	response := performJSON(fixture.server.Handler(), http.MethodPost, "/api/mcp/file-transfers/download-batch", token.TokenValue, map[string]any{
+		"server_id":    server.ID,
+		"remote_paths": []string{"/var/log/syslog"},
+		"archive_name": "logs.zip",
+	})
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"status":"blocked"`) || !strings.Contains(response.Body.String(), "always_run") {
+		t.Fatalf("approval-required token should not start MCP transfers, got %d %s", response.Code, response.Body.String())
 	}
 }

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -133,6 +133,15 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/mcp/requests", mcp.mcpListRequests)
 	s.mux.HandleFunc("GET /api/mcp/requests/{id}", mcp.mcpGetRequest)
 	s.mux.HandleFunc("POST /api/mcp/messages", mcp.mcpCreateMessage)
+	s.mux.HandleFunc("GET /api/mcp/file-transfers", mcp.mcpListFileTransfers)
+	s.mux.HandleFunc("GET /api/mcp/file-transfers/{id}", mcp.mcpGetFileTransfer)
+	s.mux.HandleFunc("GET /api/mcp/file-transfer-batches", mcp.mcpListFileTransferBatches)
+	s.mux.HandleFunc("GET /api/mcp/file-transfer-batches/{id}", mcp.mcpGetFileTransferBatch)
+	s.mux.HandleFunc("POST /api/mcp/file-transfers/browse", mcp.mcpBrowseRemoteFiles)
+	s.mux.HandleFunc("POST /api/mcp/file-transfers/download-batch", mcp.mcpStartFileDownload)
+	s.mux.HandleFunc("POST /api/mcp/file-transfer-batches/{id}/pause", mcp.mcpPauseFileTransferBatch)
+	s.mux.HandleFunc("POST /api/mcp/file-transfer-batches/{id}/resume", mcp.mcpResumeFileTransferBatch)
+	s.mux.HandleFunc("POST /api/mcp/file-transfer-batches/{id}/cancel", mcp.mcpCancelFileTransferBatch)
 }
 
 func (s *Server) health(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/filetransfer/store.go
+++ b/backend/internal/filetransfer/store.go
@@ -109,6 +109,17 @@ type ListFilter struct {
 	Direction string
 	Status    string
 	ServerID  int64
+	ServerIDs []int64
+	Query     string
+	Limit     int
+	Offset    int
+}
+
+type BatchListFilter struct {
+	Direction string
+	Status    string
+	ServerID  int64
+	ServerIDs []int64
 	Query     string
 	Limit     int
 	Offset    int
@@ -265,6 +276,68 @@ func (s *Store) List(ctx context.Context, filter ListFilter) ([]Record, int, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, 0, fmt.Errorf("iterate file transfers: %w", err)
+	}
+	return items, total, nil
+}
+
+func (s *Store) ListBatches(ctx context.Context, filter BatchListFilter) ([]BatchRecord, int, error) {
+	filter = normalizeBatchListFilter(filter)
+	where, args := batchListWhere(filter)
+	countQuery := `SELECT COUNT(*) FROM file_transfer_batches b LEFT JOIN servers srv ON srv.id = b.server_id` + where
+	var total int
+	if err := s.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count file transfer batches: %w", err)
+	}
+
+	query := `
+		SELECT b.id, b.server_id, COALESCE(srv.name, ''), b.direction, b.source, b.status,
+			b.archive_name, b.archive_path, b.total_items, b.completed_items, b.failed_items,
+			b.canceled_items, b.size_bytes, b.transferred_bytes, b.bytes_per_second,
+			b.eta_seconds, b.error, b.created_at, COALESCE(b.started_at, ''),
+			COALESCE(b.completed_at, ''), b.updated_at
+		FROM file_transfer_batches b
+		LEFT JOIN servers srv ON srv.id = b.server_id` + where + `
+		ORDER BY b.created_at DESC, b.id DESC
+		LIMIT ? OFFSET ?`
+	args = append(args, filter.Limit, filter.Offset)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list file transfer batches: %w", err)
+	}
+	defer rows.Close()
+
+	items := []BatchRecord{}
+	for rows.Next() {
+		var item BatchRecord
+		if err := rows.Scan(
+			&item.ID,
+			&item.ServerID,
+			&item.ServerName,
+			&item.Direction,
+			&item.Source,
+			&item.Status,
+			&item.ArchiveName,
+			&item.ArchivePath,
+			&item.TotalItems,
+			&item.CompletedItems,
+			&item.FailedItems,
+			&item.CanceledItems,
+			&item.SizeBytes,
+			&item.TransferredBytes,
+			&item.BytesPerSecond,
+			&item.ETASeconds,
+			&item.Error,
+			&item.CreatedAt,
+			&item.StartedAt,
+			&item.CompletedAt,
+			&item.UpdatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan file transfer batch: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate file transfer batches: %w", err)
 	}
 	return items, total, nil
 }
@@ -1037,6 +1110,12 @@ func listWhere(filter ListFilter) (string, []any) {
 		clauses = append(clauses, "ft.server_id = ?")
 		args = append(args, filter.ServerID)
 	}
+	if len(filter.ServerIDs) > 0 {
+		clauses = append(clauses, "ft.server_id IN ("+placeholders(len(filter.ServerIDs))+")")
+		for _, id := range filter.ServerIDs {
+			args = append(args, id)
+		}
+	}
 	if filter.Query != "" {
 		like := "%" + filter.Query + "%"
 		clauses = append(clauses, "(ft.remote_path LIKE ? OR ft.local_path LIKE ? OR ft.file_name LIKE ? OR COALESCE(srv.name, '') LIKE ?)")
@@ -1046,6 +1125,49 @@ func listWhere(filter ListFilter) (string, []any) {
 		return "", args
 	}
 	return " WHERE " + strings.Join(clauses, " AND "), args
+}
+
+func batchListWhere(filter BatchListFilter) (string, []any) {
+	clauses := []string{}
+	args := []any{}
+	if filter.Direction != "" {
+		clauses = append(clauses, "b.direction = ?")
+		args = append(args, filter.Direction)
+	}
+	if filter.Status != "" {
+		clauses = append(clauses, "b.status = ?")
+		args = append(args, filter.Status)
+	}
+	if filter.ServerID > 0 {
+		clauses = append(clauses, "b.server_id = ?")
+		args = append(args, filter.ServerID)
+	}
+	if len(filter.ServerIDs) > 0 {
+		clauses = append(clauses, "b.server_id IN ("+placeholders(len(filter.ServerIDs))+")")
+		for _, id := range filter.ServerIDs {
+			args = append(args, id)
+		}
+	}
+	if filter.Query != "" {
+		like := "%" + filter.Query + "%"
+		clauses = append(clauses, "(b.archive_name LIKE ? OR COALESCE(srv.name, '') LIKE ?)")
+		args = append(args, like, like)
+	}
+	if len(clauses) == 0 {
+		return "", args
+	}
+	return " WHERE " + strings.Join(clauses, " AND "), args
+}
+
+func placeholders(count int) string {
+	if count < 1 {
+		return ""
+	}
+	items := make([]string, count)
+	for i := range items {
+		items[i] = "?"
+	}
+	return strings.Join(items, ",")
 }
 
 func normalizeCreateRequest(request CreateRequest) (CreateRequest, error) {
@@ -1135,6 +1257,7 @@ func normalizeListFilter(filter ListFilter) ListFilter {
 	filter.Direction = strings.TrimSpace(filter.Direction)
 	filter.Status = strings.TrimSpace(filter.Status)
 	filter.Query = strings.TrimSpace(filter.Query)
+	filter.ServerIDs = normalizeServerIDs(filter.ServerIDs)
 	if filter.Limit < 1 || filter.Limit > 100 {
 		filter.Limit = 50
 	}
@@ -1152,6 +1275,46 @@ func normalizeListFilter(filter ListFilter) ListFilter {
 		filter.Status = ""
 	}
 	return filter
+}
+
+func normalizeBatchListFilter(filter BatchListFilter) BatchListFilter {
+	filter.Direction = strings.TrimSpace(filter.Direction)
+	filter.Status = strings.TrimSpace(filter.Status)
+	filter.Query = strings.TrimSpace(filter.Query)
+	filter.ServerIDs = normalizeServerIDs(filter.ServerIDs)
+	if filter.Limit < 1 || filter.Limit > 100 {
+		filter.Limit = 50
+	}
+	if filter.Offset < 0 {
+		filter.Offset = 0
+	}
+	switch filter.Direction {
+	case DirectionUpload, DirectionDownload:
+	default:
+		filter.Direction = ""
+	}
+	switch filter.Status {
+	case StatusPending, StatusRunning, StatusPaused, StatusCompleted, StatusFailed, StatusCanceled:
+	default:
+		filter.Status = ""
+	}
+	return filter
+}
+
+func normalizeServerIDs(values []int64) []int64 {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := map[int64]bool{}
+	result := make([]int64, 0, len(values))
+	for _, value := range values {
+		if value < 1 || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
 }
 
 func validatePathLike(field string, value string, required bool) error {

--- a/backend/internal/filetransfer/store_test.go
+++ b/backend/internal/filetransfer/store_test.go
@@ -153,6 +153,21 @@ func TestStoreCreatesPausesAndCompletesBatches(t *testing.T) {
 	if completed.Status != StatusCompleted || completed.CompletedItems != 2 || completed.TransferredBytes != 300 || completed.ETASeconds != 0 {
 		t.Fatalf("unexpected completed batch: %#v", completed)
 	}
+
+	batches, total, err := store.ListBatches(ctx, BatchListFilter{Direction: DirectionUpload, ServerIDs: []int64{serverID}, Query: "worker"})
+	if err != nil {
+		t.Fatalf("list batches: %v", err)
+	}
+	if total != 1 || len(batches) != 1 || batches[0].ID != batch.ID {
+		t.Fatalf("unexpected batch list: total=%d items=%#v", total, batches)
+	}
+	batches, total, err = store.ListBatches(ctx, BatchListFilter{ServerIDs: []int64{serverID + 1000}})
+	if err != nil {
+		t.Fatalf("list filtered batches: %v", err)
+	}
+	if total != 0 || len(batches) != 0 {
+		t.Fatalf("unexpected filtered batch list: total=%d items=%#v", total, batches)
+	}
 }
 
 func TestStoreUpdatesPausedBatchQueue(t *testing.T) {

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -19,6 +19,15 @@ read_console(server_id, tail?)
 get_request(request_id)
 list_requests(status?)
 send_message(message, server_id?, session_id?)
+list_file_transfers(server_id?, direction?, status?, limit?, offset?)
+get_file_transfer(transfer_id)
+list_file_transfer_batches(server_id?, direction?, status?, limit?, offset?)
+get_file_transfer_batch(batch_id)
+browse_remote_files(server_id, path?)
+start_file_download(server_id, remote_paths, archive_name?)
+pause_file_transfer_batch(batch_id)
+resume_file_transfer_batch(batch_id)
+cancel_file_transfer_batch(batch_id)
 ```
 
 Future SQL tools such as `list_databases()` and `query(database_id, sql, reason?)` are not implemented in the current MVP.
@@ -251,6 +260,89 @@ Input:
 User-to-AI messages are created from the Console Messages drawer. The gateway stores them by token and optionally server/session scope. Session-scoped notes are delivered only to MCP responses attached to that exact persistent console session. The next matching MCP `exec`, `read_console`, or `get_request` response can include the message as `user_note`.
 
 AI-to-user unread messages are included in Console badge counts and are displayed in the Messages drawer.
+
+## File Transfer Tools
+
+MCP file transfer tools are token-scoped and server-scoped. They use the same
+server permission table as command execution, but transfer management is stricter
+than read-only status:
+
+- `list_file_transfers`, `get_file_transfer`, `list_file_transfer_batches`, and
+  `get_file_transfer_batch` return sanitized metadata for servers visible to the
+  token.
+- `browse_remote_files`, `start_file_download`, `pause_file_transfer_batch`,
+  `resume_file_transfer_batch`, and `cancel_file_transfer_batch` require
+  `always_run` permission for that server.
+- `approval_required` transfer approval is not implemented yet. Use the local UI
+  when a human should make the transfer decision.
+- MCP can start remote downloads only. It cannot upload local files, read local
+  paths, receive file contents, or receive gateway temporary/archive paths.
+
+`list_file_transfers` and `list_file_transfer_batches` support optional
+`server_id`, `direction`, `status`, `limit`, and `offset` filters:
+
+```json
+{
+  "server_id": 3,
+  "direction": "download",
+  "status": "running",
+  "limit": 20
+}
+```
+
+`get_file_transfer_batch` returns per-file progress for a queue:
+
+```json
+{
+  "id": 12,
+  "status": "running",
+  "total_items": 3,
+  "completed_items": 1,
+  "transferred_bytes": 10485760,
+  "bytes_per_second": 5242880,
+  "eta_seconds": 8,
+  "items": [
+    {
+      "id": 41,
+      "status": "completed",
+      "remote_path": "/var/log/syslog",
+      "file_name": "syslog"
+    }
+  ]
+}
+```
+
+`browse_remote_files` lists one remote directory through SFTP:
+
+```json
+{
+  "server_id": 3,
+  "path": "/var/log"
+}
+```
+
+`start_file_download` starts a queued remote download:
+
+```json
+{
+  "server_id": 3,
+  "remote_paths": ["/var/log/syslog", "/var/log/auth.log"],
+  "archive_name": "logs.zip"
+}
+```
+
+The response includes a batch record plus `retry_after_seconds` and
+`assistant_hint`. The AI should poll `get_file_transfer_batch` for progress and
+tell the operator when the completed file or archive is ready to save from the
+AIPermission UI.
+
+Pause, resume, and cancel operate on active transfer queues:
+
+```json
+{
+  "batch_id": 12
+}
+```
 
 ## Output Normalization
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -152,14 +152,29 @@ POST /api/file-transfers/upload
 POST /api/file-transfers/upload-batch
 POST /api/file-transfers/download
 POST /api/file-transfers/download-batch
+GET  /api/mcp/file-transfers
+GET  /api/mcp/file-transfers/{id}
+GET  /api/mcp/file-transfer-batches
+GET  /api/mcp/file-transfer-batches/{id}
+POST /api/mcp/file-transfers/browse
+POST /api/mcp/file-transfers/download-batch
+POST /api/mcp/file-transfer-batches/{id}/pause
+POST /api/mcp/file-transfer-batches/{id}/resume
+POST /api/mcp/file-transfer-batches/{id}/cancel
 ```
 
 File transfers use the selected server's existing SSH credential and run over
-SFTP. They are local UI operations in the current release; MCP file-transfer
-tools are not exposed yet. AIPermission stores transfer metadata, status,
-progress, and checksum only. File contents are never stored in SQLCipher.
-Uploads and downloads use private short-lived temporary staging files under the
-local data directory.
+SFTP. AIPermission stores transfer metadata, status, progress, and checksum
+only. File contents are never stored in SQLCipher. Uploads and downloads use
+private short-lived temporary staging files under the local data directory.
+
+The local UI can upload local files and download remote files. MCP can list
+transfer status, browse remote directories, start remote download queues, and
+pause/resume/cancel queues. MCP cannot upload local files or read completed file
+contents; completed MCP downloads are staged for the human operator to save
+from the local UI. MCP transfer management requires `always_run` permission for
+that server. `approval_required` transfer approval is intentionally not
+implemented yet.
 
 `GET /api/file-transfers` returns paginated transfer history. Optional filters
 include `direction`, `status`, `server_id`, and `q`:
@@ -276,6 +291,30 @@ they were never copied.
 Remote paths must be absolute file paths. Directory transfer, recursive copy,
 remote glob expansion, restart-surviving resumable transfers, and
 SSH-agent/ProxyJump based transfers are not part of this MVP.
+
+MCP transfer status endpoints return token-scoped, sanitized transfer metadata.
+They never include local temporary paths or archive staging paths:
+
+```txt
+GET /api/mcp/file-transfers?server_id=3&direction=download&status=running
+GET /api/mcp/file-transfer-batches?server_id=3&limit=20
+GET /api/mcp/file-transfer-batches/{id}
+```
+
+MCP transfer control endpoints use the MCP API token rather than the UI session
+cookie:
+
+```json
+{
+  "server_id": 3,
+  "remote_paths": ["/var/log/syslog", "/var/log/auth.log"],
+  "archive_name": "logs.zip"
+}
+```
+
+The response includes `retry_after_seconds` and `assistant_hint`; the AI should
+poll `GET /api/mcp/file-transfer-batches/{id}` for progress and tell the user
+when the staged download is ready in the UI.
 
 ## SSH Keys
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aipermission-frontend",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@xterm/addon-fit": "^0.11.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -64,9 +64,9 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.1\.6"/);
-  assert.match(releaseSource, /Bulk file transfer queues/);
-  assert.match(releaseSource, /never stored in SQLCipher/);
+  assert.match(releaseSource, /appVersion = "0\.1\.7"/);
+  assert.match(releaseSource, /MCP transfer tools/);
+  assert.match(releaseSource, /MCP transfer responses never include local temp paths/);
 });
 
 test("Sidebar exposes explicit MCP runtime start and stop controls", () => {

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,27 @@
-export const appVersion = "0.1.6";
+export const appVersion = "0.1.7";
 
 export const changelogEntries = [
+  {
+    version: "0.1.7",
+    label: "MCP transfer tools",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "MCP tools can list token-scoped file transfer status and batch progress.",
+          "MCP can browse remote directories and start remote download queues for always-run server permissions.",
+          "MCP can pause, resume, and cancel active transfer queues.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "MCP transfer responses never include local temp paths, archive staging paths, local upload paths, or downloaded file contents.",
+          "MCP local upload remains intentionally unavailable while local path scope and approval semantics are designed separately.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.1.6",
     label: "Bulk file transfer queues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
     },
     "frontend": {
       "name": "aipermission-frontend",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@xterm/addon-fit": "^0.11.0",
@@ -1294,7 +1294,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -55,8 +55,24 @@ The generated MCP config contains a bearer token. Keep it private. For project-l
 - `list_requests`
 - `read_console`
 - `send_message`
+- `list_file_transfers`
+- `get_file_transfer`
+- `list_file_transfer_batches`
+- `get_file_transfer_batch`
+- `browse_remote_files`
+- `start_file_download`
+- `pause_file_transfer_batch`
+- `resume_file_transfer_batch`
+- `cancel_file_transfer_batch`
 
 `exec` is intended for non-interactive commands. The gateway closes stdin for MCP command bodies so stdin-reading commands cannot consume the internal shell wrapper. Use the web console for interactive work.
+
+File transfer tools are intentionally conservative. MCP can list transfer
+metadata, browse remote directories, start remote download queues, and
+pause/resume/cancel queues when the token has `always_run` permission for that
+server. MCP cannot upload local files, receive downloaded file contents, or see
+gateway temporary/archive paths; completed downloads are staged for the human
+operator to save from the AIPermission UI.
 
 ## Operator Skill
 

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "MIT",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp/src/server.js
+++ b/packages/mcp/src/server.js
@@ -111,6 +111,141 @@ server.tool(
   }
 );
 
+server.tool(
+  "list_file_transfers",
+  "List file transfer records visible to this token. Results never include local temp paths or archive paths.",
+  {
+    server_id: z.number().int().positive().optional().describe("Optional server id from list_servers."),
+    direction: z.enum(["upload", "download"]).optional().describe("Optional transfer direction."),
+    status: z.enum(["pending", "running", "paused", "completed", "failed", "canceled"]).optional().describe("Optional transfer status."),
+    limit: z.number().int().positive().max(100).optional().describe("Maximum records to return."),
+    offset: z.number().int().min(0).optional().describe("Pagination offset."),
+  },
+  async ({ server_id, direction, status, limit, offset }) => {
+    return jsonToolResult(() => {
+      const params = new URLSearchParams();
+      if (server_id) params.set("server_id", String(server_id));
+      if (direction) params.set("direction", direction);
+      if (status) params.set("status", status);
+      if (limit) params.set("limit", String(limit));
+      if (offset) params.set("offset", String(offset));
+      const suffix = params.toString() ? `?${params.toString()}` : "";
+      return apiGet(`/api/mcp/file-transfers${suffix}`);
+    });
+  }
+);
+
+server.tool(
+  "get_file_transfer",
+  "Read one file transfer record visible to this token. Local temp paths and archive paths are never returned.",
+  {
+    transfer_id: z.number().int().positive().describe("Transfer id from list_file_transfers or get_file_transfer_batch."),
+  },
+  async ({ transfer_id }) => {
+    return jsonToolResult(() => apiGet(`/api/mcp/file-transfers/${transfer_id}`));
+  }
+);
+
+server.tool(
+  "list_file_transfer_batches",
+  "List file transfer queues visible to this token. Use get_file_transfer_batch for per-file progress.",
+  {
+    server_id: z.number().int().positive().optional().describe("Optional server id from list_servers."),
+    direction: z.enum(["upload", "download"]).optional().describe("Optional transfer direction."),
+    status: z.enum(["pending", "running", "paused", "completed", "failed", "canceled"]).optional().describe("Optional transfer status."),
+    limit: z.number().int().positive().max(100).optional().describe("Maximum records to return."),
+    offset: z.number().int().min(0).optional().describe("Pagination offset."),
+  },
+  async ({ server_id, direction, status, limit, offset }) => {
+    return jsonToolResult(() => {
+      const params = new URLSearchParams();
+      if (server_id) params.set("server_id", String(server_id));
+      if (direction) params.set("direction", direction);
+      if (status) params.set("status", status);
+      if (limit) params.set("limit", String(limit));
+      if (offset) params.set("offset", String(offset));
+      const suffix = params.toString() ? `?${params.toString()}` : "";
+      return apiGet(`/api/mcp/file-transfer-batches${suffix}`);
+    });
+  }
+);
+
+server.tool(
+  "get_file_transfer_batch",
+  "Read one file transfer queue with per-file progress. Completed downloads are staged for the human operator to save from the UI.",
+  {
+    batch_id: z.number().int().positive().describe("Batch id from list_file_transfer_batches or start_file_download."),
+  },
+  async ({ batch_id }) => {
+    return jsonToolResult(() => apiGet(`/api/mcp/file-transfer-batches/${batch_id}`));
+  }
+);
+
+server.tool(
+  "browse_remote_files",
+  "Browse a remote server directory through AIPermission. Requires always_run permission. This lists remote metadata only and does not read local files.",
+  {
+    server_id: z.number().int().positive().describe("Server id from list_servers."),
+    path: z.string().optional().describe("Absolute remote directory path. Defaults to /."),
+  },
+  async ({ server_id, path }) => {
+    return jsonToolResult(() => apiPost("/api/mcp/file-transfers/browse", {
+      server_id,
+      path: path || "/",
+    }));
+  }
+);
+
+server.tool(
+  "start_file_download",
+  "Start a remote file download queue through AIPermission. Requires always_run permission. The AI cannot receive file contents; completed files are staged for the human operator to save from the UI.",
+  {
+    server_id: z.number().int().positive().describe("Server id from list_servers."),
+    remote_paths: z.array(z.string().min(1)).min(1).max(100).describe("Absolute remote file paths to download sequentially."),
+    archive_name: z.string().optional().describe("Optional archive filename for multi-file downloads."),
+  },
+  async ({ server_id, remote_paths, archive_name }) => {
+    return jsonToolResult(() => apiPost("/api/mcp/file-transfers/download-batch", {
+      server_id,
+      remote_paths,
+      archive_name: archive_name || "",
+    }));
+  }
+);
+
+server.tool(
+  "pause_file_transfer_batch",
+  "Pause an active file transfer queue started or visible through AIPermission. Requires always_run permission for that server.",
+  {
+    batch_id: z.number().int().positive().describe("Batch id from list_file_transfer_batches or start_file_download."),
+  },
+  async ({ batch_id }) => {
+    return jsonToolResult(() => apiPost(`/api/mcp/file-transfer-batches/${batch_id}/pause`, {}));
+  }
+);
+
+server.tool(
+  "resume_file_transfer_batch",
+  "Resume a paused file transfer queue. Requires always_run permission for that server.",
+  {
+    batch_id: z.number().int().positive().describe("Batch id from list_file_transfer_batches or start_file_download."),
+  },
+  async ({ batch_id }) => {
+    return jsonToolResult(() => apiPost(`/api/mcp/file-transfer-batches/${batch_id}/resume`, {}));
+  }
+);
+
+server.tool(
+  "cancel_file_transfer_batch",
+  "Cancel a pending, running, or paused file transfer queue. Requires always_run permission for that server.",
+  {
+    batch_id: z.number().int().positive().describe("Batch id from list_file_transfer_batches or start_file_download."),
+  },
+  async ({ batch_id }) => {
+    return jsonToolResult(() => apiPost(`/api/mcp/file-transfer-batches/${batch_id}/cancel`, {}));
+  }
+);
+
 const transport = new StdioServerTransport();
 await server.connect(transport);
 

--- a/packages/mcp/src/server.js
+++ b/packages/mcp/src/server.js
@@ -18,7 +18,7 @@ const apiTimeoutMs = Number.parseInt(process.env.AIPERMISSION_HTTP_TIMEOUT_MS ||
 
 const server = new McpServer({
   name: "aipermission",
-  version: "0.1.1",
+  version: "0.1.2",
 });
 
 server.tool(


### PR DESCRIPTION
## Summary

- add token-scoped MCP file transfer status and batch status endpoints
- add MCP remote browse, remote download queue start, and batch pause/resume/cancel tools
- document the safety boundary: MCP can stage remote downloads, but cannot upload local files or receive downloaded file contents
- prepare app 0.1.7 metadata and @aipermission/mcp 0.1.2 package metadata

## Security boundary

- MCP transfer responses omit local temp paths, local upload paths, archive staging paths, and file contents.
- Transfer management requires always_run permission for the server.
- approval_required transfer approval remains intentionally out of scope for this release; use the local UI for human transfer decisions.

## Verification

- make release-check
- go test -race ./...
- make build
- make audit
- make backend-vet
