### PR TITLE
docs: correct 0.1.7 transfer approval note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ and this project uses semantic versioning once public releases begin.
 
 - MCP transfer responses never include local temporary paths, local upload
   paths, archive staging paths, or file contents.
-- MCP direct upload/download tools require `always_run` permission and explicit
-  local paths. `approval_required` transfer approval remains future work.
+- MCP direct transfer tools require explicit local paths. `always_run` starts
+  queues immediately, while `approval_required` creates a local Transfer Center
+  approval queue before touching the remote server.
 
 ## [0.1.6] - 2026-06-06
 


### PR DESCRIPTION
## Summary
- Correct the 0.1.7 changelog note for MCP transfer approvals
- Clarify that approval_required creates a local Transfer Center approval queue

## Verification
- git diff --check
- searched docs for the stale future-work wording