### PR TITLE
Add temporary token server permission grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-06-07
+
+### Added
+
+- Token/server permissions can now have an optional `expires_at` timestamp for
+  temporary maintenance grants.
+- Console token controls can turn active Prompt or Always permissions into
+  1-hour, 4-hour, or 1-day temporary grants.
+- The Console always-run warning shows a countdown when an active `always_run`
+  grant is temporary.
+- MCP `list_servers` includes `expires_at` for temporary grants and omits
+  expired grants.
+
+### Security
+
+- Expired token/server permissions are not treated as effective by MCP command,
+  console, file-transfer, or server-list permission checks.
+- Permission expiration is a local safety rail for temporary maintenance
+  windows. It does not change the local-only threat model or make exposed
+  gateway ports safe.
+
 ## [0.1.7] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Implemented:
 - server management and SSH connection test
 - API token create, copy, revoke
 - token expiration for temporary MCP access
-- token-to-server permissions
+- token-to-server permissions with optional temporary expiration
 - execution rules: `always_run`, `approval_required`, `blocked`
 - global MCP Started/Stopped switch that preserves permissions while blocking live execution
 - persistent web console with live PTY streaming
@@ -221,6 +221,11 @@ In API/MCP data, denied access is represented as `blocked`. In the UI, an unset 
 
 Use `approval_required` for real systems until you trust the workflow. Use `always_run` for low-risk maintenance sessions or temporary local/dev servers.
 
+Token/server permissions can be permanent or temporary. A temporary grant has an
+`expires_at` timestamp; after it expires, MCP no longer treats that permission
+as effective. This is useful for short maintenance windows, especially temporary
+`always_run` access.
+
 Saved permissions are not the same as live execution. Each unlocked database has
 a global MCP Started/Stopped switch in the sidebar. By default, MCP execution
 starts stopped after gateway startup or database unlock, so saved `always_run`
@@ -299,9 +304,11 @@ Important boundaries:
   the user, then stored inside the encrypted local gateway.
 - AI clients authenticate with API tokens, not SSH credentials.
 - API tokens are shown once by default. Security can enable reusable token copy for newly created tokens; reusable values are stored with gateway vault encryption.
-- API tokens can be created as temporary tokens with an expiration timestamp.
+- API tokens and token/server permissions can use expiration timestamps for
+  temporary maintenance access.
 - Tokens only see servers explicitly permitted for that token.
-- Revoked or expired tokens are rejected by MCP endpoints.
+- Revoked tokens, expired tokens, and expired token/server permission grants are
+  rejected by MCP permission checks.
 - Server credentials are not returned by REST or MCP responses.
 - SSH host keys require first-connect fingerprint approval and are verified on later connections.
 - The SQLite database is encrypted with SQLCipher and requires the local database password after startup.

--- a/backend/internal/api/mcp.go
+++ b/backend/internal/api/mcp.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aipermission/aipermission/backend/internal/console"
 	"github.com/aipermission/aipermission/backend/internal/tokens"
@@ -29,13 +30,15 @@ func (s mcpHandlers) mcpListServers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rows, err := auth.runtime.database.QueryContext(r.Context(), `
-		SELECT srv.id, srv.name, srv.description, srv.host, srv.port, srv.username, p.execution_rule
+		SELECT srv.id, srv.name, srv.description, srv.host, srv.port, srv.username, p.execution_rule, COALESCE(p.expires_at, '')
 		FROM token_server_permissions p
 		JOIN servers srv ON srv.id = p.server_id
 		WHERE p.token_id = ? AND p.execution_rule != ?
+			AND (COALESCE(p.expires_at, '') = '' OR p.expires_at > ?)
 		ORDER BY srv.name`,
 		auth.TokenID,
 		tokens.RuleBlocked,
+		time.Now().UTC().Format(time.RFC3339),
 	)
 	if err != nil {
 		writeInternalError(w)
@@ -46,7 +49,7 @@ func (s mcpHandlers) mcpListServers(w http.ResponseWriter, r *http.Request) {
 	items := []mcpServerItem{}
 	for rows.Next() {
 		var item mcpServerItem
-		if err := rows.Scan(&item.ID, &item.Name, &item.Description, &item.Host, &item.Port, &item.Username, &item.ExecutionRule); err != nil {
+		if err := rows.Scan(&item.ID, &item.Name, &item.Description, &item.Host, &item.Port, &item.Username, &item.ExecutionRule, &item.ExpiresAt); err != nil {
 			writeInternalError(w)
 			return
 		}

--- a/backend/internal/api/mcp_auth.go
+++ b/backend/internal/api/mcp_auth.go
@@ -81,9 +81,11 @@ func (s *Server) mcpPermission(ctx context.Context, runtime *databaseRuntime, to
 		SELECT srv.name, p.execution_rule
 		FROM token_server_permissions p
 		JOIN servers srv ON srv.id = p.server_id
-		WHERE p.token_id = ? AND p.server_id = ?`,
+		WHERE p.token_id = ? AND p.server_id = ?
+			AND (COALESCE(p.expires_at, '') = '' OR p.expires_at > ?)`,
 		tokenID,
 		serverID,
+		time.Now().UTC().Format(time.RFC3339),
 	).Scan(&serverName, &rule)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", "", false, nil

--- a/backend/internal/api/mcp_file_transfers.go
+++ b/backend/internal/api/mcp_file_transfers.go
@@ -590,9 +590,11 @@ func (s mcpHandlers) mcpAllowedServerIDs(ctx context.Context, runtime *databaseR
 		SELECT server_id
 		FROM token_server_permissions
 		WHERE token_id = ? AND execution_rule != ?
+			AND (COALESCE(expires_at, '') = '' OR expires_at > ?)
 		ORDER BY server_id`,
 		tokenID,
 		tokens.RuleBlocked,
+		time.Now().UTC().Format(time.RFC3339),
 	)
 	if err != nil {
 		return nil, err

--- a/backend/internal/api/mcp_test.go
+++ b/backend/internal/api/mcp_test.go
@@ -178,11 +178,16 @@ func TestMCPListServersUsesTokenPermissionsAndHidesBlocked(t *testing.T) {
 	}
 	allowed := fixture.createKeyAndServer(t, "allowed")
 	blocked := fixture.createKeyAndServer(t, "blocked")
+	expired := fixture.createKeyAndServer(t, "expired")
 	if _, err := fixture.tokens.UpdatePermissions(ctx, token.ID, tokens.UpdatePermissionsRequest{Permissions: []tokens.PermissionInput{
 		{ServerID: allowed.ID, ExecutionRule: tokens.RuleAlwaysRun},
 		{ServerID: blocked.ID, ExecutionRule: tokens.RuleBlocked},
+		{ServerID: expired.ID, ExecutionRule: tokens.RuleAlwaysRun, ExpiresAt: time.Now().UTC().Add(time.Hour).Format(time.RFC3339)},
 	}}); err != nil {
 		t.Fatalf("update permissions: %v", err)
+	}
+	if _, err := fixture.db.ExecContext(ctx, `UPDATE token_server_permissions SET expires_at = ? WHERE token_id = ? AND server_id = ?`, time.Now().UTC().Add(-time.Hour).Format(time.RFC3339), token.ID, expired.ID); err != nil {
+		t.Fatalf("expire permission: %v", err)
 	}
 
 	response := performJSON(fixture.server.Handler(), http.MethodGet, "/api/mcp/servers", token.TokenValue, nil)
@@ -204,6 +209,14 @@ func TestMCPListServersUsesTokenPermissionsAndHidesBlocked(t *testing.T) {
 	}
 	if len(items[0].Hints) == 0 || !strings.Contains(strings.Join(items[0].Hints, " "), "hash -r") {
 		t.Fatalf("expected command hygiene hints in mcp server list: %#v", items[0].Hints)
+	}
+	expiredResponse := performJSON(fixture.server.Handler(), http.MethodPost, "/api/mcp/exec", token.TokenValue, map[string]any{
+		"server_id": expired.ID,
+		"command":   "date",
+		"reason":    "verify expired grant",
+	})
+	if expiredResponse.Code != http.StatusOK || !strings.Contains(expiredResponse.Body.String(), `"status":"blocked"`) {
+		t.Fatalf("expired permission should not allow execution, got %d %s", expiredResponse.Code, expiredResponse.Body.String())
 	}
 
 	if err := writeSecuritySettings(ctx, fixture.server.activeRuntime(), securitySettingsResponse{

--- a/backend/internal/api/mcp_types.go
+++ b/backend/internal/api/mcp_types.go
@@ -25,6 +25,7 @@ type mcpServerItem struct {
 	Port          int      `json:"port,omitempty"`
 	Username      string   `json:"username,omitempty"`
 	ExecutionRule string   `json:"execution_rule"`
+	ExpiresAt     string   `json:"expires_at,omitempty"`
 	Hints         []string `json:"hints"`
 }
 

--- a/backend/internal/api/routes_test.go
+++ b/backend/internal/api/routes_test.go
@@ -139,10 +139,11 @@ Host *
 		t.Fatalf("list tokens should expose token value when reusable copy is enabled: %d %s", response.Code, response.Body.String())
 	}
 
+	permissionExpiresAt := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
 	permissionResponse := performJSON(handler, http.MethodPut, "/api/tokens/"+strconv.FormatInt(token.ID, 10)+"/permissions", "", tokens.UpdatePermissionsRequest{Permissions: []tokens.PermissionInput{
-		{ServerID: server.ID, ExecutionRule: tokens.RuleApprovalRequired},
+		{ServerID: server.ID, ExecutionRule: tokens.RuleApprovalRequired, ExpiresAt: permissionExpiresAt},
 	}})
-	if permissionResponse.Code != http.StatusOK || !strings.Contains(permissionResponse.Body.String(), tokens.RuleApprovalRequired) {
+	if permissionResponse.Code != http.StatusOK || !strings.Contains(permissionResponse.Body.String(), tokens.RuleApprovalRequired) || !strings.Contains(permissionResponse.Body.String(), permissionExpiresAt) {
 		t.Fatalf("update permissions failed: %d %s", permissionResponse.Code, permissionResponse.Body.String())
 	}
 	if response := performJSON(handler, http.MethodGet, "/api/tokens/"+strconv.FormatInt(token.ID, 10)+"/permissions", "", nil); response.Code != http.StatusOK || !strings.Contains(response.Body.String(), `"worker-1b"`) {

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -11,7 +11,7 @@ import (
 	_ "github.com/mutecomm/go-sqlcipher/v4"
 )
 
-const currentSchemaVersion = 7
+const currentSchemaVersion = 8
 
 func OpenEncrypted(path string, password string) (*sql.DB, error) {
 	return openEncrypted(path, password, true)

--- a/backend/internal/db/db_test.go
+++ b/backend/internal/db/db_test.go
@@ -54,6 +54,9 @@ func TestOpenEncryptedCreatesSchemaAndRejectsWrongPassword(t *testing.T) {
 	if !columnExists(t, database, "api_tokens", "expires_at") {
 		t.Fatalf("api_tokens.expires_at column was not created")
 	}
+	if !columnExists(t, database, "token_server_permissions", "expires_at") {
+		t.Fatalf("token_server_permissions.expires_at column was not created")
+	}
 	if !columnExists(t, database, "command_requests", "source") {
 		t.Fatalf("command_requests.source column was not created")
 	}

--- a/backend/internal/db/migrations.go
+++ b/backend/internal/db/migrations.go
@@ -434,6 +434,11 @@ var fileTransferApprovalStatements = []string{
 	`CREATE INDEX IF NOT EXISTS idx_file_transfers_batch_status ON file_transfers(batch_id, status);`,
 }
 
+var permissionExpirationStatements = []string{
+	`ALTER TABLE token_server_permissions ADD COLUMN expires_at TEXT;`,
+	`CREATE INDEX IF NOT EXISTS idx_token_server_permissions_expires_at ON token_server_permissions(expires_at);`,
+}
+
 var migrations = []migration{
 	{
 		version:     1,
@@ -469,6 +474,11 @@ var migrations = []migration{
 		version:     7,
 		description: "file transfer approvals",
 		statements:  fileTransferApprovalStatements,
+	},
+	{
+		version:     8,
+		description: "token server permission expiration",
+		statements:  permissionExpirationStatements,
 	},
 }
 

--- a/backend/internal/tokens/store.go
+++ b/backend/internal/tokens/store.go
@@ -51,6 +51,7 @@ type Permission struct {
 	ServerID      int64  `json:"server_id"`
 	ServerName    string `json:"server_name"`
 	ExecutionRule string `json:"execution_rule"`
+	ExpiresAt     string `json:"expires_at,omitempty"`
 	CreatedAt     string `json:"created_at"`
 	UpdatedAt     string `json:"updated_at"`
 }
@@ -58,6 +59,7 @@ type Permission struct {
 type PermissionInput struct {
 	ServerID      int64  `json:"server_id"`
 	ExecutionRule string `json:"execution_rule"`
+	ExpiresAt     string `json:"expires_at,omitempty"`
 }
 
 type UpdatePermissionsRequest struct {
@@ -188,7 +190,7 @@ func (s *Store) ListPermissions(ctx context.Context, tokenID int64) ([]Permissio
 		return nil, err
 	}
 
-	rows, err := s.db.QueryContext(ctx, `SELECT p.server_id, srv.name, p.execution_rule, p.created_at, p.updated_at FROM token_server_permissions p JOIN servers srv ON srv.id = p.server_id WHERE p.token_id = ? ORDER BY srv.name`, tokenID)
+	rows, err := s.db.QueryContext(ctx, `SELECT p.server_id, srv.name, p.execution_rule, COALESCE(p.expires_at, ''), p.created_at, p.updated_at FROM token_server_permissions p JOIN servers srv ON srv.id = p.server_id WHERE p.token_id = ? ORDER BY srv.name`, tokenID)
 	if err != nil {
 		return nil, fmt.Errorf("list token permissions: %w", err)
 	}
@@ -197,7 +199,7 @@ func (s *Store) ListPermissions(ctx context.Context, tokenID int64) ([]Permissio
 	items := []Permission{}
 	for rows.Next() {
 		var item Permission
-		if err := rows.Scan(&item.ServerID, &item.ServerName, &item.ExecutionRule, &item.CreatedAt, &item.UpdatedAt); err != nil {
+		if err := rows.Scan(&item.ServerID, &item.ServerName, &item.ExecutionRule, &item.ExpiresAt, &item.CreatedAt, &item.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan token permission: %w", err)
 		}
 		items = append(items, item)
@@ -228,7 +230,11 @@ func (s *Store) UpdatePermissions(ctx context.Context, tokenID int64, request Up
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, permission := range request.Permissions {
-		if _, err := tx.ExecContext(ctx, `INSERT INTO token_server_permissions (token_id, server_id, execution_rule, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`, tokenID, permission.ServerID, permission.ExecutionRule, now, now); err != nil {
+		expiresAt, err := normalizePermissionExpiresAt(permission)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO token_server_permissions (token_id, server_id, execution_rule, expires_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`, tokenID, permission.ServerID, permission.ExecutionRule, expiresAt, now, now); err != nil {
 			return nil, fmt.Errorf("insert token permission: %w", err)
 		}
 	}
@@ -250,6 +256,9 @@ func validatePermissions(ctx context.Context, db *sql.DB, permissions []Permissi
 		seen[permission.ServerID] = true
 		if !validRule(permission.ExecutionRule) {
 			return ValidationError("execution_rule must be always_run, approval_required, or blocked")
+		}
+		if _, err := normalizePermissionExpiresAt(permission); err != nil {
+			return err
 		}
 		var exists int
 		err := db.QueryRowContext(ctx, `SELECT 1 FROM servers WHERE id = ?`, permission.ServerID).Scan(&exists)
@@ -273,17 +282,32 @@ func validRule(rule string) bool {
 }
 
 func normalizeTokenExpiresAt(value string) (string, error) {
+	return normalizeFutureTimestamp("expires_at", value)
+}
+
+func normalizePermissionExpiresAt(permission PermissionInput) (string, error) {
+	value := strings.TrimSpace(permission.ExpiresAt)
+	if value == "" {
+		return "", nil
+	}
+	if permission.ExecutionRule == RuleBlocked {
+		return "", ValidationError("expires_at is not supported for blocked permissions")
+	}
+	return normalizeFutureTimestamp("expires_at", value)
+}
+
+func normalizeFutureTimestamp(field string, value string) (string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return "", nil
 	}
 	expiresAt, err := time.Parse(time.RFC3339, value)
 	if err != nil {
-		return "", ValidationError("expires_at must be an RFC3339 timestamp")
+		return "", ValidationError(field + " must be an RFC3339 timestamp")
 	}
 	expiresAt = expiresAt.UTC()
 	if !expiresAt.After(time.Now().UTC()) {
-		return "", ValidationError("expires_at must be in the future")
+		return "", ValidationError(field + " must be in the future")
 	}
 	return expiresAt.Format(time.RFC3339), nil
 }

--- a/backend/internal/tokens/store_test.go
+++ b/backend/internal/tokens/store_test.go
@@ -203,9 +203,10 @@ func TestTokenPermissionsReplaceAndValidateMatrix(t *testing.T) {
 	}
 	betaID := insertTokenTestServer(t, database, "worker-beta")
 	alphaID := insertTokenTestServer(t, database, "worker-alpha")
+	permissionExpiresAt := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
 
 	permissions, err := store.UpdatePermissions(ctx, token.ID, UpdatePermissionsRequest{Permissions: []PermissionInput{
-		{ServerID: betaID, ExecutionRule: RuleAlwaysRun},
+		{ServerID: betaID, ExecutionRule: RuleAlwaysRun, ExpiresAt: permissionExpiresAt},
 		{ServerID: alphaID, ExecutionRule: RuleApprovalRequired},
 	}})
 	if err != nil {
@@ -216,6 +217,9 @@ func TestTokenPermissionsReplaceAndValidateMatrix(t *testing.T) {
 	}
 	if permissions[0].ServerName != "worker-alpha" || permissions[1].ServerName != "worker-beta" {
 		t.Fatalf("permissions should be sorted by server name: %#v", permissions)
+	}
+	if permissions[1].ExpiresAt != permissionExpiresAt {
+		t.Fatalf("permission expires_at should round-trip, got %#v", permissions[1])
 	}
 
 	permissions, err = store.UpdatePermissions(ctx, token.ID, UpdatePermissionsRequest{Permissions: []PermissionInput{
@@ -231,6 +235,9 @@ func TestTokenPermissionsReplaceAndValidateMatrix(t *testing.T) {
 	badInputs := []UpdatePermissionsRequest{
 		{Permissions: []PermissionInput{{ServerID: 0, ExecutionRule: RuleAlwaysRun}}},
 		{Permissions: []PermissionInput{{ServerID: alphaID, ExecutionRule: "root"}}},
+		{Permissions: []PermissionInput{{ServerID: alphaID, ExecutionRule: RuleAlwaysRun, ExpiresAt: "tomorrow"}}},
+		{Permissions: []PermissionInput{{ServerID: alphaID, ExecutionRule: RuleAlwaysRun, ExpiresAt: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)}}},
+		{Permissions: []PermissionInput{{ServerID: alphaID, ExecutionRule: RuleBlocked, ExpiresAt: permissionExpiresAt}}},
 		{Permissions: []PermissionInput{{ServerID: alphaID, ExecutionRule: RuleAlwaysRun}, {ServerID: alphaID, ExecutionRule: RuleBlocked}}},
 		{Permissions: []PermissionInput{{ServerID: 99999, ExecutionRule: RuleAlwaysRun}}},
 	}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,13 +127,21 @@ AIPermission against real VPS maintenance tasks.
 - MCP transfer responses stay metadata-only and never include file contents or
   gateway temporary paths.
 
+`0.1.8` ships:
+
+- Optional expiration timestamps for token/server permission grants.
+- Temporary Prompt or Always permissions from the Console token panel and Tokens
+  page permission dialogs.
+- Countdown text in the Console always-run warning for temporary `always_run`
+  grants.
+- MCP permission checks omit expired grants from server lists, command
+  execution, console reads, and file-transfer tools.
+
 ## Early RC Follow-Ups
 
 These are good candidates for small follow-up releases after the first public
 tag:
 
-- [ ] Add permission expiration for temporary server access grants.
-- [ ] Add temporary `always_run` grants with visible countdowns in Console.
 - [ ] Add command policy/risk scoring primitives without turning the product
   into a DevOps platform.
 - [ ] Add optional deny/warn rules for common high-risk command patterns.

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -48,6 +48,7 @@ Example response:
     "name": "core-1",
     "description": "Kubernetes control-plane maintenance access.",
     "execution_rule": "approval_required",
+    "expires_at": "2026-06-07T14:00:00Z",
     "hints": [
       "Use non-interactive apt commands.",
       "Prefer journalctl --no-pager for service logs."
@@ -56,7 +57,11 @@ Example response:
 ]
 ```
 
-By default, `list_servers` hides endpoint metadata and returns only `id`, `name`, `description`, `execution_rule`, and `hints`. Security can enable **Expose endpoint metadata to MCP** if an operator wants MCP clients to also receive `host`, `port`, and `username`.
+By default, `list_servers` hides endpoint metadata and returns only `id`, `name`, `description`, `execution_rule`, optional `expires_at`, and `hints`. Security can enable **Expose endpoint metadata to MCP** if an operator wants MCP clients to also receive `host`, `port`, and `username`.
+
+`expires_at` appears when the token/server permission is temporary. Expired
+permissions are omitted from `list_servers` and do not authorize `exec`,
+`read_console`, or file-transfer tools.
 
 `hints` contains gateway-generated, safe operational notes that help an AI agent produce better shell commands for that server. The current MVP does not accept custom per-server hints through the server CRUD API. Hints must not contain credentials.
 
@@ -83,8 +88,9 @@ The gateway checks:
 1. token validity
 2. token revocation
 3. token permission for the server
-4. execution rule
-5. global MCP Started/Stopped runtime state
+4. token/server permission expiration
+5. execution rule
+6. global MCP Started/Stopped runtime state
 
 If MCP execution is stopped in the web UI, `exec` returns:
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -504,11 +504,17 @@ Permission update shape:
   "permissions": [
     {
       "server_id": 3,
-      "execution_rule": "approval_required"
+      "execution_rule": "approval_required",
+      "expires_at": "2026-06-07T14:00:00Z"
     }
   ]
 }
 ```
+
+`expires_at` is optional and must be an RFC3339 timestamp in the future when
+present. It creates a temporary token/server permission grant. Expired grants
+remain visible in the local UI for clarity, but MCP permission checks no longer
+treat them as effective.
 
 Supported execution rules:
 

--- a/docs/architecture/mcp-permission-flow.md
+++ b/docs/architecture/mcp-permission-flow.md
@@ -22,7 +22,8 @@ For the detailed tool contract, see [MCP Tools](../api/mcp-tools.md).
 
 ## list_servers
 
-`list_servers()` returns only the servers that the token can access.
+`list_servers()` returns only the servers that the token can access. Temporary
+permission grants include `expires_at`; expired grants are omitted.
 
 Example:
 
@@ -31,7 +32,8 @@ Example:
   {
     "id": 3,
     "name": "core-1",
-    "execution_rule": "approval_required"
+    "execution_rule": "approval_required",
+    "expires_at": "2026-06-07T14:00:00Z"
   }
 ]
 ```
@@ -49,13 +51,14 @@ Gateway flow:
 1. Validate the API token.
 2. Reject revoked tokens.
 3. Check whether the token has permission for server `3`.
-4. Read the execution rule.
-5. Check whether the global MCP runtime is started.
-6. If the runtime is stopped, return `stopped`.
-7. If the rule is `always_run`, run the command directly.
-8. If the rule is `approval_required`, create a pending approval.
-9. If the rule is `blocked`, reject the command without execution.
-10. Return the result or a follow-up `request_id` to the MCP client.
+4. Reject expired token/server permission grants.
+5. Read the execution rule.
+6. Check whether the global MCP runtime is started.
+7. If the runtime is stopped, return `stopped`.
+8. If the rule is `always_run`, run the command directly.
+9. If the rule is `approval_required`, create a pending approval.
+10. If the rule is `blocked`, reject the command without execution.
+11. Return the result or a follow-up `request_id` to the MCP client.
 
 ## Approval Required
 

--- a/docs/community/good-first-issues.md
+++ b/docs/community/good-first-issues.md
@@ -26,7 +26,7 @@ issues small, scoped, and friendly to contributors who are learning the codebase
 
 ## Security And Safety
 
-- Add permission expiration design notes for temporary maintenance access.
+- Add short examples that explain when to use temporary permission grants.
 - Add a command policy prototype that warns, but does not block, common high-risk commands.
 - Add more built-in redaction patterns with focused tests.
 

--- a/docs/security/credential-boundary.md
+++ b/docs/security/credential-boundary.md
@@ -64,6 +64,7 @@ Rules:
 - token values are shown once by default
 - reusable token copy can be enabled in Security for tokens created afterward
 - tokens can be created with an expiration timestamp for temporary MCP access
+- token/server permissions can also expire for temporary maintenance grants
 - token lookup uses hashes
 - stored reusable token values are encrypted by the gateway vault
 - revoked or expired tokens are rejected by MCP endpoints

--- a/docs/security/storage-encryption.md
+++ b/docs/security/storage-encryption.md
@@ -120,8 +120,9 @@ SSH host key pins are not part of the SQLCipher database. They live in the local
 ## Product Decision
 
 Token values are shown once by default. Tokens may also have an `expires_at`
-timestamp for temporary MCP access. When reusable token copy is disabled, newly
-created token values are not stored for later copying; authentication still uses
-SHA256 hashes of high-entropy random token values.
+timestamp for temporary MCP access. Token/server permission grants can also have
+an `expires_at` timestamp for temporary maintenance windows. When reusable token
+copy is disabled, newly created token values are not stored for later copying;
+authentication still uses SHA256 hashes of high-entropy random token values.
 
 If the user enables reusable token copy for local convenience, token values created after that point are stored in encrypted `token_value` form through the gateway vault and can be copied again from the UI. Disabling the setting clears stored reusable token values. Token hashes remain for authentication, but token values cannot be recovered after clearing.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -65,6 +65,8 @@ Mitigations:
 - project-local MCP config files are added to `.git/info/exclude` by the MCP init command when possible
 - tokens can be revoked from the UI
 - tokens can expire automatically when created for temporary access
+- token/server permissions can expire automatically for temporary maintenance
+  windows
 - MCP auth uses SHA256 hashes of high-entropy random tokens, not stored reusable token payloads
 
 ### SSH Host Impersonation

--- a/docs/skills/aipermission-operator/SKILL.md
+++ b/docs/skills/aipermission-operator/SKILL.md
@@ -18,11 +18,14 @@ AIPermission is not a general DevOps control plane. Treat it as a temporary, sco
 Before executing commands:
 
 1. Call `list_servers()`.
-2. Read each server's `name`, `id`, `execution_rule`, and `hints`.
+2. Read each server's `name`, `id`, `execution_rule`, optional `expires_at`,
+   and `hints`.
 3. Use the numeric `id` returned by the tool.
 4. Pick the narrowest server set that can answer the task.
 
 If no server is visible, say that the current token has no accessible servers.
+If `expires_at` is present, treat access as temporary. Finish within that
+maintenance window or ask the operator to extend access.
 
 ## Command Reasons
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/components/console/token-permission-panel.jsx
+++ b/frontend/src/components/console/token-permission-panel.jsx
@@ -1,9 +1,9 @@
 import { KeyRound, PanelRightClose, PanelRightOpen, RefreshCcw, TicketCheck } from "lucide-react";
-import { maskedToken, permissionCardClass, ruleLabel } from "../../lib/permissions";
+import { useEffect, useRef, useState } from "react";
+import { effectiveRule, expiresAtFromLifetime, maskedToken, permissionCardClass, permissionLifetimeLabel, ruleLabel } from "../../lib/permissions";
 import { Badge, CountBadge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Notice } from "../ui/notice";
-import { useEffect, useRef, useState } from "react";
 
 export function TokenPermissionPanel({ tokens, selectedServer, permissionState, unreadMessages, compact = false, onToggleCompact, onRefresh, onSetRule, onOpenMessages }) {
   const activeTokens = tokens.data.filter((token) => !token.revoked_at);
@@ -47,7 +47,8 @@ export function TokenPermissionPanel({ tokens, selectedServer, permissionState, 
         <div className="grid content-start gap-2 overflow-visible p-2">
           {activeTokens.map((token) => {
             const permissions = permissionState.data[token.id] || {};
-            const selectedRule = selectedServer ? permissions[selectedServer.id] || "" : "";
+            const selectedPermission = selectedServer ? permissions[selectedServer.id] : null;
+            const selectedRule = effectiveRule(selectedPermission);
             const unreadCount = selectedServer
               ? unreadMessages.filter((message) => Number(message.server_id) === Number(selectedServer.id) && Number(message.token_id) === Number(token.id)).length
               : unreadMessages.filter((message) => Number(message.token_id) === Number(token.id)).length;
@@ -64,26 +65,32 @@ export function TokenPermissionPanel({ tokens, selectedServer, permissionState, 
                   {unreadCount > 0 ? <CountBadge className="absolute -right-1 -top-1">{unreadCount}</CountBadge> : null}
                 </button>
                 {open && selectedServer ? (
-                  <div className="absolute right-full top-0 z-30 mr-2 grid w-72 gap-3 rounded-lg border border-stone-200 bg-white p-3 shadow-xl">
+                  <div className="absolute right-full top-0 z-30 mr-2 grid w-80 gap-3 rounded-lg border border-stone-200 bg-white p-3 shadow-xl">
                     <div className="min-w-0">
                       <p className="truncate text-sm font-semibold text-stone-900">{token.name}</p>
-                      <p className="mt-1 text-xs text-stone-500">{ruleLabel(selectedRule)} on {selectedServer.name}</p>
+                      <p className="mt-1 text-xs text-stone-500">
+                        {ruleLabel(selectedRule)} on {selectedServer.name}
+                        {selectedRule ? ` - ${permissionLifetimeLabel(selectedPermission)}` : ""}
+                      </p>
                     </div>
-                    <div className="grid grid-cols-3 gap-1">
-                      <PermissionButton active={!selectedRule} disabled={permissionState.savingKey === `${token.id}:${selectedServer.id}`} onClick={() => onSetRule(token, selectedServer, "")}>
-                        Disabled
-                      </PermissionButton>
-                      <PermissionButton active={selectedRule === "approval_required"} disabled={permissionState.savingKey === `${token.id}:${selectedServer.id}`} onClick={() => onSetRule(token, selectedServer, "approval_required")}>
-                        Prompt
-                      </PermissionButton>
-                      <PermissionButton active={selectedRule === "always_run"} disabled={permissionState.savingKey === `${token.id}:${selectedServer.id}`} onClick={() => onSetRule(token, selectedServer, "always_run")}>
-                        Always
-                      </PermissionButton>
-                    </div>
+                    <PermissionRuleButtons
+                      saving={permissionState.savingKey === `${token.id}:${selectedServer.id}`}
+                      selectedRule={selectedRule}
+                      onDisable={() => onSetRule(token, selectedServer, "")}
+                      onPrompt={() => onSetRule(token, selectedServer, "approval_required")}
+                      onAlways={() => onSetRule(token, selectedServer, "always_run")}
+                    />
                     {unreadCount > 0 ? (
                       <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={() => onOpenMessages(token.id)}>
                         Messages
                       </Button>
+                    ) : null}
+                    {selectedRule ? (
+                      <PermissionLifetimeControls
+                        value={selectedPermission}
+                        onSetPermanent={() => onSetRule(token, selectedServer, selectedRule, { expiresAt: "" })}
+                        onSetTemporary={(lifetime) => onSetRule(token, selectedServer, selectedRule, { expiresAt: expiresAtFromLifetime(lifetime) })}
+                      />
                     ) : null}
                   </div>
                 ) : null}
@@ -126,7 +133,8 @@ export function TokenPermissionPanel({ tokens, selectedServer, permissionState, 
         <div className="grid gap-3">
           {activeTokens.map((token) => {
             const permissions = permissionState.data[token.id] || {};
-            const selectedRule = selectedServer ? permissions[selectedServer.id] || "" : "";
+            const selectedPermission = selectedServer ? permissions[selectedServer.id] : null;
+            const selectedRule = effectiveRule(selectedPermission);
             const unreadCount = selectedServer
               ? unreadMessages.filter((message) => Number(message.server_id) === Number(selectedServer.id) && Number(message.token_id) === Number(token.id)).length
               : unreadMessages.filter((message) => Number(message.token_id) === Number(token.id)).length;
@@ -151,37 +159,70 @@ export function TokenPermissionPanel({ tokens, selectedServer, permissionState, 
                 </div>
 
                 {selectedServer ? (
-                  <div className="grid grid-cols-3 gap-1">
-                    <PermissionButton
-                      active={!selectedRule}
-                      disabled={permissionState.savingKey === `${token.id}:${selectedServer.id}`}
-                      onClick={() => onSetRule(token, selectedServer, "")}
-                    >
-                      Disabled
-                    </PermissionButton>
-                    <PermissionButton
-                      active={selectedRule === "approval_required"}
-                      disabled={permissionState.savingKey === `${token.id}:${selectedServer.id}`}
-                      onClick={() => onSetRule(token, selectedServer, "approval_required")}
-                    >
-                      Prompt
-                    </PermissionButton>
-                    <PermissionButton
-                      active={selectedRule === "always_run"}
-                      disabled={permissionState.savingKey === `${token.id}:${selectedServer.id}`}
-                      onClick={() => onSetRule(token, selectedServer, "always_run")}
-                    >
-                      Always
-                    </PermissionButton>
-                  </div>
+                  <>
+                    <PermissionRuleButtons
+                      saving={permissionState.savingKey === `${token.id}:${selectedServer.id}`}
+                      selectedRule={selectedRule}
+                      onDisable={() => onSetRule(token, selectedServer, "")}
+                      onPrompt={() => onSetRule(token, selectedServer, "approval_required")}
+                      onAlways={() => onSetRule(token, selectedServer, "always_run")}
+                    />
+                    {selectedRule ? (
+                      <PermissionLifetimeControls
+                        value={selectedPermission}
+                        onSetPermanent={() => onSetRule(token, selectedServer, selectedRule, { expiresAt: "" })}
+                        onSetTemporary={(lifetime) => onSetRule(token, selectedServer, selectedRule, { expiresAt: expiresAtFromLifetime(lifetime) })}
+                      />
+                    ) : null}
+                  </>
                 ) : null}
-
               </section>
             );
           })}
         </div>
       </div>
     </aside>
+  );
+}
+
+function PermissionRuleButtons({ saving, selectedRule, onDisable, onPrompt, onAlways }) {
+  return (
+    <div className="grid grid-cols-3 gap-1">
+      <PermissionButton active={!selectedRule} disabled={saving} onClick={onDisable}>
+        Disabled
+      </PermissionButton>
+      <PermissionButton active={selectedRule === "approval_required"} disabled={saving} onClick={onPrompt}>
+        Prompt
+      </PermissionButton>
+      <PermissionButton active={selectedRule === "always_run"} disabled={saving} onClick={onAlways}>
+        Always
+      </PermissionButton>
+    </div>
+  );
+}
+
+function PermissionLifetimeControls({ value, onSetPermanent, onSetTemporary }) {
+  return (
+    <div className="dark-panel-subtle grid gap-2 rounded-md border border-stone-200 bg-white/70 p-2 text-xs">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-semibold text-stone-700">Lifetime</span>
+        <span className="text-stone-500">{permissionLifetimeLabel(value)}</span>
+      </div>
+      <div className="grid grid-cols-4 gap-1">
+        <PermissionButton active={!value?.expires_at} onClick={onSetPermanent}>
+          Keep
+        </PermissionButton>
+        <PermissionButton active={false} onClick={() => onSetTemporary("1h")}>
+          1h
+        </PermissionButton>
+        <PermissionButton active={false} onClick={() => onSetTemporary("4h")}>
+          4h
+        </PermissionButton>
+        <PermissionButton active={false} onClick={() => onSetTemporary("1d")}>
+          1d
+        </PermissionButton>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/console/use-console-page-state.js
+++ b/frontend/src/components/console/use-console-page-state.js
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
+import { effectiveRule } from "../../lib/permissions";
 import { emptySession, isLiveConsoleSession, isUnreadMessage, latestSessionForServer } from "./helpers";
 
-export function useConsolePageState({ servers, tokens, approvals, messages, sessions, selectedServerID, permissionState }) {
+export function useConsolePageState({ servers, tokens, approvals, messages, sessions, selectedServerID, permissionState, now = Date.now() }) {
   const selectedServer = useMemo(() => {
     if (!servers.data.length) return null;
     return servers.data.find((server) => String(server.id) === selectedServerID) || servers.data[0];
@@ -16,8 +17,8 @@ export function useConsolePageState({ servers, tokens, approvals, messages, sess
 
   const selectedTokenOptions = useMemo(() => {
     if (!selectedServer) return [];
-    return tokens.data.filter((token) => !token.revoked_at && (permissionState.data[token.id]?.[selectedServer.id] || null));
-  }, [tokens.data, selectedServer?.id, permissionState.data]);
+    return tokens.data.filter((token) => !token.revoked_at && effectiveRule(permissionState.data[token.id]?.[selectedServer.id], now));
+  }, [tokens.data, selectedServer?.id, permissionState.data, now]);
 
   const defaultServerID = useMemo(() => {
     if (!servers.data.length) return "";

--- a/frontend/src/components/tokens/permission-dialog.jsx
+++ b/frontend/src/components/tokens/permission-dialog.jsx
@@ -1,9 +1,12 @@
 import { Dialog } from "../ui/dialog";
+import { Button } from "../ui/button";
+import { effectiveRule, expiresAtFromLifetime, permissionLifetimeLabel } from "../../lib/permissions";
 
 export function PermissionDialog({ value, permissionState, onClose, onSetRule }) {
   const token = value?.token;
   const server = value?.server;
-  const rule = token && server ? permissionState.data[token.id]?.[server.id] || "" : "";
+  const permission = token && server ? permissionState.data[token.id]?.[server.id] : null;
+  const rule = effectiveRule(permission);
   const saving = token && server ? permissionState.savingKey === `${token.id}:${server.id}` : false;
 
   return (
@@ -36,6 +39,28 @@ export function PermissionDialog({ value, permissionState, onClose, onSetRule })
             disabled={saving}
             onClick={() => onSetRule(token, server, "")}
           />
+          {rule ? (
+            <div className="dark-panel-subtle grid gap-2 rounded-lg border border-stone-200 bg-stone-50 p-3">
+              <div className="flex items-center justify-between gap-2 text-sm">
+                <span className="font-semibold text-stone-900">Lifetime</span>
+                <span className="text-stone-500">{permissionLifetimeLabel(permission)}</span>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-4">
+                <Button type="button" variant="outline" className="h-9 px-2 text-xs" disabled={saving} onClick={() => onSetRule(token, server, rule, { expiresAt: "" })}>
+                  Keep
+                </Button>
+                <Button type="button" variant="outline" className="h-9 px-2 text-xs" disabled={saving} onClick={() => onSetRule(token, server, rule, { expiresAt: expiresAtFromLifetime("1h") })}>
+                  1 hour
+                </Button>
+                <Button type="button" variant="outline" className="h-9 px-2 text-xs" disabled={saving} onClick={() => onSetRule(token, server, rule, { expiresAt: expiresAtFromLifetime("4h") })}>
+                  4 hours
+                </Button>
+                <Button type="button" variant="outline" className="h-9 px-2 text-xs" disabled={saving} onClick={() => onSetRule(token, server, rule, { expiresAt: expiresAtFromLifetime("1d") })}>
+                  1 day
+                </Button>
+              </div>
+            </div>
+          ) : null}
         </div>
       ) : null}
     </Dialog>

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -21,6 +21,8 @@ const fileTransferDialogSource = readFileSync(join(currentDir, "..", "components
 const fileTransferBrowserSource = readFileSync(join(currentDir, "..", "components", "console", "file-transfer-browser-dialog.jsx"), "utf8");
 const fileTransferConfirmSource = readFileSync(join(currentDir, "..", "components", "console", "file-transfer-confirm-dialogs.jsx"), "utf8");
 const transferCenterSource = readFileSync(join(currentDir, "..", "components", "transfer-center.jsx"), "utf8");
+const tokenPermissionPanelSource = readFileSync(join(currentDir, "..", "components", "console", "token-permission-panel.jsx"), "utf8");
+const permissionDialogSource = readFileSync(join(currentDir, "..", "components", "tokens", "permission-dialog.jsx"), "utf8");
 
 test("App keeps the primary route surface available", () => {
   for (const route of ["/console", "/servers", "/history", "/audit-logs", "/tokens", "/ssh-keys", "/mcp-setup", "/security", "/settings"]) {
@@ -65,15 +67,26 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.1\.7"/);
-  assert.match(releaseSource, /MCP transfer tools/);
-  assert.match(releaseSource, /MCP transfer responses never include local temp paths/);
+  assert.match(releaseSource, /appVersion = "0\.1\.8"/);
+  assert.match(releaseSource, /Temporary permissions/);
+  assert.match(releaseSource, /Expired token\/server permissions no longer authorize MCP command/);
 });
 
 test("Sidebar exposes explicit MCP runtime start and stop controls", () => {
   assert.match(sidebarSource, /Start MCP/);
   assert.match(sidebarSource, /Stop MCP/);
   assert.match(sidebarSource, /onSetMCPRuntimeEnabled/);
+});
+
+test("Token permission controls expose temporary grant lifetimes", () => {
+  assert.match(tokenPermissionPanelSource, /PermissionLifetimeControls/);
+  assert.match(tokenPermissionPanelSource, /onSetTemporary\("1h"\)/);
+  assert.match(tokenPermissionPanelSource, /onSetTemporary\("4h"\)/);
+  assert.match(tokenPermissionPanelSource, /onSetTemporary\("1d"\)/);
+  assert.match(permissionDialogSource, /Lifetime/);
+  assert.match(permissionDialogSource, /1 hour/);
+  assert.match(permissionDialogSource, /4 hours/);
+  assert.match(permissionDialogSource, /1 day/);
 });
 
 test("Approval dialog warns before persisting command context", () => {

--- a/frontend/src/lib/permissions.js
+++ b/frontend/src/lib/permissions.js
@@ -1,5 +1,65 @@
 export function permissionsToMap(permissions) {
-  return Object.fromEntries(permissions.map((permission) => [permission.server_id, permission.execution_rule]));
+  return Object.fromEntries(
+    permissions.map((permission) => [
+      permission.server_id,
+      {
+        execution_rule: permission.execution_rule,
+        expires_at: permission.expires_at || "",
+      },
+    ])
+  );
+}
+
+export const permissionLifetimeOptions = [
+  { value: "permanent", label: "Permanent", ms: 0 },
+  { value: "1h", label: "1 hour", ms: 60 * 60 * 1000 },
+  { value: "4h", label: "4 hours", ms: 4 * 60 * 60 * 1000 },
+  { value: "1d", label: "1 day", ms: 24 * 60 * 60 * 1000 },
+];
+
+export function normalizePermission(value) {
+  if (!value) return null;
+  if (typeof value === "string") {
+    return { execution_rule: value, expires_at: "" };
+  }
+  return {
+    execution_rule: value.execution_rule || "",
+    expires_at: value.expires_at || "",
+  };
+}
+
+export function permissionExpired(value, now = Date.now()) {
+  const permission = normalizePermission(value);
+  if (!permission?.expires_at) return false;
+  const expiresAt = new Date(permission.expires_at).getTime();
+  return Number.isFinite(expiresAt) && expiresAt <= now;
+}
+
+export function effectiveRule(value, now = Date.now()) {
+  const permission = normalizePermission(value);
+  if (!permission || permissionExpired(permission, now)) return "";
+  return permission.execution_rule;
+}
+
+export function permissionLifetimeLabel(value, now = Date.now()) {
+  const permission = normalizePermission(value);
+  if (!permission?.expires_at) return "Permanent";
+  const expiresAt = new Date(permission.expires_at).getTime();
+  if (!Number.isFinite(expiresAt)) return "Permanent";
+  const diff = expiresAt - now;
+  if (diff <= 0) return "Expired";
+  const minutes = Math.max(1, Math.round(diff / 60000));
+  if (minutes < 60) return `${minutes}m left`;
+  const hours = Math.max(1, Math.round(minutes / 60));
+  if (hours < 24) return `${hours}h left`;
+  const days = Math.max(1, Math.round(hours / 24));
+  return `${days}d left`;
+}
+
+export function expiresAtFromLifetime(value, now = Date.now()) {
+  const option = permissionLifetimeOptions.find((item) => item.value === value);
+  if (!option?.ms) return "";
+  return new Date(now + option.ms).toISOString();
 }
 
 export function ruleLabel(rule) {

--- a/frontend/src/lib/permissions.test.js
+++ b/frontend/src/lib/permissions.test.js
@@ -1,19 +1,29 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { maskedToken, permissionsToMap, ruleLabel } from "./permissions.js";
+import { effectiveRule, maskedToken, permissionLifetimeLabel, permissionsToMap, ruleLabel } from "./permissions.js";
 
 test("permissionsToMap indexes execution rules by server id", () => {
   assert.deepEqual(
     permissionsToMap([
-      { server_id: 4, execution_rule: "always_run" },
+      { server_id: 4, execution_rule: "always_run", expires_at: "2026-06-07T10:00:00Z" },
       { server_id: 7, execution_rule: "approval_required" },
     ]),
     {
-      4: "always_run",
-      7: "approval_required",
+      4: { execution_rule: "always_run", expires_at: "2026-06-07T10:00:00Z" },
+      7: { execution_rule: "approval_required", expires_at: "" },
     }
   );
+});
+
+test("permission helpers treat expired grants as ineffective", () => {
+  const now = new Date("2026-06-07T11:00:00Z").getTime();
+  assert.equal(effectiveRule({ execution_rule: "always_run", expires_at: "2026-06-07T10:00:00Z" }, now), "");
+  assert.equal(effectiveRule({ execution_rule: "always_run", expires_at: "2026-06-07T12:00:00Z" }, now), "always_run");
+  assert.equal(permissionLifetimeLabel({ execution_rule: "always_run", expires_at: "2026-06-07T12:00:00Z" }, now), "1h left");
+  assert.equal(permissionLifetimeLabel({ execution_rule: "always_run", expires_at: "2026-06-07T12:00:01Z" }, now), "1h left");
+  assert.equal(permissionLifetimeLabel({ execution_rule: "always_run", expires_at: "2026-06-07T15:00:01Z" }, now), "4h left");
+  assert.equal(permissionLifetimeLabel({ execution_rule: "always_run", expires_at: "2026-06-08T11:00:01Z" }, now), "1d left");
 });
 
 test("token and rule helpers produce compact labels", () => {

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,28 @@
-export const appVersion = "0.1.7";
+export const appVersion = "0.1.8";
 
 export const changelogEntries = [
+  {
+    version: "0.1.8",
+    label: "Temporary permissions",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Token/server permissions can expire after a temporary maintenance window.",
+          "Console token controls can set active Prompt or Always permissions to 1 hour, 4 hours, or 1 day.",
+          "The always-run warning shows a countdown when an active Always grant is temporary.",
+          "MCP list_servers reports temporary grant expiration and omits expired grants.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "Expired token/server permissions no longer authorize MCP command, console, file-transfer, or server-list access.",
+          "Permission expiration is a local safety rail; it does not make LAN or public exposure safe.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.1.7",
     label: "MCP transfer tools",

--- a/frontend/src/lib/use-token-permissions.js
+++ b/frontend/src/lib/use-token-permissions.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { apiGet, apiPut } from "./api";
-import { permissionsToMap } from "./permissions";
+import { effectiveRule, normalizePermission, permissionExpired, permissionsToMap } from "./permissions";
 
 export function useTokenPermissions(initialTokens = []) {
   const [permissionState, setPermissionState] = useState({ state: "idle", data: {}, error: null, savingKey: "" });
@@ -24,14 +24,20 @@ export function useTokenPermissions(initialTokens = []) {
     }
   }
 
-  async function setTokenServerRule(token, server, rule) {
+  async function setTokenServerRule(token, server, rule, options = {}) {
     const tokenID = Number(token.id);
     const serverID = Number(server.id);
     const savingKey = `${tokenID}:${serverID}`;
     const currentMap = permissionState.data[tokenID] || {};
+    const currentPermission = normalizePermission(currentMap[serverID]);
     const nextMap = { ...currentMap };
     if (rule) {
-      nextMap[serverID] = rule;
+      const expiresAt = Object.prototype.hasOwnProperty.call(options, "expiresAt")
+        ? options.expiresAt || ""
+        : currentPermission && !permissionExpired(currentPermission) && effectiveRule(currentPermission) === rule
+          ? currentPermission.expires_at || ""
+          : "";
+      nextMap[serverID] = { execution_rule: rule, expires_at: expiresAt };
     } else {
       delete nextMap[serverID];
     }
@@ -48,10 +54,7 @@ export function useTokenPermissions(initialTokens = []) {
 
     try {
       const permissions = await apiPut(`/api/tokens/${tokenID}/permissions`, {
-        permissions: Object.entries(nextMap).map(([id, executionRule]) => ({
-          server_id: Number(id),
-          execution_rule: executionRule,
-        })),
+        permissions: permissionPayload(nextMap),
       });
       setPermissionState((current) => ({
         ...current,
@@ -77,14 +80,15 @@ export function useTokenPermissions(initialTokens = []) {
     }
   }
 
-  async function setTokenAllServerRules(token, servers, rule) {
+  async function setTokenAllServerRules(token, servers, rule, options = {}) {
     const tokenID = Number(token.id);
     const savingKey = `${tokenID}:all`;
     const currentMap = permissionState.data[tokenID] || {};
     const nextMap = {};
     if (rule) {
+      const expiresAt = options.expiresAt || "";
       servers.forEach((server) => {
-        nextMap[Number(server.id)] = rule;
+        nextMap[Number(server.id)] = { execution_rule: rule, expires_at: expiresAt };
       });
     }
 
@@ -100,10 +104,7 @@ export function useTokenPermissions(initialTokens = []) {
 
     try {
       const permissions = await apiPut(`/api/tokens/${tokenID}/permissions`, {
-        permissions: Object.entries(nextMap).map(([id, executionRule]) => ({
-          server_id: Number(id),
-          execution_rule: executionRule,
-        })),
+        permissions: permissionPayload(nextMap),
       });
       setPermissionState((current) => ({
         ...current,
@@ -130,4 +131,19 @@ export function useTokenPermissions(initialTokens = []) {
   }
 
   return { permissionState, loadAllTokenPermissions, setTokenServerRule, setTokenAllServerRules };
+}
+
+function permissionPayload(permissionMap) {
+  return Object.entries(permissionMap)
+    .map(([id, permission]) => {
+      const normalized = normalizePermission(permission);
+      if (!normalized?.execution_rule) return null;
+      if (permissionExpired(normalized)) return null;
+      return {
+        server_id: Number(id),
+        execution_rule: normalized.execution_rule,
+        expires_at: normalized.expires_at || "",
+      };
+    })
+    .filter(Boolean);
 }

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { apiGet, apiPost } from "../lib/api";
 import { useGateway } from "../lib/gateway-context";
+import { effectiveRule, permissionLifetimeLabel } from "../lib/permissions";
 import { useTokenPermissions } from "../lib/use-token-permissions";
 import { CountBadge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
@@ -50,6 +51,7 @@ export function ConsolePage() {
   const [serversCompact, setServersCompact] = useState(false);
   const [tokensCompact, setTokensCompact] = useState(false);
   const [fileTransferOpen, setFileTransferOpen] = useState(false);
+  const [now, setNow] = useState(Date.now());
 
   const selectedServerID = searchParams.get("server");
   const sessions = consoleSessions.data || [];
@@ -71,10 +73,17 @@ export function ConsolePage() {
     sessions,
     selectedServerID,
     permissionState,
+    now,
   });
   const activeApproval = activeApprovalID ? pendingApprovals.find((approval) => Number(approval.id) === Number(activeApprovalID)) : null;
   const alwaysRunTokens = selectedServer
-    ? selectedTokenOptions.filter((token) => permissionState.data?.[token.id]?.[selectedServer.id] === "always_run")
+    ? selectedTokenOptions.filter((token) => effectiveRule(permissionState.data?.[token.id]?.[selectedServer.id], now) === "always_run")
+    : [];
+  const temporaryAlwaysRunLabels = selectedServer
+    ? alwaysRunTokens
+        .map((token) => permissionState.data?.[token.id]?.[selectedServer.id])
+        .filter((permission) => permission?.expires_at)
+        .map((permission) => permissionLifetimeLabel(permission, now))
     : [];
   const showAlwaysRunWarning = Boolean(mcpRuntime?.data?.enabled && selectedServer && alwaysRunTokens.length > 0);
 
@@ -90,6 +99,11 @@ export function ConsolePage() {
     if (tokens.state !== "ready") return;
     loadAllTokenPermissions(tokens.data);
   }, [tokens.state, tokens.data.map((token) => token.id).join(",")]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 30000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   useEffect(() => {
     if (!selectedServer) return;
@@ -396,6 +410,7 @@ export function ConsolePage() {
           {showAlwaysRunWarning ? (
             <div className="sticky top-0 z-10 border-b border-red-800/50 bg-red-950 px-4 py-2 text-xs font-semibold text-red-50">
               MCP is started and {alwaysRunTokens.length} token{alwaysRunTokens.length === 1 ? "" : "s"} can run commands on this server without approval. Prefer prompt mode unless direct execution is intentional.
+              {temporaryAlwaysRunLabels.length > 0 ? ` Temporary grant: ${temporaryAlwaysRunLabels[0]}.` : ""}
             </div>
           ) : null}
           {selectedServer && selectedSessionLive ? (

--- a/frontend/src/pages/tokens.jsx
+++ b/frontend/src/pages/tokens.jsx
@@ -2,7 +2,7 @@ import { Ban, CalendarClock, KeyRound, PlugZap, Plus, RefreshCcw, TicketCheck } 
 import { useEffect, useMemo, useState } from "react";
 import { apiPost } from "../lib/api";
 import { useGateway } from "../lib/gateway-context";
-import { maskedToken, ruleDotClass, ruleLabel } from "../lib/permissions";
+import { effectiveRule, expiresAtFromLifetime, maskedToken, permissionLifetimeLabel, ruleDotClass, ruleLabel } from "../lib/permissions";
 import { useAsyncAction } from "../lib/use-async-action";
 import { useTokenPermissions } from "../lib/use-token-permissions";
 import { Badge } from "../components/ui/badge";
@@ -32,7 +32,7 @@ export function TokensPage() {
   const [permissionDialog, setPermissionDialog] = useState(null);
   const { permissionState, loadAllTokenPermissions, setTokenServerRule, setTokenAllServerRules } = useTokenPermissions(tokens.data);
   const [installDialog, setInstallDialog] = useState({ open: false, token: null, provider: "manual" });
-  const [bulkDialog, setBulkDialog] = useState({ open: false, token: null, rule: "approval_required" });
+  const [bulkDialog, setBulkDialog] = useState({ open: false, token: null, rule: "approval_required", lifetime: "permanent" });
   const { actionState: state, runAction } = useAsyncAction();
   const [tokenFilter, setTokenFilter] = useState("active");
 
@@ -93,8 +93,8 @@ export function TokensPage() {
   async function applyBulkPermissions(event) {
     event.preventDefault();
     if (!bulkDialog.token) return;
-    await setTokenAllServerRules(bulkDialog.token, servers.data, bulkDialog.rule);
-    setBulkDialog({ open: false, token: null, rule: "approval_required" });
+    await setTokenAllServerRules(bulkDialog.token, servers.data, bulkDialog.rule, { expiresAt: expiresAtFromLifetime(bulkDialog.lifetime) });
+    setBulkDialog({ open: false, token: null, rule: "approval_required", lifetime: "permanent" });
   }
 
   return (
@@ -184,7 +184,7 @@ export function TokensPage() {
               const revoked = Boolean(token.revoked_at);
               const inactive = status !== "active";
               const permissions = permissionState.data[token.id] || {};
-              const allowedCount = servers.data.filter((server) => Boolean(permissions[server.id])).length;
+              const allowedCount = servers.data.filter((server) => Boolean(effectiveRule(permissions[server.id]))).length;
               return (
                 <tr className="hover:bg-stone-50" key={token.id}>
                   <td className="px-4 py-4">
@@ -212,12 +212,13 @@ export function TokensPage() {
                     <div className="grid gap-1.5">
                       <div className="flex flex-wrap gap-1.5">
                         {servers.data.map((server) => {
-                          const rule = permissions[server.id] || "";
+                          const permission = permissions[server.id];
+                          const rule = effectiveRule(permission);
                           return (
                             <button
                               type="button"
                               key={server.id}
-                              title={`${server.name}: ${ruleLabel(rule)}`}
+                              title={`${server.name}: ${ruleLabel(rule)}${rule ? ` - ${permissionLifetimeLabel(permission)}` : ""}`}
                               className={`h-4 w-4 rounded-full border border-white shadow-sm ring-1 ring-stone-200 ${ruleDotClass(rule)}`}
                               onClick={() => setPermissionDialog({ token, server })}
                               disabled={inactive}
@@ -248,7 +249,7 @@ export function TokensPage() {
                         type="button"
                         variant="outline"
                         className="h-9 px-3"
-                        onClick={() => setBulkDialog({ open: true, token, rule: "approval_required" })}
+                        onClick={() => setBulkDialog({ open: true, token, rule: "approval_required", lifetime: "permanent" })}
                         disabled={inactive || servers.data.length === 0 || permissionState.savingKey === `${token.id}:all`}
                         title="Set this token's permission for all servers"
                       >
@@ -328,7 +329,7 @@ export function TokensPage() {
         open={bulkDialog.open}
         title="Set all server permissions"
         description={bulkDialog.token ? `Apply one permission rule to every server for ${bulkDialog.token.name}.` : ""}
-        onClose={() => setBulkDialog({ open: false, token: null, rule: "approval_required" })}
+        onClose={() => setBulkDialog({ open: false, token: null, rule: "approval_required", lifetime: "permanent" })}
         size="md"
       >
         <form className="grid gap-4" onSubmit={applyBulkPermissions}>
@@ -341,8 +342,21 @@ export function TokensPage() {
               <option value="always_run">Always run for all servers</option>
             </Select>
           </Field>
+          <Field>
+            Lifetime
+            <Select
+              value={bulkDialog.lifetime}
+              onChange={(event) => setBulkDialog((current) => ({ ...current, lifetime: event.target.value }))}
+              disabled={!bulkDialog.rule}
+            >
+              <option value="permanent">Permanent</option>
+              <option value="1h">1 hour</option>
+              <option value="4h">4 hours</option>
+              <option value="1d">1 day</option>
+            </Select>
+          </Field>
           <div className="grid gap-2 sm:grid-cols-2">
-            <Button type="button" variant="outline" onClick={() => setBulkDialog({ open: false, token: null, rule: "approval_required" })}>
+            <Button type="button" variant="outline" onClick={() => setBulkDialog({ open: false, token: null, rule: "approval_required", lifetime: "permanent" })}>
               Cancel
             </Button>
             <Button type="submit" disabled={!bulkDialog.token || permissionState.savingKey === `${bulkDialog.token?.id}:all`}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
     },
     "frontend": {
       "name": "aipermission-frontend",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@xterm/addon-fit": "^0.11.0",
@@ -1294,7 +1294,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -101,7 +101,7 @@ These instructions teach the agent how to poll `approval_pending` and `running` 
 
 ## Security Boundary
 
-This package talks to a local AIPermission gateway. `AIPERMISSION_API_URL` must point to `localhost`, `127.0.0.1`, or `[::1]`; remote URLs are rejected before the bearer token is sent. Do not expose the gateway on LAN or the public internet, and do not use it as a shared DevOps service. Tokens grant access only to the servers and execution rules configured in the gateway UI.
+This package talks to a local AIPermission gateway. `AIPERMISSION_API_URL` must point to `localhost`, `127.0.0.1`, or `[::1]`; remote URLs are rejected before the bearer token is sent. Do not expose the gateway on LAN or the public internet, and do not use it as a shared DevOps service. Tokens grant access only to the servers and execution rules configured in the gateway UI. Token/server permissions may be temporary; expired grants are omitted from `list_servers` and no longer authorize command, console, or file-transfer tools.
 
 ## License
 

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "MIT",

--- a/packages/mcp/resources/aipermission-operator/SKILL.md
+++ b/packages/mcp/resources/aipermission-operator/SKILL.md
@@ -18,11 +18,14 @@ AIPermission is not a general DevOps control plane. Treat it as a temporary, sco
 Before executing commands:
 
 1. Call `list_servers()`.
-2. Read each server's `name`, `id`, `execution_rule`, and `hints`.
+2. Read each server's `name`, `id`, `execution_rule`, optional `expires_at`,
+   and `hints`.
 3. Use the numeric `id` returned by the tool.
 4. Pick the narrowest server set that can answer the task.
 
 If no server is visible, say that the current token has no accessible servers.
+If `expires_at` is present, treat access as temporary. Finish within that
+maintenance window or ask the operator to extend access.
 
 ## Command Reasons
 

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- add optional expires_at support for token/server permissions
- treat expired permission grants as ineffective for MCP server list, command, console, and file-transfer checks
- add Console and Tokens UI controls for 1h, 4h, and 1d temporary grants
- update README, API/security docs, operator skill, changelog, and MCP package metadata for 0.1.8

## Validation
- go test ./...
- go test -race ./...
- go vet ./...
- frontend npm test
- frontend npm run build
- frontend npm run test:e2e
- packages/mcp npm test
- packages/mcp npm run build
- packages/mcp npm pack --dry-run
- make audit
- node scripts/secret-scan.js
- docker compose up -d --build

## Notes
- Permission expiration is a local safety rail for temporary maintenance access; it does not change the local-only threat model.