### PR TITLE
Fix console prelude noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+### Fixed
+
+- Hide internal persistent-console prelude lines from the live console and MCP
+  command output when a PTY echoes setup commands.
+
 ## [0.1.9] - 2026-06-07
 
 ### Added

--- a/backend/internal/console/console_display.go
+++ b/backend/internal/console/console_display.go
@@ -101,18 +101,38 @@ func cleanConsoleDisplayOutput(data string, keepShellPrompt bool) string {
 	return output
 }
 
+func cleanConsoleCommandResultOutput(data string) string {
+	if data == "" {
+		return ""
+	}
+	data = ansiSequencePattern.ReplaceAllString(data, "")
+	data = strings.ReplaceAll(data, "\r\n", "\n")
+	data = strings.ReplaceAll(data, "\r", "\n")
+	lines := strings.Split(data, "\n")
+	endedWithNewline := strings.HasSuffix(data, "\n")
+	cleaned := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimRight(line, " \t")
+		if isConsoleInternalNoise(strings.TrimSpace(line)) {
+			continue
+		}
+		cleaned = append(cleaned, line)
+	}
+	if len(cleaned) == 0 {
+		return ""
+	}
+	output := strings.Join(cleaned, "\n")
+	if endedWithNewline && !strings.HasSuffix(output, "\n") {
+		output += "\n"
+	}
+	return output
+}
+
 func isConsoleDisplayNoise(line string, keepShellPrompt bool) bool {
 	if line == "" {
 		return false
 	}
-	if strings.Contains(line, "__AIPERMISSION_EXIT_") ||
-		strings.Contains(line, "__aipermission_saved_ps2") ||
-		strings.Contains(line, "stty -echo") ||
-		strings.Contains(line, "stty sane") ||
-		strings.Contains(line, "stty echo icanon opost") ||
-		strings.Contains(line, "stty echo") ||
-		line == "PS2=" ||
-		line == ">" {
+	if isConsoleInternalNoise(line) {
 		return true
 	}
 	if shellPromptPattern.MatchString(line) {
@@ -122,4 +142,19 @@ func isConsoleDisplayNoise(line string, keepShellPrompt bool) bool {
 		return true
 	}
 	return false
+}
+
+func isConsoleInternalNoise(line string) bool {
+	if line == "" {
+		return false
+	}
+	return strings.Contains(line, "__AIPERMISSION_EXIT_") ||
+		strings.Contains(line, "__aipermission_saved_stty") ||
+		strings.Contains(line, "__aipermission_saved_ps2") ||
+		strings.Contains(line, "stty -echo") ||
+		strings.Contains(line, "stty sane") ||
+		strings.Contains(line, "stty echo icanon opost") ||
+		strings.Contains(line, "stty echo") ||
+		line == "PS2=" ||
+		line == ">"
 }

--- a/backend/internal/console/console_exec.go
+++ b/backend/internal/console/console_exec.go
@@ -226,7 +226,7 @@ func (s *managedConsoleSession) checkCommandResult(startOffset int, marker strin
 	markerNeedle := "\n" + marker + ":"
 	markerIndex := strings.Index(segment, markerNeedle)
 	if markerIndex >= 0 {
-		output := segment[:markerIndex]
+		output := cleanConsoleCommandResultOutput(segment[:markerIndex])
 		afterMarker := segment[markerIndex+len(markerNeedle):]
 		lineEnd := strings.IndexAny(afterMarker, "\r\n")
 		exitText := afterMarker

--- a/backend/internal/console/console_sessions_test.go
+++ b/backend/internal/console/console_sessions_test.go
@@ -1022,6 +1022,40 @@ func TestAppendOutputCleansOnlyDuringAutomation(t *testing.T) {
 	}
 }
 
+func TestAppendOutputHidesConsolePreludeNoise(t *testing.T) {
+	session := &managedConsoleSession{
+		activeExec: &consoleSessionActiveExec{Marker: "__AIPERMISSION_EXIT_1"},
+	}
+	session.appendOutput("__aipermission_saved_stty=$(stty -g 2>/dev/null || true)\r\nuseful output\r\n__AIPERMISSION_EXIT_1:0\r\n")
+
+	if strings.Contains(session.transcript, "__aipermission_saved_stty") {
+		t.Fatalf("display transcript should hide console prelude noise: %q", session.transcript)
+	}
+	if !strings.Contains(session.transcript, "useful output") {
+		t.Fatalf("display transcript should keep command output: %q", session.transcript)
+	}
+}
+
+func TestCheckCommandResultFiltersConsolePreludeNoise(t *testing.T) {
+	session := &managedConsoleSession{
+		rawTranscript: "__aipermission_saved_stty=$(stty -g 2>/dev/null || true)\nuseful output\n__AIPERMISSION_EXIT_1:0\nroot@worker:~# ",
+	}
+
+	output, exitCode, completed, err := session.checkCommandResult(0, "__AIPERMISSION_EXIT_1")
+	if err != nil {
+		t.Fatalf("check command result: %v", err)
+	}
+	if !completed || exitCode != 0 {
+		t.Fatalf("expected completed success, got completed=%v exit=%d", completed, exitCode)
+	}
+	if strings.Contains(output, "__aipermission_saved_stty") {
+		t.Fatalf("command result should hide console prelude noise: %q", output)
+	}
+	if strings.TrimSpace(output) != "useful output" {
+		t.Fatalf("unexpected command output: %q", output)
+	}
+}
+
 func TestAppendOutputKeepsFinalPromptAfterAutomationCompletes(t *testing.T) {
 	session := &managedConsoleSession{
 		activeExec: &consoleSessionActiveExec{Marker: "__AIPERMISSION_EXIT_1"},


### PR DESCRIPTION
## Summary

- Hide internal persistent-console prelude lines from live console output.
- Filter the same prelude noise from MCP command results and history output.
- Add regression coverage for echoed PTY setup commands.

## Verification

- `go test ./internal/console`
- Local Docker Compose dogfood for about 15 minutes.

## Release

No release tag for this fix PR.