### PR TITLE
Release 0.1.10 console recovery controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-06-08
+
+### Added
+
+- Console now shows active long-running MCP commands for the selected server,
+  including running age, token label, command, reason, and stuck-session
+  guidance.
+- Local operators can restart a server-scoped persistent console session from
+  the Console UI when it appears wedged.
+- MCP running-request hints and operator instructions now document the recovery
+  sequence: poll `get_request`, inspect `read_console`, then use
+  `restart_console_session(server_id)` when no useful progress is visible.
+
 ### Fixed
 
 - Hide internal persistent-console prelude lines from the live console and MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project uses semantic versioning once public releases begin.
 
 - Hide internal persistent-console prelude lines from the live console and MCP
   command output when a PTY echoes setup commands.
+- MCP `list_servers` now includes last-known console status and error context
+  so agents do not confuse permission visibility with a live SSH health check.
 
 ## [0.1.9] - 2026-06-07
 

--- a/backend/internal/api/approvals.go
+++ b/backend/internal/api/approvals.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	pendingApprovalAssistantHint = "Wait 3 seconds, then call get_request. Continue polling get_request until terminal status."
-	runningAssistantHint         = "Wait 3 seconds, then call get_request again. Use read_console to inspect live output before sending another command to this server."
+	runningAssistantHint         = "Wait 3 seconds, then call get_request again. Use read_console to inspect live output before sending another command to this server. If the request remains running and the console shows no useful progress, use restart_console_session(server_id) to recover the gateway-owned persistent console session."
 
 	commandRequestSourceMCP    = "mcp"
 	commandRequestSourceManual = "manual"

--- a/backend/internal/api/console_session_handlers.go
+++ b/backend/internal/api/console_session_handlers.go
@@ -127,6 +127,32 @@ func (s consoleHandlers) closeConsoleSession(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusOK, map[string]any{"status": "closed"})
 }
 
+func (s consoleHandlers) restartServerConsoleSession(w http.ResponseWriter, r *http.Request) {
+	runtime, ok := s.activeRuntimeOrLocked(w)
+	if !ok {
+		return
+	}
+	serverID, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	result, err := s.Server.restartServerConsoleSession(r.Context(), runtime, serverID, "console session restarted by local user before command completed")
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	s.writeAudit(r.Context(), runtime, "user", nil, serverID, "console.session.restarted", map[string]any{
+		"closed_session_ids":        result.ClosedSessionIDs,
+		"canceled_running_requests": result.CanceledRunningRequests,
+	})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":                    "restarted",
+		"server_id":                 serverID,
+		"closed_session_ids":        result.ClosedSessionIDs,
+		"canceled_running_requests": result.CanceledRunningRequests,
+	})
+}
+
 func (s consoleHandlers) attachConsoleSession(w http.ResponseWriter, r *http.Request) {
 	runtime, ok := s.activeRuntimeOrLocked(w)
 	if !ok {

--- a/backend/internal/api/mcp.go
+++ b/backend/internal/api/mcp.go
@@ -28,6 +28,11 @@ func (s mcpHandlers) mcpListServers(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w)
 		return
 	}
+	consoleStates, err := mcpLatestConsoleStates(r.Context(), auth.runtime)
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
 
 	rows, err := auth.runtime.database.QueryContext(r.Context(), `
 		SELECT srv.id, srv.name, srv.description, srv.host, srv.port, srv.username, p.execution_rule, COALESCE(p.expires_at, '')
@@ -58,6 +63,11 @@ func (s mcpHandlers) mcpListServers(w http.ResponseWriter, r *http.Request) {
 			item.Port = 0
 			item.Username = ""
 		}
+		item.LiveConsoleStatus = "none"
+		if state, ok := consoleStates[item.ID]; ok {
+			item.LiveConsoleStatus = state.Status
+			item.LastConsoleError = state.Error
+		}
 		item.Hints = mcpServerHints(item.ExecutionRule)
 		items = append(items, item)
 	}
@@ -67,6 +77,39 @@ func (s mcpHandlers) mcpListServers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, items)
+}
+
+type mcpConsoleState struct {
+	Status string
+	Error  string
+}
+
+func mcpLatestConsoleStates(ctx context.Context, runtime *databaseRuntime) (map[int64]mcpConsoleState, error) {
+	rows, err := runtime.database.QueryContext(ctx, `
+		SELECT server_id, status, error
+		FROM console_sessions
+		ORDER BY CASE WHEN status IN ('connecting', 'connected') THEN 0 ELSE 1 END, updated_at DESC, created_at DESC, id DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	states := map[int64]mcpConsoleState{}
+	for rows.Next() {
+		var serverID int64
+		var state mcpConsoleState
+		if err := rows.Scan(&serverID, &state.Status, &state.Error); err != nil {
+			return nil, err
+		}
+		if _, exists := states[serverID]; exists {
+			continue
+		}
+		states[serverID] = state
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return states, nil
 }
 
 func (s mcpHandlers) mcpExec(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/api/mcp_console_handlers.go
+++ b/backend/internal/api/mcp_console_handlers.go
@@ -1,10 +1,16 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/aipermission/aipermission/backend/internal/tokens"
 )
+
+type consoleRestartResult struct {
+	ClosedSessionIDs        []int64
+	CanceledRunningRequests int64
+}
 
 func (s mcpHandlers) mcpRestartConsoleSession(w http.ResponseWriter, r *http.Request) {
 	auth, ok := s.authenticateMCP(w, r)
@@ -41,10 +47,30 @@ func (s mcpHandlers) mcpRestartConsoleSession(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	sessions, err := auth.runtime.consoleSessions.List(r.Context(), request.ServerID)
+	result, err := s.restartServerConsoleSession(r.Context(), auth.runtime, request.ServerID, "console session restarted before command completed")
 	if err != nil {
 		writeInternalError(w)
 		return
+	}
+
+	s.writeAudit(r.Context(), auth.runtime, "mcp", int64Ptr(auth.TokenID), request.ServerID, "mcp.console.restarted", map[string]any{
+		"closed_session_ids":        result.ClosedSessionIDs,
+		"canceled_running_requests": result.CanceledRunningRequests,
+	})
+	writeJSON(w, http.StatusOK, mcpRestartConsoleResponse{
+		Status:                  "restarted",
+		ServerID:                request.ServerID,
+		ServerName:              serverName,
+		ClosedSessionIDs:        result.ClosedSessionIDs,
+		CanceledRunningRequests: result.CanceledRunningRequests,
+		AssistantHint:           "The persistent console session was closed. The next exec call for this server will open a fresh SSH session.",
+	})
+}
+
+func (s *Server) restartServerConsoleSession(ctx context.Context, runtime *databaseRuntime, serverID int64, runningRequestError string) (consoleRestartResult, error) {
+	sessions, err := runtime.consoleSessions.List(ctx, serverID)
+	if err != nil {
+		return consoleRestartResult{}, err
 	}
 	closedSessionIDs := []int64{}
 	for _, session := range sessions {
@@ -53,26 +79,15 @@ func (s mcpHandlers) mcpRestartConsoleSession(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	canceledRequests, err := s.cancelRunningCommandRequestsForServer(r.Context(), auth.runtime, request.ServerID, "console session restarted before command completed")
+	canceledRequests, err := s.cancelRunningCommandRequestsForServer(ctx, runtime, serverID, runningRequestError)
 	if err != nil {
-		writeInternalError(w)
-		return
+		return consoleRestartResult{}, err
 	}
-	if err := auth.runtime.consoleSessions.CloseServer(r.Context(), request.ServerID); err != nil {
-		writeInternalError(w)
-		return
+	if err := runtime.consoleSessions.CloseServer(ctx, serverID); err != nil {
+		return consoleRestartResult{}, err
 	}
-
-	s.writeAudit(r.Context(), auth.runtime, "mcp", int64Ptr(auth.TokenID), request.ServerID, "mcp.console.restarted", map[string]any{
-		"closed_session_ids":        closedSessionIDs,
-		"canceled_running_requests": canceledRequests,
-	})
-	writeJSON(w, http.StatusOK, mcpRestartConsoleResponse{
-		Status:                  "restarted",
-		ServerID:                request.ServerID,
-		ServerName:              serverName,
+	return consoleRestartResult{
 		ClosedSessionIDs:        closedSessionIDs,
 		CanceledRunningRequests: canceledRequests,
-		AssistantHint:           "The persistent console session was closed. The next exec call for this server will open a fresh SSH session.",
-	})
+	}, nil
 }

--- a/backend/internal/api/mcp_test.go
+++ b/backend/internal/api/mcp_test.go
@@ -207,8 +207,35 @@ func TestMCPListServersUsesTokenPermissionsAndHidesBlocked(t *testing.T) {
 	if items[0].Host != "" || items[0].Port != 0 || items[0].Username != "" {
 		t.Fatalf("endpoint metadata should be hidden by default: %#v", items[0])
 	}
+	if items[0].LiveConsoleStatus != "none" || items[0].LastConsoleError != "" {
+		t.Fatalf("expected no live console context by default: %#v", items[0])
+	}
 	if len(items[0].Hints) == 0 || !strings.Contains(strings.Join(items[0].Hints, " "), "hash -r") {
 		t.Fatalf("expected command hygiene hints in mcp server list: %#v", items[0].Hints)
+	}
+	if !strings.Contains(strings.Join(items[0].Hints, " "), "permission-scoped") {
+		t.Fatalf("expected permission-scoped health hint in mcp server list: %#v", items[0].Hints)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := fixture.db.ExecContext(ctx, `
+		INSERT INTO console_sessions (server_id, name, status, transcript, error, cols, rows, created_at, updated_at)
+		VALUES (?, 'failed-ssh', 'error', '', 'dial tcp 203.0.113.10:22: i/o timeout', 120, 32, ?, ?)`,
+		allowed.ID,
+		now,
+		now,
+	); err != nil {
+		t.Fatalf("insert console context: %v", err)
+	}
+	response = performJSON(fixture.server.Handler(), http.MethodGet, "/api/mcp/servers", token.TokenValue, nil)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200 after console context, got %d: %s", response.Code, response.Body.String())
+	}
+	items = nil
+	if err := json.Unmarshal(response.Body.Bytes(), &items); err != nil {
+		t.Fatalf("decode console context response: %v", err)
+	}
+	if len(items) != 1 || items[0].LiveConsoleStatus != "error" || !strings.Contains(items[0].LastConsoleError, "i/o timeout") {
+		t.Fatalf("expected last known console error context: %#v", items)
 	}
 	expiredResponse := performJSON(fixture.server.Handler(), http.MethodPost, "/api/mcp/exec", token.TokenValue, map[string]any{
 		"server_id": expired.ID,

--- a/backend/internal/api/mcp_types.go
+++ b/backend/internal/api/mcp_types.go
@@ -116,6 +116,7 @@ func mcpServerHints(executionRule string) []string {
 		"Use absolute paths or 'cd /path && command' when directory context matters.",
 		"Avoid printing secrets; inspect whether a file/key exists before catting environment files or credential paths.",
 		"Read console output before sending another long-running command to the same server.",
+		"If a request stays running and read_console shows no useful progress, use restart_console_session(server_id) before sending more commands.",
 	}
 	if executionRule == tokens.RuleApprovalRequired {
 		hints = append(hints, "This server requires approval; after exec returns approval_pending, poll get_request until it is completed, failed, or declined.")

--- a/backend/internal/api/mcp_types.go
+++ b/backend/internal/api/mcp_types.go
@@ -18,15 +18,17 @@ type mcpAuthContext struct {
 }
 
 type mcpServerItem struct {
-	ID            int64    `json:"id"`
-	Name          string   `json:"name"`
-	Description   string   `json:"description,omitempty"`
-	Host          string   `json:"host,omitempty"`
-	Port          int      `json:"port,omitempty"`
-	Username      string   `json:"username,omitempty"`
-	ExecutionRule string   `json:"execution_rule"`
-	ExpiresAt     string   `json:"expires_at,omitempty"`
-	Hints         []string `json:"hints"`
+	ID                int64    `json:"id"`
+	Name              string   `json:"name"`
+	Description       string   `json:"description,omitempty"`
+	Host              string   `json:"host,omitempty"`
+	Port              int      `json:"port,omitempty"`
+	Username          string   `json:"username,omitempty"`
+	ExecutionRule     string   `json:"execution_rule"`
+	ExpiresAt         string   `json:"expires_at,omitempty"`
+	LiveConsoleStatus string   `json:"live_console_status"`
+	LastConsoleError  string   `json:"last_console_error,omitempty"`
+	Hints             []string `json:"hints"`
 }
 
 type mcpExecRequest struct {
@@ -107,6 +109,7 @@ type historyLabelRecord struct {
 
 func mcpServerHints(executionRule string) []string {
 	hints := []string{
+		"list_servers is permission-scoped, not a live SSH health check; use live_console_status as last-known context and treat exec dial/timeout errors as reachability failures.",
 		"Use a short reason when calling exec so the operator can approve or audit the command.",
 		"For install/uninstall verification in the same shell, run 'hash -r 2>/dev/null || true' before checking command -v.",
 		"On Debian/Ubuntu, dpkg -l can show removed packages as rc; use dpkg-query installed state 'ii' to verify packages are installed.",

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -96,6 +96,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/console/sessions/{id}/input", console.inputConsoleSession)
 	s.mux.HandleFunc("POST /api/console/sessions/{id}/close", console.closeConsoleSession)
 	s.mux.HandleFunc("GET /api/console/sessions/{id}/attach", console.attachConsoleSession)
+	s.mux.HandleFunc("POST /api/console/servers/{id}/restart", console.restartServerConsoleSession)
 	s.mux.HandleFunc("GET /api/approvals", approvals.listApprovals)
 	s.mux.HandleFunc("GET /api/approvals/{id}", approvals.getApproval)
 	s.mux.HandleFunc("POST /api/approvals/{id}/run", approvals.runApproval)

--- a/backend/internal/api/routes_test.go
+++ b/backend/internal/api/routes_test.go
@@ -841,6 +841,55 @@ func TestMessageAndConsoleRoutes(t *testing.T) {
 		t.Fatalf("close should mark session running request error, status=%s error=%q", closedRequestStatus, closedRequestError)
 	}
 
+	restartServer := fixture.createKeyAndServer(t, "worker-restart")
+	restartSessionResult, err := fixture.db.Exec(`
+		INSERT INTO console_sessions (server_id, name, status, transcript, cols, rows, created_at, updated_at)
+		VALUES (?, 'stuck', 'connected', 'stuck transcript', 120, 32, ?, ?)`,
+		restartServer.ID,
+		now,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("insert restart console session: %v", err)
+	}
+	restartSessionID, err := restartSessionResult.LastInsertId()
+	if err != nil {
+		t.Fatalf("restart session id: %v", err)
+	}
+	restartRequestResult, err := fixture.db.Exec(`
+		INSERT INTO command_requests (server_id, source, command, reason, status, session_id, created_at)
+		VALUES (?, 'mcp', 'kubectl get nodes', 'stuck request', 'running', ?, ?)`,
+		restartServer.ID,
+		restartSessionID,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("insert restart running command request: %v", err)
+	}
+	restartRequestID, err := restartRequestResult.LastInsertId()
+	if err != nil {
+		t.Fatalf("restart request id: %v", err)
+	}
+	restartResponse := performJSON(fixture.server.Handler(), http.MethodPost, "/api/console/servers/"+strconv.FormatInt(restartServer.ID, 10)+"/restart", "", map[string]any{})
+	if restartResponse.Code != http.StatusOK || !strings.Contains(restartResponse.Body.String(), `"status":"restarted"`) {
+		t.Fatalf("restart console session failed: %d %s", restartResponse.Code, restartResponse.Body.String())
+	}
+	var restartedSessionStatus string
+	if err := fixture.db.QueryRow(`SELECT status FROM console_sessions WHERE id = ?`, restartSessionID).Scan(&restartedSessionStatus); err != nil {
+		t.Fatalf("read restarted session: %v", err)
+	}
+	if restartedSessionStatus != "closed" {
+		t.Fatalf("expected restarted session closed, got %s", restartedSessionStatus)
+	}
+	var restartedRequestStatus string
+	var restartedRequestError string
+	if err := fixture.db.QueryRow(`SELECT status, error FROM command_requests WHERE id = ?`, restartRequestID).Scan(&restartedRequestStatus, &restartedRequestError); err != nil {
+		t.Fatalf("read restarted request: %v", err)
+	}
+	if restartedRequestStatus != "error" || !strings.Contains(restartedRequestError, "restarted by local user") {
+		t.Fatalf("restart should mark running request error, status=%s error=%q", restartedRequestStatus, restartedRequestError)
+	}
+
 	blockedServer := fixture.createKeyAndServer(t, "worker-blocked")
 	if response := performJSON(fixture.server.Handler(), http.MethodPost, "/api/mcp/messages", token.TokenValue, createMessageRequest{Message: "blocked", ServerID: &blockedServer.ID}); response.Code != http.StatusForbidden {
 		t.Fatalf("mcp create message for unauthorized server should fail, got %d %s", response.Code, response.Body.String())

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -50,6 +50,7 @@ Example response:
     "description": "Kubernetes control-plane maintenance access.",
     "execution_rule": "approval_required",
     "expires_at": "2026-06-07T14:00:00Z",
+    "live_console_status": "connected",
     "hints": [
       "Use non-interactive apt commands.",
       "Prefer journalctl --no-pager for service logs."
@@ -58,7 +59,17 @@ Example response:
 ]
 ```
 
-By default, `list_servers` hides endpoint metadata and returns only `id`, `name`, `description`, `execution_rule`, optional `expires_at`, and `hints`. Security can enable **Expose endpoint metadata to MCP** if an operator wants MCP clients to also receive `host`, `port`, and `username`.
+By default, `list_servers` hides endpoint metadata and returns only `id`,
+`name`, `description`, `execution_rule`, optional `expires_at`,
+`live_console_status`, optional `last_console_error`, and `hints`. Security can
+enable **Expose endpoint metadata to MCP** if an operator wants MCP clients to
+also receive `host`, `port`, and `username`.
+
+`live_console_status` is last-known console context, not a fresh SSH health
+check. It can be `none`, `connecting`, `connected`, `closed`, or `error`.
+`last_console_error` appears when the latest console session for that server
+ended with an error. Agents should still treat `exec` dial, timeout, and SSH
+errors as the current reachability signal.
 
 `expires_at` appears when the token/server permission is temporary. Expired
 permissions are omitted from `list_servers` and do not authorize `exec`,

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -106,7 +106,15 @@ If MCP execution is stopped in the web UI, `exec` returns:
 
 `always_run` commands run through the backend-owned persistent console session. If the web console is attached to that session, AI/MCP commands are visible in the same transcript.
 
-For MCP client timeout safety, the backend waits for a bounded period in a single `exec` call. If the command is still running, the response is `running`; the shell session continues and output keeps streaming to the web console. The AI should call `read_console(server_id)` and poll `get_request(request_id)` before sending another long-running command to that server.
+For MCP client timeout safety, the backend waits for a bounded period in a
+single `exec` call. If the command is still running, the response is
+`running`; the shell session continues and output keeps streaming to the web
+console. The AI should poll `get_request(request_id)`, use
+`read_console(server_id)` to inspect live output when the token has
+`always_run`, and avoid sending another long-running command to that server
+until the active request reaches a terminal status. If the request remains
+running and `read_console` shows no useful progress, the recovery path is
+`restart_console_session(server_id)`.
 
 Example completed response:
 
@@ -130,7 +138,7 @@ Example running response:
   "server_id": 3,
   "session_id": 12,
   "retry_after_seconds": 3,
-  "assistant_hint": "Wait 3 seconds, then call get_request again. Use read_console to inspect live output before sending another command to this server."
+  "assistant_hint": "Wait 3 seconds, then call get_request again. Use read_console to inspect live output before sending another command to this server. If the request remains running and the console shows no useful progress, use restart_console_session(server_id) to recover the persistent console session."
 }
 ```
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -561,6 +561,7 @@ GET    /api/console/sessions/{id}
 POST   /api/console/sessions/{id}/input
 POST   /api/console/sessions/{id}/close
 GET    /api/console/sessions/{id}/attach
+POST   /api/console/servers/{id}/restart
 ```
 
 `POST /api/console/exec` is a direct local web/API command endpoint kept for compatibility. The current Console UI uses persistent sessions instead.
@@ -570,6 +571,12 @@ The backend owns the SSH shell. Browser and MCP clients attach to the same `sess
 Console websockets are locally hardened with bounded message size, client count, read deadlines, ping/pong keepalive, and lightweight input/resize frequency limits. These are abuse guardrails for the local gateway; they are not a remote multi-user quota system.
 
 `close_existing=true` closes any open shell for the same server and starts a new one. The UI New Session action uses this.
+
+`POST /api/console/servers/{id}/restart` is the local UI recovery action for a
+stuck persistent console session. It closes live console sessions for that
+server, marks running command requests for that server as `error`, writes an
+audit event, and lets the next command open a fresh SSH session. This route is
+protected by the UI session and CSRF checks.
 
 Attach WebSocket messages from the server include:
 

--- a/docs/setup/mcp-client-setup.md
+++ b/docs/setup/mcp-client-setup.md
@@ -99,7 +99,7 @@ MCP server config shape:
 }
 ```
 
-If the related server permission is not `always_run`, a smoke test returns `approval_pending`. After the user clicks Run or Decline in Console, the MCP client checks the result with `get_request(request_id)`. Long-running `always_run` commands can be observed with `read_console(server_id)`.
+If the related server permission is not `always_run`, a smoke test returns `approval_pending`. After the user clicks Run or Decline in Console, the MCP client checks the result with `get_request(request_id)`. Long-running `always_run` commands can be observed with `read_console(server_id)`. If a request remains running and the console shows no useful progress, `restart_console_session(server_id)` closes the gateway-owned persistent console session so the next command opens a fresh SSH session.
 
 Provider config file targets:
 

--- a/docs/skills/aipermission-operator/SKILL.md
+++ b/docs/skills/aipermission-operator/SKILL.md
@@ -83,11 +83,12 @@ When `exec` or `get_request` returns `running`:
 4. Do not start another long-running command on the same server until the active request reaches a terminal status, unless the user explicitly asks.
 
 If the request appears stuck for an unusually long time and `read_console`
-shows no useful progress, ask the operator before recovery. When the operator
-agrees, call `restart_console_session(server_id)`. This closes the
-gateway-owned persistent console session and the next `exec` opens a fresh SSH
-session. Treat any canceled request as inconclusive and re-run only the minimal
-safe inspection needed.
+shows no useful progress, ask the operator before recovery unless they already
+asked you to recover the session. When recovery is approved, call
+`restart_console_session(server_id)`. This does not intentionally run a remote
+shell command; it closes the gateway-owned persistent console session and the
+next `exec` opens a fresh SSH session. Treat any canceled request as
+inconclusive and re-run only the minimal safe inspection needed.
 
 ## Message Flow
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aipermission-frontend",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@xterm/addon-fit": "^0.11.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/components/app-shell.jsx
+++ b/frontend/src/components/app-shell.jsx
@@ -326,6 +326,20 @@ export function Shell({ theme, setTheme }) {
     patchConsoleSession(sessionID, () => ({ status: "closed" }));
   }
 
+  async function restartConsoleSession(serverID) {
+    const affectedSessions = consoleSessions.data.filter((session) => Number(session.server_id) === Number(serverID));
+    affectedSessions.forEach((session) => {
+      const connection = consoleConnectionsRef.current[session.id];
+      if (connection) {
+        connection.close();
+        delete consoleConnectionsRef.current[session.id];
+      }
+    });
+    const result = await apiPost(`/api/console/servers/${serverID}/restart`, {});
+    await Promise.all([loadConsoleSessions(), loadApprovals()]);
+    return result;
+  }
+
   async function runApproval(requestID, userNote = "") {
     try {
       const item = await apiPost(`/api/approvals/${requestID}/run`, { user_note: userNote });
@@ -526,6 +540,7 @@ export function Shell({ theme, setTheme }) {
               attachConsoleSession,
               closeConsoleSession,
               cancelConsoleCommand,
+              restartConsoleSession,
               sendConsoleInput,
               resizeConsoleSession,
               runApproval,

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -178,6 +178,15 @@ test("Console and History expose SSH file transfer flows", () => {
   assert.match(shellSource, /\/api\/file-transfer-batches\/\$\{batchID\}\/decline/);
 });
 
+test("Console exposes stuck command recovery controls", () => {
+  assert.match(shellSource, /restartConsoleSession/);
+  assert.match(shellSource, /\/api\/console\/servers\/\$\{serverID\}\/restart/);
+  assert.match(consolePageSource, /ConsoleRecoveryPanel/);
+  assert.match(consolePageSource, /AI command running/);
+  assert.match(consolePageSource, /No terminal status has arrived yet/);
+  assert.match(consolePageSource, /Restart Session/);
+});
+
 test("Settings page exposes history label management", () => {
   assert.match(settingsSource, /\/api\/history-labels/);
   assert.match(settingsSource, /History labels/);

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -183,8 +183,9 @@ test("Console exposes stuck command recovery controls", () => {
   assert.match(shellSource, /\/api\/console\/servers\/\$\{serverID\}\/restart/);
   assert.match(consolePageSource, /ConsoleRecoveryPanel/);
   assert.match(consolePageSource, /AI command running/);
-  assert.match(consolePageSource, /No terminal status has arrived yet/);
-  assert.match(consolePageSource, /Restart Session/);
+  assert.match(consolePageSource, /Looks stuck\? Restart opens a fresh SSH session/);
+  assert.match(consolePageSource, /commandPreview/);
+  assert.match(consolePageSource, /Restart/);
 });
 
 test("Settings page exposes history label management", () => {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -68,7 +68,7 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.1\.9"/);
+  assert.match(releaseSource, /appVersion = "0\.1\.10"/);
   assert.match(releaseSource, /Approval drift and console recovery/);
   assert.match(releaseSource, /Persistent console MCP exec is more resilient/);
 });

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,26 @@
-export const appVersion = "0.1.9";
+export const appVersion = "0.1.10";
 
 export const changelogEntries = [
+  {
+    version: "0.1.10",
+    label: "Console recovery controls",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Console shows the active long-running MCP command, running age, token label, command, and reason for the selected server.",
+          "Local operators can restart a stuck persistent console session from the Console UI.",
+          "MCP hints and operator instructions now describe the get_request, read_console, and restart_console_session recovery sequence.",
+        ],
+      },
+      {
+        title: "Fixed",
+        items: [
+          "Internal persistent-console prelude lines are hidden from the live console and MCP command output.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.1.9",
     label: "Approval drift and console recovery",

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -17,6 +17,7 @@ export const changelogEntries = [
         title: "Fixed",
         items: [
           "Internal persistent-console prelude lines are hidden from the live console and MCP command output.",
+          "MCP list_servers includes last-known console status so agents do not treat permission visibility as a live SSH health check.",
         ],
       },
     ],

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -532,57 +532,51 @@ export function ConsolePage() {
 
 function ConsoleRecoveryPanel({ request, now, theme, action, onRestart }) {
   const ageMs = Math.max(0, now - parseTimestamp(request.created_at));
-  const longRunning = ageMs >= 60000;
-  const panelClass =
-    theme === "light"
-      ? longRunning
-        ? "border-amber-300 bg-amber-50 text-amber-950"
-        : "border-stone-200 bg-stone-50 text-stone-900"
-      : longRunning
-        ? "border-amber-900/70 bg-amber-950/40 text-amber-50"
-        : "border-stone-700 bg-[#252526] text-stone-100";
-  const mutedClass = theme === "light" ? "text-stone-600" : "text-stone-300";
-  const codeClass = theme === "light" ? "bg-white text-stone-950" : "bg-[#1e1e1e] text-stone-100";
+  const showRecoveryHint = ageMs >= 20000;
+  const panelClass = theme === "light" ? "border-amber-300 bg-amber-50 text-amber-950" : "border-amber-900/70 bg-amber-950/40 text-amber-50";
+  const mutedClass = theme === "light" ? "text-amber-900/80" : "text-amber-100/80";
+  const commandPreview = firstLine(request.command || "command");
 
   return (
-    <div className={`grid gap-3 border-b px-4 py-3 text-sm ${panelClass}`}>
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="grid min-w-0 gap-1">
-          <div className="flex flex-wrap items-center gap-2 font-semibold">
-            <Clock className="h-4 w-4" />
-            <span>AI command running</span>
-            <span className={`rounded-full px-2 py-0.5 text-xs ${theme === "light" ? "bg-stone-200 text-stone-700" : "bg-stone-800 text-stone-200"}`}>
-              {formatDuration(ageMs)}
-            </span>
-            {request.token_name ? (
-              <span className={`rounded-full px-2 py-0.5 text-xs ${theme === "light" ? "bg-emerald-100 text-emerald-800" : "bg-emerald-950 text-emerald-100"}`}>
-                {request.token_name}
-              </span>
-            ) : null}
-          </div>
-          <p className={`text-xs ${mutedClass}`}>
-            {longRunning
-              ? "No terminal status has arrived yet. If the console output is not progressing, interrupt the command or restart the persistent session."
-              : "AIPermission is waiting for the command exit marker before marking this request completed."}
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant={longRunning ? "danger" : "outline"}
-          className={`h-9 shrink-0 ${theme === "dark" && !longRunning ? "border-stone-600 bg-[#1e1e1e] text-stone-100 hover:bg-stone-800" : ""}`}
-          onClick={onRestart}
-          disabled={action.state === "running"}
-          title="Close the gateway-owned persistent console session and let the next command open a fresh SSH session"
-        >
-          <RefreshCcw className="h-3.5 w-3.5" />
-          {action.state === "running" ? "Restarting..." : "Restart Session"}
-        </Button>
+    <div className={`flex min-h-9 items-center gap-3 border-b px-4 py-2 text-xs ${panelClass}`}>
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <Clock className="h-3.5 w-3.5 shrink-0" />
+        <span className="shrink-0 font-semibold">AI command running</span>
+        <span className={`shrink-0 rounded-full px-2 py-0.5 ${theme === "light" ? "bg-stone-200 text-stone-700" : "bg-stone-800 text-stone-200"}`}>
+          {formatDuration(ageMs)}
+        </span>
+        {request.token_name ? (
+          <span className={`shrink-0 rounded-full px-2 py-0.5 ${theme === "light" ? "bg-emerald-100 text-emerald-800" : "bg-emerald-950 text-emerald-100"}`}>
+            {request.token_name}
+          </span>
+        ) : null}
+        <span className={`min-w-0 truncate font-mono ${mutedClass}`}>{commandPreview}</span>
+        {showRecoveryHint ? <span className="shrink-0 font-medium">Looks stuck? Restart opens a fresh SSH session.</span> : null}
       </div>
-      <pre className={`max-h-20 overflow-auto rounded-md px-3 py-2 font-mono text-xs ${codeClass}`}>{request.command}</pre>
-      {request.reason ? <p className={`text-xs ${mutedClass}`}>Reason: {request.reason}</p> : null}
-      {action.error ? <Notice tone="bad">{action.error}</Notice> : null}
+      {action.error ? <span className="max-w-80 truncate text-red-300">{action.error}</span> : null}
+      <Button
+        type="button"
+        variant="outline"
+        className={`h-7 shrink-0 px-2 text-xs ${
+          theme === "light"
+            ? "border-amber-400 bg-amber-100 text-amber-950 hover:bg-amber-200"
+            : "border-amber-700 bg-amber-950/70 text-amber-50 hover:bg-amber-900/70"
+        }`}
+        onClick={onRestart}
+        disabled={action.state === "running"}
+        title="Close the gateway-owned persistent console session and let the next command open a fresh SSH session"
+      >
+        <RefreshCcw className="h-3.5 w-3.5" />
+        {action.state === "running" ? "Restarting..." : "Restart"}
+      </Button>
     </div>
   );
+}
+
+function firstLine(value) {
+  const line = String(value || "").split(/\r?\n/, 1)[0].trim();
+  if (line.length <= 90) return line;
+  return `${line.slice(0, 87)}...`;
 }
 
 function parseTimestamp(value) {

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -611,5 +611,6 @@ function ConsoleStatusDot({ status, className = "" }) {
     idle: "Live session idle",
     busy: "Pending or running work",
   };
-  return <Circle className={`h-3 w-3 shrink-0 ${colors[status] || colors.offline} ${className}`} aria-label={label[status] || label.offline} />;
+  const title = label[status] || label.offline;
+  return <Circle className={`h-3 w-3 shrink-0 ${colors[status] || colors.offline} ${className}`} aria-label={title} title={title} />;
 }

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Circle, Files, MessageSquare, PanelLeftClose, PanelLeftOpen, RefreshCcw, Server, Square, TerminalSquare, XCircle } from "lucide-react";
+import { AlertTriangle, Circle, Clock, Files, MessageSquare, PanelLeftClose, PanelLeftOpen, RefreshCcw, Server, Square, TerminalSquare, XCircle } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { apiGet, apiPost } from "../lib/api";
@@ -31,6 +31,7 @@ export function ConsolePage() {
     attachConsoleSession,
     closeConsoleSession,
     cancelConsoleCommand,
+    restartConsoleSession,
     sendConsoleInput,
     resizeConsoleSession,
     runApproval,
@@ -52,6 +53,7 @@ export function ConsolePage() {
   const [serversCompact, setServersCompact] = useState(false);
   const [tokensCompact, setTokensCompact] = useState(false);
   const [fileTransferOpen, setFileTransferOpen] = useState(false);
+  const [restartAction, setRestartAction] = useState({ state: "idle", error: null });
   const [now, setNow] = useState(Date.now());
 
   const selectedServerID = searchParams.get("server");
@@ -88,6 +90,11 @@ export function ConsolePage() {
         .map((permission) => permissionLifetimeLabel(permission, now))
     : [];
   const showAlwaysRunWarning = Boolean(mcpRuntime?.data?.enabled && selectedServer && alwaysRunTokens.length > 0);
+  const selectedRunningRequests = selectedServer
+    ? approvals.data.filter((approval) => approval.status === "running" && Number(approval.server_id) === Number(selectedServer.id))
+    : [];
+  const selectedRunningRequest = selectedRunningRequests[0] || null;
+  const consoleBannerCount = (showAlwaysRunWarning ? 1 : 0) + (selectedRunningRequest ? 1 : 0);
 
   useEffect(() => {
     if (servers.data.length === 0) return;
@@ -103,7 +110,7 @@ export function ConsolePage() {
   }, [tokens.state, tokens.data.map((token) => token.id).join(",")]);
 
   useEffect(() => {
-    const timer = window.setInterval(() => setNow(Date.now()), 30000);
+    const timer = window.setInterval(() => setNow(Date.now()), 5000);
     return () => window.clearInterval(timer);
   }, []);
 
@@ -113,6 +120,10 @@ export function ConsolePage() {
       attachConsoleSession(selectedSession.id);
     }
   }, [selectedServer?.id, selectedSession.id, selectedSession.status]);
+
+  useEffect(() => {
+    setRestartAction({ state: "idle", error: null });
+  }, [selectedServer?.id, selectedRunningRequest?.id]);
 
   useEffect(() => {
     if (activeApprovalID && !pendingApprovals.some((approval) => Number(approval.id) === Number(activeApprovalID)) && approvalAction.state !== "error" && approvalAction.state !== "stale") {
@@ -242,6 +253,17 @@ export function ConsolePage() {
   function isStaleApprovalError(error) {
     const message = String(error?.message || "").toLowerCase();
     return message.includes("stale") || message.includes("approval context") || message.includes("fresh request");
+  }
+
+  async function restartSelectedConsoleSession() {
+    if (!selectedServer) return;
+    setRestartAction({ state: "running", error: null });
+    try {
+      await restartConsoleSession(selectedServer.id);
+      setRestartAction({ state: "idle", error: null });
+    } catch (error) {
+      setRestartAction({ state: "error", error: error.message });
+    }
   }
 
   return (
@@ -421,12 +443,24 @@ export function ConsolePage() {
           </div>
         </header>
 
-        <div className={showAlwaysRunWarning ? "grid min-h-0 grid-rows-[auto_minmax(0,1fr)]" : "min-h-0"}>
+        <div
+          className={consoleBannerCount > 0 ? "grid min-h-0" : "min-h-0"}
+          style={consoleBannerCount > 0 ? { gridTemplateRows: `${Array(consoleBannerCount).fill("auto").join(" ")} minmax(0, 1fr)` } : undefined}
+        >
           {showAlwaysRunWarning ? (
             <div className="sticky top-0 z-10 border-b border-red-800/50 bg-red-950 px-4 py-2 text-xs font-semibold text-red-50">
               MCP is started and {alwaysRunTokens.length} token{alwaysRunTokens.length === 1 ? "" : "s"} can run commands on this server without approval. Prefer prompt mode unless direct execution is intentional.
               {temporaryAlwaysRunLabels.length > 0 ? ` Temporary grant: ${temporaryAlwaysRunLabels[0]}.` : ""}
             </div>
+          ) : null}
+          {selectedRunningRequest ? (
+            <ConsoleRecoveryPanel
+              request={selectedRunningRequest}
+              now={now}
+              theme={theme}
+              action={restartAction}
+              onRestart={restartSelectedConsoleSession}
+            />
           ) : null}
           {selectedServer && selectedSessionLive ? (
             <PtyConsole
@@ -494,6 +528,76 @@ export function ConsolePage() {
       />
     </section>
   );
+}
+
+function ConsoleRecoveryPanel({ request, now, theme, action, onRestart }) {
+  const ageMs = Math.max(0, now - parseTimestamp(request.created_at));
+  const longRunning = ageMs >= 60000;
+  const panelClass =
+    theme === "light"
+      ? longRunning
+        ? "border-amber-300 bg-amber-50 text-amber-950"
+        : "border-stone-200 bg-stone-50 text-stone-900"
+      : longRunning
+        ? "border-amber-900/70 bg-amber-950/40 text-amber-50"
+        : "border-stone-700 bg-[#252526] text-stone-100";
+  const mutedClass = theme === "light" ? "text-stone-600" : "text-stone-300";
+  const codeClass = theme === "light" ? "bg-white text-stone-950" : "bg-[#1e1e1e] text-stone-100";
+
+  return (
+    <div className={`grid gap-3 border-b px-4 py-3 text-sm ${panelClass}`}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="grid min-w-0 gap-1">
+          <div className="flex flex-wrap items-center gap-2 font-semibold">
+            <Clock className="h-4 w-4" />
+            <span>AI command running</span>
+            <span className={`rounded-full px-2 py-0.5 text-xs ${theme === "light" ? "bg-stone-200 text-stone-700" : "bg-stone-800 text-stone-200"}`}>
+              {formatDuration(ageMs)}
+            </span>
+            {request.token_name ? (
+              <span className={`rounded-full px-2 py-0.5 text-xs ${theme === "light" ? "bg-emerald-100 text-emerald-800" : "bg-emerald-950 text-emerald-100"}`}>
+                {request.token_name}
+              </span>
+            ) : null}
+          </div>
+          <p className={`text-xs ${mutedClass}`}>
+            {longRunning
+              ? "No terminal status has arrived yet. If the console output is not progressing, interrupt the command or restart the persistent session."
+              : "AIPermission is waiting for the command exit marker before marking this request completed."}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant={longRunning ? "danger" : "outline"}
+          className={`h-9 shrink-0 ${theme === "dark" && !longRunning ? "border-stone-600 bg-[#1e1e1e] text-stone-100 hover:bg-stone-800" : ""}`}
+          onClick={onRestart}
+          disabled={action.state === "running"}
+          title="Close the gateway-owned persistent console session and let the next command open a fresh SSH session"
+        >
+          <RefreshCcw className="h-3.5 w-3.5" />
+          {action.state === "running" ? "Restarting..." : "Restart Session"}
+        </Button>
+      </div>
+      <pre className={`max-h-20 overflow-auto rounded-md px-3 py-2 font-mono text-xs ${codeClass}`}>{request.command}</pre>
+      {request.reason ? <p className={`text-xs ${mutedClass}`}>Reason: {request.reason}</p> : null}
+      {action.error ? <Notice tone="bad">{action.error}</Notice> : null}
+    </div>
+  );
+}
+
+function parseTimestamp(value) {
+  const parsed = Date.parse(value || "");
+  return Number.isNaN(parsed) ? Date.now() : parsed;
+}
+
+function formatDuration(ms) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
 }
 
 function selectedServerStatus({ session, pendingCount = 0, runningCount = 0 }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
     },
     "frontend": {
       "name": "aipermission-frontend",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@xterm/addon-fit": "^0.11.0",
@@ -1294,7 +1294,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -102,7 +102,7 @@ These instructions teach the agent how to poll `approval_pending` and `running` 
 
 ## Security Boundary
 
-This package talks to a local AIPermission gateway. `AIPERMISSION_API_URL` must point to `localhost`, `127.0.0.1`, or `[::1]`; remote URLs are rejected before the bearer token is sent. Do not expose the gateway on LAN or the public internet, and do not use it as a shared DevOps service. Tokens grant access only to the servers and execution rules configured in the gateway UI. Token/server permissions may be temporary; expired grants are omitted from `list_servers` and no longer authorize command, console, or file-transfer tools.
+This package talks to a local AIPermission gateway. `AIPERMISSION_API_URL` must point to `localhost`, `127.0.0.1`, or `[::1]`; remote URLs are rejected before the bearer token is sent. Do not expose the gateway on LAN or the public internet, and do not use it as a shared DevOps service. Tokens grant access only to the servers and execution rules configured in the gateway UI. Token/server permissions may be temporary; expired grants are omitted from `list_servers` and no longer authorize command, console, or file-transfer tools. `list_servers` is permission-scoped, not a live SSH health check; use its last-known console status as context and treat `exec` connection errors as the current reachability signal.
 
 ## License
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -98,7 +98,7 @@ Supported clients:
 - `gemini`: `GEMINI.md`
 - `custom`: prints portable Markdown to stdout
 
-These instructions teach the agent how to poll `approval_pending` and `running` requests, handle `stale` approvals by sending a fresh request, read live console output, write short reasons, use explicit file transfer paths, and avoid printing secrets. The default installer uses the operator instruction bundled in the npm package; `--source` accepts local file paths only and rejects HTTP(S) sources.
+These instructions teach the agent how to poll `approval_pending` and `running` requests, handle `stale` approvals by sending a fresh request, read live console output, recover stuck persistent console sessions with `restart_console_session`, write short reasons, use explicit file transfer paths, and avoid printing secrets. The default installer uses the operator instruction bundled in the npm package; `--source` accepts local file paths only and rejects HTTP(S) sources.
 
 ## Security Boundary
 

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "MIT",

--- a/packages/mcp/resources/aipermission-operator/SKILL.md
+++ b/packages/mcp/resources/aipermission-operator/SKILL.md
@@ -83,11 +83,12 @@ When `exec` or `get_request` returns `running`:
 4. Do not start another long-running command on the same server until the active request reaches a terminal status, unless the user explicitly asks.
 
 If the request appears stuck for an unusually long time and `read_console`
-shows no useful progress, ask the operator before recovery. When the operator
-agrees, call `restart_console_session(server_id)`. This closes the
-gateway-owned persistent console session and the next `exec` opens a fresh SSH
-session. Treat any canceled request as inconclusive and re-run only the minimal
-safe inspection needed.
+shows no useful progress, ask the operator before recovery unless they already
+asked you to recover the session. When recovery is approved, call
+`restart_console_session(server_id)`. This does not intentionally run a remote
+shell command; it closes the gateway-owned persistent console session and the
+next `exec` opens a fresh SSH session. Treat any canceled request as
+inconclusive and re-run only the minimal safe inspection needed.
 
 ## Message Flow
 

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- add Console recovery controls for long-running or stuck MCP commands
- document the recovery flow for operators and MCP clients
- compact the active-command UI into a thin amber execution bar
- expose last-known console status in MCP `list_servers` so agents do not treat permission visibility as a live SSH health check

## Verification

- `make test`
- `make build`
- `make audit`
- local Docker Compose redeploy
- MCP smoke: `list_servers` reports `live_console_status`; exec opens a fresh session and updates status to `connected`
