### PR TITLE
Keep MCP server list permission scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ and this project uses semantic versioning once public releases begin.
 
 - Hide internal persistent-console prelude lines from the live console and MCP
   command output when a PTY echoes setup commands.
-- MCP `list_servers` now includes last-known console status and error context
-  so agents do not confuse permission visibility with a live SSH health check.
+- MCP server-list hints now clarify that `list_servers` is permission-scoped;
+  agents should rely on `exec` dial, timeout, SSH authentication, and host-key
+  errors for current reachability.
 
 ## [0.1.9] - 2026-06-07
 

--- a/backend/internal/api/mcp.go
+++ b/backend/internal/api/mcp.go
@@ -28,11 +28,6 @@ func (s mcpHandlers) mcpListServers(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w)
 		return
 	}
-	consoleStates, err := mcpLatestConsoleStates(r.Context(), auth.runtime)
-	if err != nil {
-		writeInternalError(w)
-		return
-	}
 
 	rows, err := auth.runtime.database.QueryContext(r.Context(), `
 		SELECT srv.id, srv.name, srv.description, srv.host, srv.port, srv.username, p.execution_rule, COALESCE(p.expires_at, '')
@@ -63,11 +58,6 @@ func (s mcpHandlers) mcpListServers(w http.ResponseWriter, r *http.Request) {
 			item.Port = 0
 			item.Username = ""
 		}
-		item.LiveConsoleStatus = "none"
-		if state, ok := consoleStates[item.ID]; ok {
-			item.LiveConsoleStatus = state.Status
-			item.LastConsoleError = state.Error
-		}
 		item.Hints = mcpServerHints(item.ExecutionRule)
 		items = append(items, item)
 	}
@@ -77,39 +67,6 @@ func (s mcpHandlers) mcpListServers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, items)
-}
-
-type mcpConsoleState struct {
-	Status string
-	Error  string
-}
-
-func mcpLatestConsoleStates(ctx context.Context, runtime *databaseRuntime) (map[int64]mcpConsoleState, error) {
-	rows, err := runtime.database.QueryContext(ctx, `
-		SELECT server_id, status, error
-		FROM console_sessions
-		ORDER BY CASE WHEN status IN ('connecting', 'connected') THEN 0 ELSE 1 END, updated_at DESC, created_at DESC, id DESC`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	states := map[int64]mcpConsoleState{}
-	for rows.Next() {
-		var serverID int64
-		var state mcpConsoleState
-		if err := rows.Scan(&serverID, &state.Status, &state.Error); err != nil {
-			return nil, err
-		}
-		if _, exists := states[serverID]; exists {
-			continue
-		}
-		states[serverID] = state
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return states, nil
 }
 
 func (s mcpHandlers) mcpExec(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/api/mcp_test.go
+++ b/backend/internal/api/mcp_test.go
@@ -207,35 +207,11 @@ func TestMCPListServersUsesTokenPermissionsAndHidesBlocked(t *testing.T) {
 	if items[0].Host != "" || items[0].Port != 0 || items[0].Username != "" {
 		t.Fatalf("endpoint metadata should be hidden by default: %#v", items[0])
 	}
-	if items[0].LiveConsoleStatus != "none" || items[0].LastConsoleError != "" {
-		t.Fatalf("expected no live console context by default: %#v", items[0])
-	}
 	if len(items[0].Hints) == 0 || !strings.Contains(strings.Join(items[0].Hints, " "), "hash -r") {
 		t.Fatalf("expected command hygiene hints in mcp server list: %#v", items[0].Hints)
 	}
 	if !strings.Contains(strings.Join(items[0].Hints, " "), "permission-scoped") {
 		t.Fatalf("expected permission-scoped health hint in mcp server list: %#v", items[0].Hints)
-	}
-	now := time.Now().UTC().Format(time.RFC3339)
-	if _, err := fixture.db.ExecContext(ctx, `
-		INSERT INTO console_sessions (server_id, name, status, transcript, error, cols, rows, created_at, updated_at)
-		VALUES (?, 'failed-ssh', 'error', '', 'dial tcp 203.0.113.10:22: i/o timeout', 120, 32, ?, ?)`,
-		allowed.ID,
-		now,
-		now,
-	); err != nil {
-		t.Fatalf("insert console context: %v", err)
-	}
-	response = performJSON(fixture.server.Handler(), http.MethodGet, "/api/mcp/servers", token.TokenValue, nil)
-	if response.Code != http.StatusOK {
-		t.Fatalf("expected 200 after console context, got %d: %s", response.Code, response.Body.String())
-	}
-	items = nil
-	if err := json.Unmarshal(response.Body.Bytes(), &items); err != nil {
-		t.Fatalf("decode console context response: %v", err)
-	}
-	if len(items) != 1 || items[0].LiveConsoleStatus != "error" || !strings.Contains(items[0].LastConsoleError, "i/o timeout") {
-		t.Fatalf("expected last known console error context: %#v", items)
 	}
 	expiredResponse := performJSON(fixture.server.Handler(), http.MethodPost, "/api/mcp/exec", token.TokenValue, map[string]any{
 		"server_id": expired.ID,

--- a/backend/internal/api/mcp_types.go
+++ b/backend/internal/api/mcp_types.go
@@ -18,17 +18,15 @@ type mcpAuthContext struct {
 }
 
 type mcpServerItem struct {
-	ID                int64    `json:"id"`
-	Name              string   `json:"name"`
-	Description       string   `json:"description,omitempty"`
-	Host              string   `json:"host,omitempty"`
-	Port              int      `json:"port,omitempty"`
-	Username          string   `json:"username,omitempty"`
-	ExecutionRule     string   `json:"execution_rule"`
-	ExpiresAt         string   `json:"expires_at,omitempty"`
-	LiveConsoleStatus string   `json:"live_console_status"`
-	LastConsoleError  string   `json:"last_console_error,omitempty"`
-	Hints             []string `json:"hints"`
+	ID            int64    `json:"id"`
+	Name          string   `json:"name"`
+	Description   string   `json:"description,omitempty"`
+	Host          string   `json:"host,omitempty"`
+	Port          int      `json:"port,omitempty"`
+	Username      string   `json:"username,omitempty"`
+	ExecutionRule string   `json:"execution_rule"`
+	ExpiresAt     string   `json:"expires_at,omitempty"`
+	Hints         []string `json:"hints"`
 }
 
 type mcpExecRequest struct {
@@ -109,7 +107,7 @@ type historyLabelRecord struct {
 
 func mcpServerHints(executionRule string) []string {
 	hints := []string{
-		"list_servers is permission-scoped, not a live SSH health check; use live_console_status as last-known context and treat exec dial/timeout errors as reachability failures.",
+		"list_servers is permission-scoped, not a live SSH health check; treat exec dial, timeout, SSH authentication, and host key errors as the current reachability signal.",
 		"Use a short reason when calling exec so the operator can approve or audit the command.",
 		"For install/uninstall verification in the same shell, run 'hash -r 2>/dev/null || true' before checking command -v.",
 		"On Debian/Ubuntu, dpkg -l can show removed packages as rc; use dpkg-query installed state 'ii' to verify packages are installed.",

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -50,7 +50,6 @@ Example response:
     "description": "Kubernetes control-plane maintenance access.",
     "execution_rule": "approval_required",
     "expires_at": "2026-06-07T14:00:00Z",
-    "live_console_status": "connected",
     "hints": [
       "Use non-interactive apt commands.",
       "Prefer journalctl --no-pager for service logs."
@@ -60,16 +59,13 @@ Example response:
 ```
 
 By default, `list_servers` hides endpoint metadata and returns only `id`,
-`name`, `description`, `execution_rule`, optional `expires_at`,
-`live_console_status`, optional `last_console_error`, and `hints`. Security can
-enable **Expose endpoint metadata to MCP** if an operator wants MCP clients to
-also receive `host`, `port`, and `username`.
+`name`, `description`, `execution_rule`, optional `expires_at`, and `hints`.
+Security can enable **Expose endpoint metadata to MCP** if an operator wants MCP
+clients to also receive `host`, `port`, and `username`.
 
-`live_console_status` is last-known console context, not a fresh SSH health
-check. It can be `none`, `connecting`, `connected`, `closed`, or `error`.
-`last_console_error` appears when the latest console session for that server
-ended with an error. Agents should still treat `exec` dial, timeout, and SSH
-errors as the current reachability signal.
+`list_servers` is permission-scoped, not a live SSH health check. Agents should
+try `exec` when they need to use a server and treat dial, timeout, SSH
+authentication, and host-key errors as the current reachability signal.
 
 `expires_at` appears when the token/server permission is temporary. Expired
 permissions are omitted from `list_servers` and do not authorize `exec`,

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -17,7 +17,7 @@ export const changelogEntries = [
         title: "Fixed",
         items: [
           "Internal persistent-console prelude lines are hidden from the live console and MCP command output.",
-          "MCP list_servers includes last-known console status so agents do not treat permission visibility as a live SSH health check.",
+          "MCP server-list hints clarify that agents should use exec connection errors as the current reachability signal.",
         ],
       },
     ],

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -102,7 +102,7 @@ These instructions teach the agent how to poll `approval_pending` and `running` 
 
 ## Security Boundary
 
-This package talks to a local AIPermission gateway. `AIPERMISSION_API_URL` must point to `localhost`, `127.0.0.1`, or `[::1]`; remote URLs are rejected before the bearer token is sent. Do not expose the gateway on LAN or the public internet, and do not use it as a shared DevOps service. Tokens grant access only to the servers and execution rules configured in the gateway UI. Token/server permissions may be temporary; expired grants are omitted from `list_servers` and no longer authorize command, console, or file-transfer tools. `list_servers` is permission-scoped, not a live SSH health check; use its last-known console status as context and treat `exec` connection errors as the current reachability signal.
+This package talks to a local AIPermission gateway. `AIPERMISSION_API_URL` must point to `localhost`, `127.0.0.1`, or `[::1]`; remote URLs are rejected before the bearer token is sent. Do not expose the gateway on LAN or the public internet, and do not use it as a shared DevOps service. Tokens grant access only to the servers and execution rules configured in the gateway UI. Token/server permissions may be temporary; expired grants are omitted from `list_servers` and no longer authorize command, console, or file-transfer tools. `list_servers` is permission-scoped, not a live SSH health check; treat `exec` connection errors as the current reachability signal.
 
 ## License
 


### PR DESCRIPTION
## Summary

- keep MCP `list_servers` strictly permission-scoped
- remove last-known console status/error from the server list response to avoid stale reachability signals
- clarify docs and hints that current reachability comes from `exec` dial, timeout, SSH auth, and host-key errors

## Verification

- `cd backend && go test ./internal/api`
- `cd frontend && npm test && npm run build`
- `git diff --check`
- local Docker Compose smoke: `list_servers` returns no status; closed server `exec` returns a clear SSH dial timeout
