### PR TITLE
Release 0.1.11

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto
+
+*.sh text eol=lf
+Dockerfile text eol=lf
+*.Dockerfile text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.mp4 binary
+*.zip binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.25.11"
+          go-version: "1.26.4"
           cache-dependency-path: backend/go.sum
       - name: Test
         working-directory: backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install
         working-directory: frontend
-        run: npm ci
+        run: npm ci --workspaces=false
       - name: Test
         working-directory: frontend
         run: npm test
@@ -83,7 +83,7 @@ jobs:
           cache-dependency-path: packages/mcp/package-lock.json
       - name: Install
         working-directory: packages/mcp
-        run: npm ci
+        run: npm ci --workspaces=false
       - name: Test
         working-directory: packages/mcp
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           node-version: 24
       - name: Secret scan
         run: node scripts/secret-scan.js
+      - name: Line ending check
+        run: node scripts/line-ending-check.js
 
   backend:
     name: Backend

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         if: matrix.language == 'go'
         with:
-          go-version: "1.25.11"
+          go-version: "1.26.4"
           cache-dependency-path: backend/go.sum
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project uses semantic versioning once public releases begin.
   commands.
 - SSH command execution, Docker checks, and connection tests now share clearer
   timeout, connection refused, authentication, and host-key error messages.
+- Approval Run now checks SSH session readiness before closing the prompt, so
+  unreachable/offline targets surface a readable terminal error immediately.
 - Basic redaction no longer masks normal shell `PWD=/path` output while still
   masking lowercase `pwd=...`, password, token, API key, bearer token, and
   private-key patterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.1.11] - 2026-06-08
+
+### Added
+
+- Servers can now store optional advanced SSH startup settings for NAS and
+  appliance targets that show an interactive menu before a normal shell.
+- Advanced startup settings support post-connect input, such as `q\n` for some
+  QNAP menus, and an optional forced shell command for compatibility targets.
+
+### Changed
+
+- Updated the Go toolchain/Docker builder image, frontend dependencies, and the
+  SFTP dependency after local test verification.
+
+### Fixed
+
+- Windows checkouts now preserve LF line endings for Docker shell scripts, with
+  a hygiene check to catch CRLF entrypoint regressions.
+- Console recovery banners now distinguish manual console commands from MCP/AI
+  commands.
+- SSH command execution, Docker checks, and connection tests now share clearer
+  timeout, connection refused, authentication, and host-key error messages.
+- Basic redaction no longer masks normal shell `PWD=/path` output while still
+  masking lowercase `pwd=...`, password, token, API key, bearer token, and
+  private-key patterns.
+- README and operator instructions now clarify that `list_servers` is
+  permission-scoped and not a live SSH health check.
+
 ## [0.1.10] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -286,6 +286,11 @@ list_requests(status?)
 send_message(message, server_id?, session_id?)
 ```
 
+`list_servers` is permission-scoped, not a live SSH health check. It tells the
+agent which servers the token may try to use. Current reachability is learned
+when the gateway actually attempts SSH and returns a dial, timeout,
+authentication, or host-key error.
+
 If a command returns `approval_pending`, the response includes an `assistant_hint` telling the AI to poll `get_request` until the request reaches a terminal state.
 
 Pending command approvals store an approval-context snapshot. If the token

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Implemented:
 - SSH host import from OpenSSH config files for prefilling server records
 - copy/paste public key install command for servers
 - server management and SSH connection test
+- optional advanced SSH startup settings for menu-based NAS/appliance shells
 - API token create, copy, revoke
 - token expiration for temporary MCP access
 - token-to-server permissions with optional temporary expiration

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ Start the gateway:
 docker compose up -d --build
 ```
 
+On Windows, clone the repository with Git's default text handling or make sure
+shell scripts keep LF line endings. The repository includes `.gitattributes` and
+a CI check for this because Docker Linux containers cannot run CRLF shell
+entrypoints.
+
 Open the UI:
 
 ```txt

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11-bookworm@sha256:a1ae6b6c564f3e0072d70081036827a2705dbcf6b38aaa6d97f5de97fe9abdb4 AS build
+FROM golang:1.26.4-bookworm@sha256:5d2b868674b57c9e48cdd39e891acce4196b6926ca6d11e9c270a8f85106203d AS build
 
 WORKDIR /src
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,7 +7,7 @@ toolchain go1.25.11
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/mutecomm/go-sqlcipher/v4 v4.4.2
-	github.com/pkg/sftp v1.13.9
+	github.com/pkg/sftp v1.13.10
 	golang.org/x/crypto v0.52.0
 )
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,7 +2,7 @@ module github.com/aipermission/aipermission/backend
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.26.4
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -10,6 +10,8 @@ github.com/mutecomm/go-sqlcipher/v4 v4.4.2 h1:eM10bFtI4UvibIsKr10/QT7Yfz+NADfjZY
 github.com/mutecomm/go-sqlcipher/v4 v4.4.2/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
 github.com/pkg/sftp v1.13.9 h1:4NGkvGudBL7GteO3m6qnaQ4pC0Kvf0onSVc9gR3EWBw=
 github.com/pkg/sftp v1.13.9/go.mod h1:OBN7bVXdstkFFN/gdnHPUb5TE8eb8G1Rp9wCItqjkkA=
+github.com/pkg/sftp v1.13.10 h1:+5FbKNTe5Z9aspU88DPIKJ9z2KZoaGCu6Sr6kKR/5mU=
+github.com/pkg/sftp v1.13.10/go.mod h1:bJ1a7uDhrX/4OII+agvy28lzRvQrmIQuaHrcI1HbeGA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/backend/internal/api/approval_context.go
+++ b/backend/internal/api/approval_context.go
@@ -45,16 +45,18 @@ type approvalContextPermission struct {
 }
 
 type approvalContextServer struct {
-	ID                int64  `json:"id"`
-	Name              string `json:"name"`
-	Host              string `json:"host"`
-	Port              int    `json:"port"`
-	Username          string `json:"username"`
-	Description       string `json:"description,omitempty"`
-	AuthType          string `json:"auth_type"`
-	KeyLabel          string `json:"key_label,omitempty"`
-	SSHKeyID          int64  `json:"ssh_key_id"`
-	SSHKeyFingerprint string `json:"ssh_key_fingerprint,omitempty"`
+	ID                       int64  `json:"id"`
+	Name                     string `json:"name"`
+	Host                     string `json:"host"`
+	Port                     int    `json:"port"`
+	Username                 string `json:"username"`
+	Description              string `json:"description,omitempty"`
+	StartupInputAfterConnect string `json:"startup_input_after_connect,omitempty"`
+	ForceShellCommand        string `json:"force_shell_command,omitempty"`
+	AuthType                 string `json:"auth_type"`
+	KeyLabel                 string `json:"key_label,omitempty"`
+	SSHKeyID                 int64  `json:"ssh_key_id"`
+	SSHKeyFingerprint        string `json:"ssh_key_fingerprint,omitempty"`
 }
 
 type approvalContextCommand struct {
@@ -87,7 +89,9 @@ func (s *Server) readCurrentApprovalContext(ctx context.Context, runtime *databa
 	err := runtime.database.QueryRowContext(ctx, `
 		SELECT tok.id, tok.name, COALESCE(tok.expires_at, ''), COALESCE(tok.revoked_at, ''),
 		       p.execution_rule, COALESCE(p.expires_at, ''),
-		       srv.id, srv.name, srv.host, srv.port, srv.username, srv.description, srv.auth_type, srv.key_label, srv.ssh_key_id,
+		       srv.id, srv.name, srv.host, srv.port, srv.username, srv.description,
+		       srv.startup_input_after_connect, srv.force_shell_command,
+		       srv.auth_type, srv.key_label, srv.ssh_key_id,
 		       COALESCE(k.fingerprint, '')
 		FROM api_tokens tok
 		JOIN token_server_permissions p ON p.token_id = tok.id AND p.server_id = ?
@@ -109,6 +113,8 @@ func (s *Server) readCurrentApprovalContext(ctx context.Context, runtime *databa
 		&snapshot.Server.Port,
 		&snapshot.Server.Username,
 		&snapshot.Server.Description,
+		&snapshot.Server.StartupInputAfterConnect,
+		&snapshot.Server.ForceShellCommand,
 		&snapshot.Server.AuthType,
 		&snapshot.Server.KeyLabel,
 		&snapshot.Server.SSHKeyID,

--- a/backend/internal/api/approvals.go
+++ b/backend/internal/api/approvals.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/aipermission/aipermission/backend/internal/console"
 )
@@ -14,6 +15,7 @@ import (
 const (
 	pendingApprovalAssistantHint = "Wait 3 seconds, then call get_request. Continue polling get_request until terminal status."
 	runningAssistantHint         = "Wait 3 seconds, then call get_request again. Use read_console to inspect live output before sending another command to this server. If the request remains running and the console shows no useful progress, use restart_console_session(server_id) to recover the gateway-owned persistent console session."
+	approvalRunPreflightTimeout  = 15 * time.Second
 
 	commandRequestSourceMCP    = "mcp"
 	commandRequestSourceManual = "manual"
@@ -198,9 +200,36 @@ func (s approvalHandlers) runApproval(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w)
 		return
 	}
+
+	preflightCtx, cancel := context.WithTimeout(context.Background(), approvalRunPreflightTimeout)
+	sessionID, preflightErr := runtime.consoleSessions.EnsureReady(preflightCtx, item.ServerID)
+	cancel()
+	if preflightErr != nil {
+		message := sshCommandFailureMessage(preflightErr)
+		_ = s.finishCommandRequest(context.Background(), runtime, id, "error", sessionID, "", "", 0, message)
+		item.Status = "error"
+		if sessionID > 0 {
+			item.SessionID = int64Ptr(sessionID)
+		}
+		item.Error = message
+		annotateCommandRequestForAssistant(&item)
+		s.writeAudit(r.Context(), runtime, "user", item.TokenID, item.ServerID, "approval.run.error", map[string]any{
+			"request_id": id,
+			"command":    item.Command,
+			"error":      message,
+		})
+		writeJSON(w, http.StatusOK, item)
+		return
+	}
+	if sessionID > 0 {
+		_ = s.setCommandRequestSession(context.Background(), runtime, id, sessionID)
+	}
 	go s.runApprovedCommand(runtime, id, item.ServerID, command)
 
 	item.Status = "running"
+	if sessionID > 0 {
+		item.SessionID = int64Ptr(sessionID)
+	}
 	annotateCommandRequestForAssistant(&item)
 	s.writeAudit(r.Context(), runtime, "user", item.TokenID, item.ServerID, "approval.run", map[string]any{
 		"request_id": id,

--- a/backend/internal/api/mcp_test.go
+++ b/backend/internal/api/mcp_test.go
@@ -289,6 +289,55 @@ func TestApprovalRunRejectsServerContextDriftBeforeExecution(t *testing.T) {
 	}
 }
 
+func TestApprovalRunReturnsConnectionFailure(t *testing.T) {
+	fixture := newAPITestFixture(t)
+	ctx := context.Background()
+	token, err := fixture.tokens.Create(ctx, tokens.CreateRequest{Name: "agent"})
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	server := fixture.createKeyAndServer(t, "offline")
+	server, err = fixture.servers.Update(ctx, server.ID, servers.UpdateRequest{
+		Name:        server.Name,
+		Host:        "127.0.0.1",
+		Port:        1,
+		Username:    server.Username,
+		SSHKeyID:    server.SSHKeyID,
+		Description: server.Description,
+	})
+	if err != nil {
+		t.Fatalf("update server port: %v", err)
+	}
+	if _, err := fixture.tokens.UpdatePermissions(ctx, token.ID, tokens.UpdatePermissionsRequest{Permissions: []tokens.PermissionInput{
+		{ServerID: server.ID, ExecutionRule: tokens.RuleApprovalRequired},
+	}}); err != nil {
+		t.Fatalf("update permissions: %v", err)
+	}
+
+	runtime := fixture.server.activeRuntime()
+	id, err := fixture.server.insertCommandRequest(ctx, runtime, token.ID, server.ID, "hostname", "check host", "pending_approval")
+	if err != nil {
+		t.Fatalf("insert command request: %v", err)
+	}
+
+	response := performJSON(fixture.server.Handler(), http.MethodPost, "/api/approvals/"+strconv.FormatInt(id, 10)+"/run", "", map[string]any{})
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected approval run response, got %d: %s", response.Code, response.Body.String())
+	}
+	item := decodeRouteResponse[commandRequestRecord](t, response.Body.Bytes())
+	if item.Status != "error" || !strings.Contains(item.Error, "command execution failed") {
+		t.Fatalf("expected connection failure item, got %#v", item)
+	}
+	var status string
+	var errorText string
+	if err := fixture.db.QueryRowContext(ctx, `SELECT status, error FROM command_requests WHERE id = ?`, id).Scan(&status, &errorText); err != nil {
+		t.Fatalf("read request state: %v", err)
+	}
+	if status != "error" || !strings.Contains(errorText, "command execution failed") {
+		t.Fatalf("expected persisted error, status=%q error=%q", status, errorText)
+	}
+}
+
 func TestApprovalContextDetectsPermissionDrift(t *testing.T) {
 	fixture := newAPITestFixture(t)
 	ctx := context.Background()

--- a/backend/internal/api/redaction.go
+++ b/backend/internal/api/redaction.go
@@ -9,7 +9,7 @@ import (
 var (
 	privateKeyBlockPattern = regexp.MustCompile(`(?is)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
 	bearerTokenPattern     = regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+`)
-	namedSecretPattern     = regexp.MustCompile(`(?i)\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|private[_-]?key)\b(\s*[:=]\s*)(['"]?)[^\s'"]+`)
+	namedSecretPattern     = regexp.MustCompile(`(?i)\b(password|passwd|pwd|token|api[_-]?key|secret|access[_-]?key|private[_-]?key)\b(\s*[:=]\s*)(['"]?)([^\s'"]+)`)
 	commonTokenPattern     = regexp.MustCompile(`\b(ghp|gho|ghu|ghs|github_pat|sk|xoxb|xoxp|xapp|ya29)[A-Za-z0-9_./=-]{16,}\b`)
 )
 
@@ -54,6 +54,9 @@ func redactBasic(value string) string {
 		parts := namedSecretPattern.FindStringSubmatch(match)
 		if len(parts) < 4 {
 			return "[REDACTED]"
+		}
+		if parts[1] == "PWD" && len(parts) >= 5 && strings.HasPrefix(parts[4], "/") {
+			return match
 		}
 		return parts[1] + parts[2] + parts[3] + "[REDACTED]"
 	})

--- a/backend/internal/api/redaction_test.go
+++ b/backend/internal/api/redaction_test.go
@@ -27,6 +27,18 @@ func TestRedactBasicMasksCommonSecretShapes(t *testing.T) {
 	}
 }
 
+func TestRedactBasicKeepsShellPWDOutput(t *testing.T) {
+	output := redactBasic("PWD=/home/hakan/workspace\npwd=super-secret\nPASSWORD=another-secret")
+	if !strings.Contains(output, "PWD=/home/hakan/workspace") {
+		t.Fatalf("shell PWD output should not be redacted: %s", output)
+	}
+	for _, secret := range []string{"super-secret", "another-secret"} {
+		if strings.Contains(output, secret) {
+			t.Fatalf("secret %q was not redacted: %s", secret, output)
+		}
+	}
+}
+
 func TestCustomRedactionRulesApplyOnlyInBasicMode(t *testing.T) {
 	fixture := newAPITestFixture(t)
 	runtime := fixture.server.activeRuntime()

--- a/backend/internal/api/server_connection_handlers.go
+++ b/backend/internal/api/server_connection_handlers.go
@@ -228,33 +228,33 @@ func (s *Server) serverSSHMaterial(ctx context.Context, serverID int64) (servers
 }
 
 func sshConnectionFailureMessage(err error) string {
-	detail := safeSSHErrorDetail(err)
-	switch {
-	case detail == "":
-		return "server connection test failed"
-	case strings.Contains(detail, "unable to authenticate") || strings.Contains(detail, "no supported methods remain") || strings.Contains(detail, "permission denied"):
-		return "server connection test failed: authentication failed. Install the selected SSH public key on the server, then try again."
-	case strings.Contains(detail, "connection refused"):
-		return "server connection test failed: SSH port refused the connection. Check the host, port, and SSH service."
-	case strings.Contains(detail, "i/o timeout") || strings.Contains(detail, "timed out") || strings.Contains(detail, "deadline exceeded"):
-		return "server connection test failed: SSH connection timed out. Check network access, firewall rules, host, and port."
-	case strings.Contains(detail, "no route to host") || strings.Contains(detail, "network is unreachable"):
-		return "server connection test failed: the host is not reachable from the local gateway."
-	case strings.Contains(detail, "host key"):
-		return "server connection test failed: SSH host key verification failed."
-	case strings.Contains(detail, "parse private key"):
-		return "server connection test failed: selected SSH key could not be parsed."
-	default:
-		return "server connection test failed: " + detail
-	}
+	return sshFailureMessage("server connection test failed", err)
 }
 
 func sshCommandFailureMessage(err error) string {
+	return sshFailureMessage("command execution failed", err)
+}
+
+func sshFailureMessage(prefix string, err error) string {
 	detail := safeSSHErrorDetail(err)
-	if detail == "" {
-		return "command execution failed"
+	switch {
+	case detail == "":
+		return prefix
+	case strings.Contains(detail, "unable to authenticate") || strings.Contains(detail, "no supported methods remain") || strings.Contains(detail, "permission denied"):
+		return prefix + ": SSH authentication failed. Install the selected SSH public key on the server, then try again."
+	case strings.Contains(detail, "connection refused"):
+		return prefix + ": SSH port refused the connection. Check the host, port, and SSH service."
+	case strings.Contains(detail, "i/o timeout") || strings.Contains(detail, "timed out") || strings.Contains(detail, "deadline exceeded"):
+		return prefix + ": SSH connection timed out. Check network access, firewall rules, host, and port."
+	case strings.Contains(detail, "no route to host") || strings.Contains(detail, "network is unreachable"):
+		return prefix + ": the host is not reachable from the local gateway."
+	case strings.Contains(detail, "host key"):
+		return prefix + ": SSH host key verification failed."
+	case strings.Contains(detail, "parse private key"):
+		return prefix + ": selected SSH key could not be parsed."
+	default:
+		return prefix + ": " + detail
 	}
-	return "command execution failed: " + detail
 }
 
 func safeSSHErrorDetail(err error) string {

--- a/backend/internal/api/server_connection_handlers.go
+++ b/backend/internal/api/server_connection_handlers.go
@@ -24,12 +24,14 @@ type serverTestResponse struct {
 }
 
 type serverConnectionTestRequest struct {
-	Name        string `json:"name"`
-	Host        string `json:"host"`
-	Port        int    `json:"port"`
-	Username    string `json:"username"`
-	SSHKeyID    int64  `json:"ssh_key_id"`
-	Description string `json:"description"`
+	Name                     string `json:"name"`
+	Host                     string `json:"host"`
+	Port                     int    `json:"port"`
+	Username                 string `json:"username"`
+	SSHKeyID                 int64  `json:"ssh_key_id"`
+	Description              string `json:"description"`
+	StartupInputAfterConnect string `json:"startup_input_after_connect"`
+	ForceShellCommand        string `json:"force_shell_command"`
 }
 
 func (s serverConnectionHandlers) testServer(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/api/server_connection_handlers_test.go
+++ b/backend/internal/api/server_connection_handlers_test.go
@@ -15,7 +15,7 @@ func TestSSHConnectionFailureMessageClassifiesCommonFailures(t *testing.T) {
 		{
 			name: "auth failure",
 			err:  errors.New("ssh dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"),
-			want: "authentication failed",
+			want: "SSH authentication failed",
 		},
 		{
 			name: "connection refused",
@@ -44,6 +44,16 @@ func TestSSHConnectionFailureMessageClassifiesCommonFailures(t *testing.T) {
 			got := sshConnectionFailureMessage(test.err)
 			if !strings.Contains(got, test.want) {
 				t.Fatalf("message %q does not contain %q", got, test.want)
+			}
+			if !strings.HasPrefix(got, "server connection test failed:") {
+				t.Fatalf("connection test message should keep endpoint prefix, got %q", got)
+			}
+			commandMessage := sshCommandFailureMessage(test.err)
+			if !strings.Contains(commandMessage, test.want) {
+				t.Fatalf("command message %q does not contain %q", commandMessage, test.want)
+			}
+			if !strings.HasPrefix(commandMessage, "command execution failed:") {
+				t.Fatalf("command message should keep exec prefix, got %q", commandMessage)
 			}
 		})
 	}

--- a/backend/internal/console/console_session_manager.go
+++ b/backend/internal/console/console_session_manager.go
@@ -219,6 +219,29 @@ func (m *Manager) Exec(ctx context.Context, serverID int64, command string) (Exe
 	return session.execCommand(ctx, command)
 }
 
+func (m *Manager) EnsureReady(ctx context.Context, serverID int64) (int64, error) {
+	session := m.activeForServer(serverID)
+	if session == nil {
+		record, err := m.Create(ctx, CreateRequest{
+			ServerID: serverID,
+			Name:     fmt.Sprintf("server-%d ai session", serverID),
+			Cols:     120,
+			Rows:     32,
+		})
+		if err != nil {
+			return 0, err
+		}
+		session = m.active(record.ID)
+	}
+	if session == nil {
+		return 0, fmt.Errorf("console session did not start")
+	}
+	if err := session.waitReady(ctx); err != nil {
+		return session.id, err
+	}
+	return session.id, nil
+}
+
 func (m *Manager) WaitActive(ctx context.Context, serverID int64) (ExecResult, error) {
 	session := m.activeForServer(serverID)
 	if session == nil {

--- a/backend/internal/console/console_session_runtime.go
+++ b/backend/internal/console/console_session_runtime.go
@@ -95,13 +95,25 @@ func (s *managedConsoleSession) run() {
 		s.fail(fmt.Sprintf("request pty: %v", err))
 		return
 	}
-	if err := sshSession.Shell(); err != nil {
+	if server.ForceShellCommand != "" {
+		if err := sshSession.Start(server.ForceShellCommand); err != nil {
+			s.fail(fmt.Sprintf("start forced shell command: %v", err))
+			return
+		}
+	} else if err := sshSession.Shell(); err != nil {
 		s.fail(fmt.Sprintf("start shell: %v", err))
 		return
 	}
 
 	s.setStatus("connected", "")
 	s.broadcast(ptyServerMessage{Type: "ready", Status: "connected", SessionID: s.id})
+
+	if server.StartupInputAfterConnect != "" {
+		if _, err := io.WriteString(stdin, server.StartupInputAfterConnect); err != nil {
+			s.fail(fmt.Sprintf("write startup input: %v", err))
+			return
+		}
+	}
 
 	go s.pipe(stdout)
 	go s.pipe(stderr)

--- a/backend/internal/console/console_sessions_test.go
+++ b/backend/internal/console/console_sessions_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	dbpkg "github.com/aipermission/aipermission/backend/internal/db"
+	"github.com/aipermission/aipermission/backend/internal/servers"
+	"github.com/aipermission/aipermission/backend/internal/sshkeys"
 	"github.com/gorilla/websocket"
 )
 
@@ -1137,6 +1139,45 @@ func TestConsoleSessionManagerCreateValidationAndCloseInactive(t *testing.T) {
 	}
 	if err := manager.Close(context.Background(), 999); err != nil {
 		t.Fatalf("closing inactive/missing session should be idempotent: %v", err)
+	}
+}
+
+func TestConsoleSessionManagerEnsureReadyReturnsConnectionError(t *testing.T) {
+	database, err := dbpkg.OpenEncrypted(filepath.Join(t.TempDir(), "console.db"), "ConsolePassword123")
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	now := time.Now().UTC().Format(time.RFC3339)
+	result, err := database.Exec(`
+		INSERT INTO servers (name, host, port, username, ssh_key_id, created_at, updated_at)
+		VALUES ('worker-1', '127.0.0.1', 23, 'root', 1, ?, ?)`,
+		now,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("insert server: %v", err)
+	}
+	serverID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("read server id: %v", err)
+	}
+	manager := NewManager(database, func(context.Context, int64) (servers.Server, sshkeys.PrivateKey, error) {
+		return servers.Server{}, sshkeys.PrivateKey{}, errors.New("ssh dial: dial tcp 127.0.0.1:23: connect: connection refused")
+	}, "", nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	sessionID, err := manager.EnsureReady(ctx, serverID)
+	if err == nil || !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("expected connection error, session=%d err=%v", sessionID, err)
+	}
+	record, recordErr := manager.Get(context.Background(), sessionID)
+	if recordErr != nil {
+		t.Fatalf("read failed session: %v", recordErr)
+	}
+	if record.Status != "error" || !strings.Contains(record.Error, "connection refused") {
+		t.Fatalf("expected failed session record, got %#v", record)
 	}
 }
 

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -11,7 +11,7 @@ import (
 	_ "github.com/mutecomm/go-sqlcipher/v4"
 )
 
-const currentSchemaVersion = 9
+const currentSchemaVersion = 10
 
 func OpenEncrypted(path string, password string) (*sql.DB, error) {
 	return openEncrypted(path, password, true)

--- a/backend/internal/db/migrations.go
+++ b/backend/internal/db/migrations.go
@@ -446,6 +446,11 @@ var approvalContextStatements = []string{
 	`CREATE INDEX IF NOT EXISTS idx_command_requests_approval_context_hash ON command_requests(approval_context_hash);`,
 }
 
+var serverSSHAdvancedSettingsStatements = []string{
+	`ALTER TABLE servers ADD COLUMN startup_input_after_connect TEXT NOT NULL DEFAULT '';`,
+	`ALTER TABLE servers ADD COLUMN force_shell_command TEXT NOT NULL DEFAULT '';`,
+}
+
 var migrations = []migration{
 	{
 		version:     1,
@@ -491,6 +496,11 @@ var migrations = []migration{
 		version:     9,
 		description: "approval context snapshots",
 		statements:  approvalContextStatements,
+	},
+	{
+		version:     10,
+		description: "server ssh advanced startup settings",
+		statements:  serverSSHAdvancedSettingsStatements,
 	},
 }
 

--- a/backend/internal/servers/store.go
+++ b/backend/internal/servers/store.go
@@ -11,25 +11,29 @@ import (
 )
 
 type Server struct {
-	ID          int64  `json:"id"`
-	Name        string `json:"name"`
-	Host        string `json:"host"`
-	Port        int    `json:"port"`
-	Username    string `json:"username"`
-	SSHKeyID    int64  `json:"ssh_key_id"`
-	SSHKeyName  string `json:"ssh_key_name,omitempty"`
-	Description string `json:"description"`
-	CreatedAt   string `json:"created_at"`
-	UpdatedAt   string `json:"updated_at"`
+	ID                       int64  `json:"id"`
+	Name                     string `json:"name"`
+	Host                     string `json:"host"`
+	Port                     int    `json:"port"`
+	Username                 string `json:"username"`
+	SSHKeyID                 int64  `json:"ssh_key_id"`
+	SSHKeyName               string `json:"ssh_key_name,omitempty"`
+	Description              string `json:"description"`
+	StartupInputAfterConnect string `json:"startup_input_after_connect,omitempty"`
+	ForceShellCommand        string `json:"force_shell_command,omitempty"`
+	CreatedAt                string `json:"created_at"`
+	UpdatedAt                string `json:"updated_at"`
 }
 
 type CreateRequest struct {
-	Name        string `json:"name"`
-	Host        string `json:"host"`
-	Port        int    `json:"port"`
-	Username    string `json:"username"`
-	SSHKeyID    int64  `json:"ssh_key_id"`
-	Description string `json:"description"`
+	Name                     string `json:"name"`
+	Host                     string `json:"host"`
+	Port                     int    `json:"port"`
+	Username                 string `json:"username"`
+	SSHKeyID                 int64  `json:"ssh_key_id"`
+	Description              string `json:"description"`
+	StartupInputAfterConnect string `json:"startup_input_after_connect"`
+	ForceShellCommand        string `json:"force_shell_command"`
 }
 
 type UpdateRequest = CreateRequest
@@ -43,7 +47,7 @@ func NewStore(db *sql.DB) *Store {
 }
 
 func (s *Store) List(ctx context.Context) ([]Server, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT s.id, s.name, s.host, s.port, s.username, s.ssh_key_id, COALESCE(k.name, ''), s.description, s.created_at, s.updated_at FROM servers s LEFT JOIN ssh_keys k ON k.id = s.ssh_key_id ORDER BY s.name`)
+	rows, err := s.db.QueryContext(ctx, `SELECT s.id, s.name, s.host, s.port, s.username, s.ssh_key_id, COALESCE(k.name, ''), s.description, s.startup_input_after_connect, s.force_shell_command, s.created_at, s.updated_at FROM servers s LEFT JOIN ssh_keys k ON k.id = s.ssh_key_id ORDER BY s.name`)
 	if err != nil {
 		return nil, fmt.Errorf("list servers: %w", err)
 	}
@@ -52,7 +56,7 @@ func (s *Store) List(ctx context.Context) ([]Server, error) {
 	items := []Server{}
 	for rows.Next() {
 		var item Server
-		if err := rows.Scan(&item.ID, &item.Name, &item.Host, &item.Port, &item.Username, &item.SSHKeyID, &item.SSHKeyName, &item.Description, &item.CreatedAt, &item.UpdatedAt); err != nil {
+		if err := rows.Scan(&item.ID, &item.Name, &item.Host, &item.Port, &item.Username, &item.SSHKeyID, &item.SSHKeyName, &item.Description, &item.StartupInputAfterConnect, &item.ForceShellCommand, &item.CreatedAt, &item.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan server: %w", err)
 		}
 		items = append(items, item)
@@ -65,8 +69,8 @@ func (s *Store) List(ctx context.Context) ([]Server, error) {
 
 func (s *Store) Get(ctx context.Context, id int64) (Server, error) {
 	var item Server
-	err := s.db.QueryRowContext(ctx, `SELECT s.id, s.name, s.host, s.port, s.username, s.ssh_key_id, COALESCE(k.name, ''), s.description, s.created_at, s.updated_at FROM servers s LEFT JOIN ssh_keys k ON k.id = s.ssh_key_id WHERE s.id = ?`, id).
-		Scan(&item.ID, &item.Name, &item.Host, &item.Port, &item.Username, &item.SSHKeyID, &item.SSHKeyName, &item.Description, &item.CreatedAt, &item.UpdatedAt)
+	err := s.db.QueryRowContext(ctx, `SELECT s.id, s.name, s.host, s.port, s.username, s.ssh_key_id, COALESCE(k.name, ''), s.description, s.startup_input_after_connect, s.force_shell_command, s.created_at, s.updated_at FROM servers s LEFT JOIN ssh_keys k ON k.id = s.ssh_key_id WHERE s.id = ?`, id).
+		Scan(&item.ID, &item.Name, &item.Host, &item.Port, &item.Username, &item.SSHKeyID, &item.SSHKeyName, &item.Description, &item.StartupInputAfterConnect, &item.ForceShellCommand, &item.CreatedAt, &item.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Server{}, ErrNotFound
 	}
@@ -85,7 +89,7 @@ func (s *Store) Create(ctx context.Context, request CreateRequest) (Server, erro
 	now := time.Now().UTC().Format(time.RFC3339)
 	result, err := s.db.ExecContext(
 		ctx,
-		`INSERT INTO servers (name, host, port, username, ssh_key_id, auth_type, key_label, encrypted_secret, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO servers (name, host, port, username, ssh_key_id, auth_type, key_label, encrypted_secret, description, startup_input_after_connect, force_shell_command, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		normalized.Name,
 		normalized.Host,
 		normalized.Port,
@@ -95,6 +99,8 @@ func (s *Store) Create(ctx context.Context, request CreateRequest) (Server, erro
 		"",
 		"gateway-managed-ssh-key",
 		normalized.Description,
+		normalized.StartupInputAfterConnect,
+		normalized.ForceShellCommand,
 		now,
 		now,
 	)
@@ -121,7 +127,7 @@ func (s *Store) Update(ctx context.Context, id int64, request UpdateRequest) (Se
 	now := time.Now().UTC().Format(time.RFC3339)
 	result, err := s.db.ExecContext(
 		ctx,
-		`UPDATE servers SET name = ?, host = ?, port = ?, username = ?, ssh_key_id = ?, auth_type = ?, key_label = ?, encrypted_secret = ?, description = ?, updated_at = ? WHERE id = ?`,
+		`UPDATE servers SET name = ?, host = ?, port = ?, username = ?, ssh_key_id = ?, auth_type = ?, key_label = ?, encrypted_secret = ?, description = ?, startup_input_after_connect = ?, force_shell_command = ?, updated_at = ? WHERE id = ?`,
 		normalized.Name,
 		normalized.Host,
 		normalized.Port,
@@ -131,6 +137,8 @@ func (s *Store) Update(ctx context.Context, id int64, request UpdateRequest) (Se
 		"",
 		"gateway-managed-ssh-key",
 		normalized.Description,
+		normalized.StartupInputAfterConnect,
+		normalized.ForceShellCommand,
 		now,
 		id,
 	)
@@ -171,6 +179,8 @@ func normalizeRequest(ctx context.Context, db *sql.DB, request CreateRequest) (C
 	request.Host = strings.TrimSpace(request.Host)
 	request.Username = strings.TrimSpace(request.Username)
 	request.Description = strings.TrimSpace(request.Description)
+	request.StartupInputAfterConnect = normalizeStartupInput(request.StartupInputAfterConnect)
+	request.ForceShellCommand = strings.TrimSpace(request.ForceShellCommand)
 
 	if request.Port == 0 {
 		request.Port = 22
@@ -200,6 +210,12 @@ func normalizeRequest(ctx context.Context, db *sql.DB, request CreateRequest) (C
 	if err := validateSingleLineField("description", request.Description, 1000); err != nil {
 		return request, err
 	}
+	if err := validateStartupInput(request.StartupInputAfterConnect); err != nil {
+		return request, err
+	}
+	if err := validateSingleLineField("force_shell_command", request.ForceShellCommand, 200); err != nil {
+		return request, err
+	}
 	if request.SSHKeyID < 1 {
 		return request, ValidationError("ssh_key_id is required")
 	}
@@ -214,6 +230,26 @@ func normalizeRequest(ctx context.Context, db *sql.DB, request CreateRequest) (C
 	}
 
 	return request, nil
+}
+
+func normalizeStartupInput(value string) string {
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	return strings.ReplaceAll(value, "\r", "\n")
+}
+
+func validateStartupInput(value string) error {
+	if len([]byte(value)) > 2000 {
+		return ValidationError("startup_input_after_connect must be 2000 bytes or fewer")
+	}
+	for _, r := range value {
+		if r == '\n' || r == '\t' {
+			continue
+		}
+		if unicode.IsControl(r) {
+			return ValidationError("startup_input_after_connect may only contain printable text, tabs, and newlines")
+		}
+	}
+	return nil
 }
 
 func ValidateHost(host string) error {

--- a/backend/internal/servers/store_test.go
+++ b/backend/internal/servers/store_test.go
@@ -49,11 +49,13 @@ func TestServerStoreCreateListUpdateDelete(t *testing.T) {
 	store := NewStore(database)
 
 	created, err := store.Create(ctx, CreateRequest{
-		Name:        " worker-1 ",
-		Host:        " 10.0.0.10 ",
-		Username:    " root ",
-		SSHKeyID:    keyID,
-		Description: " first server ",
+		Name:                     " worker-1 ",
+		Host:                     " 10.0.0.10 ",
+		Username:                 " root ",
+		SSHKeyID:                 keyID,
+		Description:              " first server ",
+		StartupInputAfterConnect: "q\r\n",
+		ForceShellCommand:        " /bin/sh -l ",
 	})
 	if err != nil {
 		t.Fatalf("create server: %v", err)
@@ -64,20 +66,28 @@ func TestServerStoreCreateListUpdateDelete(t *testing.T) {
 	if created.SSHKeyName != "main" {
 		t.Fatalf("expected ssh key join name, got %q", created.SSHKeyName)
 	}
+	if created.StartupInputAfterConnect != "q\n" || created.ForceShellCommand != "/bin/sh -l" {
+		t.Fatalf("server advanced startup settings were not normalized: %#v", created)
+	}
 
 	updated, err := store.Update(ctx, created.ID, UpdateRequest{
-		Name:        "worker-1b",
-		Host:        "example.test",
-		Port:        2200,
-		Username:    "ubuntu",
-		SSHKeyID:    keyID,
-		Description: "updated",
+		Name:                     "worker-1b",
+		Host:                     "example.test",
+		Port:                     2200,
+		Username:                 "ubuntu",
+		SSHKeyID:                 keyID,
+		Description:              "updated",
+		StartupInputAfterConnect: "menu\nexit\n",
+		ForceShellCommand:        "/usr/bin/env sh",
 	})
 	if err != nil {
 		t.Fatalf("update server: %v", err)
 	}
 	if updated.Name != "worker-1b" || updated.Port != 2200 || updated.Description != "updated" {
 		t.Fatalf("server was not updated: %#v", updated)
+	}
+	if updated.StartupInputAfterConnect != "menu\nexit\n" || updated.ForceShellCommand != "/usr/bin/env sh" {
+		t.Fatalf("server advanced startup settings were not updated: %#v", updated)
 	}
 
 	list, err := store.List(ctx)
@@ -122,6 +132,10 @@ func TestServerStoreValidatesRequests(t *testing.T) {
 		{Name: "server", Host: "host", Port: 22, Username: strings.Repeat("a", 65), SSHKeyID: keyID},
 		{Name: "server", Host: "host", Port: 22, Username: "root", SSHKeyID: keyID, Description: "bad\ndescription"},
 		{Name: "server", Host: "host", Port: 22, Username: "root", SSHKeyID: keyID, Description: strings.Repeat("a", 1001)},
+		{Name: "server", Host: "host", Port: 22, Username: "root", SSHKeyID: keyID, StartupInputAfterConnect: strings.Repeat("a", 2001)},
+		{Name: "server", Host: "host", Port: 22, Username: "root", SSHKeyID: keyID, StartupInputAfterConnect: "bad\x00input"},
+		{Name: "server", Host: "host", Port: 22, Username: "root", SSHKeyID: keyID, ForceShellCommand: "bad\ncommand"},
+		{Name: "server", Host: "host", Port: 22, Username: "root", SSHKeyID: keyID, ForceShellCommand: strings.Repeat("a", 201)},
 		{Name: "server", Host: "host", Port: 22, Username: "root", SSHKeyID: 0},
 		{Name: "server", Host: "host", Port: 22, Username: "root", SSHKeyID: 999},
 	}

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -162,7 +162,12 @@ Example running response:
 }
 ```
 
-`approval_pending` is not terminal. The AI should follow `assistant_hint` and poll `get_request` until the request reaches a terminal status.
+`approval_pending` is not terminal. The AI should follow `assistant_hint` and
+poll `get_request` until the request reaches a terminal status. When the
+operator clicks Run, the gateway first checks that the SSH-backed console
+session can become ready; offline hosts, refused ports, authentication failures,
+and host-key failures become terminal request errors instead of silent approval
+successes.
 
 When a pending approval is created, the gateway records an approval-context
 snapshot covering the token, token/server permission, server profile, SSH key

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -68,9 +68,18 @@ Create/update shape:
   "port": 22,
   "username": "root",
   "ssh_key_id": 7,
-  "description": "maintenance target"
+  "description": "maintenance target",
+  "startup_input_after_connect": "",
+  "force_shell_command": ""
 }
 ```
+
+`startup_input_after_connect` and `force_shell_command` are optional advanced
+SSH compatibility settings. They are intended for appliances that show an
+interactive menu before a normal shell, such as some NAS devices. The startup
+input is written exactly to the PTY after connect. The forced shell command
+starts that command instead of the default SSH shell. Leave both empty for
+normal Linux servers.
 
 Server-specific custom hints are not accepted by the server CRUD API in the current MVP. MCP `list_servers` may still return gateway-generated operational hints, such as safe package verification or bounded log commands.
 

--- a/docs/security/ssh-key-model.md
+++ b/docs/security/ssh-key-model.md
@@ -78,6 +78,13 @@ Responses must not show:
 
 A server record does not contain credentials. It references the gateway key by `ssh_key_id`.
 
+Some SSH targets, especially NAS appliances, show an interactive menu before a
+normal shell. Server records can store optional advanced startup behavior for
+that compatibility case: startup input sent after connect, or a forced shell
+command. These values are not credentials. Keep them empty for normal Linux
+servers and avoid putting secrets in them because console transcripts and audit
+metadata can include shell output.
+
 ## Host Key Verification
 
 Gateway SSH clients use explicit first-connect fingerprint approval:

--- a/docs/setup/docker-runtime.md
+++ b/docs/setup/docker-runtime.md
@@ -8,6 +8,11 @@ The default runtime model for the MVP is local Docker.
 docker compose up
 ```
 
+On Windows, keep shell scripts checked out with LF line endings. Git should do
+this automatically through the repository `.gitattributes` file; if
+`docker compose up -d --build` fails with `exec /entrypoint.sh: no such file or
+directory`, reset the checkout line endings and rebuild the images.
+
 Expected local endpoints:
 
 ```txt

--- a/docs/skills/aipermission-operator/SKILL.md
+++ b/docs/skills/aipermission-operator/SKILL.md
@@ -27,6 +27,11 @@ If no server is visible, say that the current token has no accessible servers.
 If `expires_at` is present, treat access as temporary. Finish within that
 maintenance window or ask the operator to extend access.
 
+`list_servers()` is permission-scoped, not a live health check. A visible server
+may still be powered off, unreachable, reject SSH authentication, or require host
+key review. Treat `exec` dial, timeout, authentication, and host-key errors as
+the current reachability signal.
+
 ## Command Reasons
 
 Every `exec` call should include a short `reason`.

--- a/docs/skills/aipermission-operator/SKILL.md
+++ b/docs/skills/aipermission-operator/SKILL.md
@@ -77,6 +77,9 @@ stale
 
 If the request is `declined`, read `user_note` and follow the user's correction.
 If the request is `stale`, the approval context changed before execution; send a fresh `exec` request with the current command and reason instead of trying to reuse the old approval.
+If the request is `error`, read the error text. SSH reachability, refused ports,
+authentication failures, and host-key failures are current connection signals;
+do not assume a listed server is live just because `list_servers` returned it.
 
 ## Running Flow
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aipermission-frontend",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.5",
         "@xterm/addon-fit": "^0.11.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,24 +8,24 @@
       "name": "aipermission-frontend",
       "version": "0.1.10",
       "dependencies": {
-        "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-slot": "^1.2.5",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.17.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "react-router-dom": "^7.15.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router-dom": "^7.17.0",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/vite": "^4.3.0",
         "@vitejs/plugin-react": "^4.3.4",
         "tailwindcss": "^4.3.0",
         "typescript": "^5.7.2",
-        "vite": "^6.0.7"
+        "vite": "^6.4.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -803,13 +803,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -819,9 +819,9 @@
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -834,12 +834,12 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2284,13 +2284,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2360,24 +2360,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-refresh": {
@@ -2391,9 +2391,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
-      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -2413,12 +2413,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
-      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.15.1"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2599,9 +2599,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,23 +11,23 @@
     "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-slot": "^1.2.5",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.17.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router-dom": "^7.15.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.17.0",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.3.0",
     "@vitejs/plugin-react": "^4.3.4",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.7.2",
-    "vite": "^6.0.7"
+    "vite": "^6.4.3"
   }
 }

--- a/frontend/src/components/console/approval-dialog.jsx
+++ b/frontend/src/components/console/approval-dialog.jsx
@@ -10,6 +10,7 @@ export function ApprovalDialog({ approval, note, action, onNoteChange, onRun, on
   const requestAge = approval ? formatRequestAge(approval.created_at) : "";
   const requestTimestamp = approval?.created_at ? formatRequestTimestamp(approval.created_at) : "";
   const stale = action.state === "stale";
+  const terminalError = action.state === "failed";
   return (
     <Dialog
       open={Boolean(approval)}
@@ -56,8 +57,8 @@ export function ApprovalDialog({ approval, note, action, onNoteChange, onRun, on
                 className="!min-h-16 resize-none"
               />
             </label>
-            {action.state === "error" || stale ? <Notice tone="bad">{action.error}</Notice> : null}
-            {stale ? (
+            {action.state === "error" || stale || terminalError ? <Notice tone="bad">{action.error}</Notice> : null}
+            {stale || terminalError ? (
               <Button type="button" onClick={onClose}>
                 OK
               </Button>

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -118,6 +118,15 @@ test("Servers page exposes on-demand Docker checks", () => {
   assert.match(serversSource, /No running Docker containers/);
 });
 
+test("Servers page exposes advanced SSH startup settings", () => {
+  assert.match(serversSource, /Advanced SSH startup/);
+  assert.match(serversSource, /startup_input_after_connect/);
+  assert.match(serversSource, /force_shell_command/);
+  assert.match(serversSource, /Startup input after connect/);
+  assert.match(serversSource, /Force shell command/);
+  assert.match(serversSource, /QNAP/);
+});
+
 test("Servers page can prefill servers from host config", () => {
   assert.match(serversSource, /\/api\/ssh-config\/discover/);
   assert.match(serversSource, /\/api\/ssh-config\/parse/);

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -96,9 +96,11 @@ test("Approval dialog warns before persisting command context", () => {
   assert.match(approvalDialogSource, /redaction is best-effort/i);
   assert.match(approvalDialogSource, /sent \{requestAge\}/);
   assert.match(approvalDialogSource, /action\.state === "stale"/);
+  assert.match(approvalDialogSource, /action\.state === "failed"/);
   assert.match(approvalDialogSource, /OK/);
   assert.match(consolePageSource, /activeApprovalSnapshot/);
   assert.match(consolePageSource, /isStaleApprovalError/);
+  assert.match(consolePageSource, /item\?\.status === "error"/);
 });
 
 test("Server host key dialog handles first approval and changed fingerprints", () => {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -68,9 +68,9 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.1\.10"/);
-  assert.match(releaseSource, /Approval drift and console recovery/);
-  assert.match(releaseSource, /Persistent console MCP exec is more resilient/);
+  assert.match(releaseSource, /appVersion = "0\.1\.11"/);
+  assert.match(releaseSource, /SSH compatibility polish/);
+  assert.match(releaseSource, /Windows checkouts preserve LF line endings/);
 });
 
 test("Sidebar exposes explicit MCP runtime start and stop controls", () => {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -192,6 +192,7 @@ test("Console exposes stuck command recovery controls", () => {
   assert.match(shellSource, /\/api\/console\/servers\/\$\{serverID\}\/restart/);
   assert.match(consolePageSource, /ConsoleRecoveryPanel/);
   assert.match(consolePageSource, /AI command running/);
+  assert.match(consolePageSource, /Manual command running/);
   assert.match(consolePageSource, /Looks stuck\? Restart opens a fresh SSH session/);
   assert.match(consolePageSource, /commandPreview/);
   assert.match(consolePageSource, /Restart/);

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -18,6 +18,7 @@ export const changelogEntries = [
           "Windows checkouts preserve LF line endings for Docker shell entrypoints.",
           "Console recovery banners distinguish manual commands from MCP/AI commands.",
           "SSH command, Docker check, and connection-test failures now show clearer timeout, refused, auth, and host-key messages.",
+          "Approval Run checks SSH session readiness before closing the prompt.",
           "Basic redaction no longer masks normal shell PWD=/path output.",
         ],
       },

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,28 @@
-export const appVersion = "0.1.10";
+export const appVersion = "0.1.11";
 
 export const changelogEntries = [
+  {
+    version: "0.1.11",
+    label: "SSH compatibility polish",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Servers can store optional advanced SSH startup settings for NAS and appliance targets that show a menu before shell access.",
+          "Advanced startup settings can send post-connect input such as q plus newline, or start a specific shell command when needed.",
+        ],
+      },
+      {
+        title: "Fixed",
+        items: [
+          "Windows checkouts preserve LF line endings for Docker shell entrypoints.",
+          "Console recovery banners distinguish manual commands from MCP/AI commands.",
+          "SSH command, Docker check, and connection-test failures now show clearer timeout, refused, auth, and host-key messages.",
+          "Basic redaction no longer masks normal shell PWD=/path output.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.1.10",
     label: "Console recovery controls",

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -536,12 +536,13 @@ function ConsoleRecoveryPanel({ request, now, theme, action, onRestart }) {
   const panelClass = theme === "light" ? "border-amber-300 bg-amber-50 text-amber-950" : "border-amber-900/70 bg-amber-950/40 text-amber-50";
   const mutedClass = theme === "light" ? "text-amber-900/80" : "text-amber-100/80";
   const commandPreview = firstLine(request.command || "command");
+  const sourceLabel = runningRequestLabel(request);
 
   return (
     <div className={`flex min-h-9 items-center gap-3 border-b px-4 py-2 text-xs ${panelClass}`}>
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <Clock className="h-3.5 w-3.5 shrink-0" />
-        <span className="shrink-0 font-semibold">AI command running</span>
+        <span className="shrink-0 font-semibold">{sourceLabel}</span>
         <span className={`shrink-0 rounded-full px-2 py-0.5 ${theme === "light" ? "bg-stone-200 text-stone-700" : "bg-stone-800 text-stone-200"}`}>
           {formatDuration(ageMs)}
         </span>
@@ -571,6 +572,12 @@ function ConsoleRecoveryPanel({ request, now, theme, action, onRestart }) {
       </Button>
     </div>
   );
+}
+
+function runningRequestLabel(request) {
+  if (request?.source === "manual") return "Manual command running";
+  if (request?.source === "mcp") return "AI command running";
+  return "Command running";
 }
 
 function firstLine(value) {

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -126,7 +126,7 @@ export function ConsolePage() {
   }, [selectedServer?.id, selectedRunningRequest?.id]);
 
   useEffect(() => {
-    if (activeApprovalID && !pendingApprovals.some((approval) => Number(approval.id) === Number(activeApprovalID)) && approvalAction.state !== "error" && approvalAction.state !== "stale") {
+    if (activeApprovalID && !pendingApprovals.some((approval) => Number(approval.id) === Number(activeApprovalID)) && !["error", "failed", "running", "stale"].includes(approvalAction.state)) {
       setActiveApprovalID(null);
       setActiveApprovalSnapshot(null);
       setApprovalNote("");
@@ -215,7 +215,12 @@ export function ConsolePage() {
     const approval = activeApproval;
     setApprovalAction({ state: "running", error: null });
     try {
-      await runApproval(approval.id, approvalNote);
+      const item = await runApproval(approval.id, approvalNote);
+      if (item?.status === "error" || item?.status === "failed") {
+        setActiveApprovalSnapshot({ ...approval, ...item });
+        setApprovalAction({ state: "failed", error: item.error || "Approval run failed before the command could complete." });
+        return;
+      }
       setDismissedApprovalIDs((current) => {
         const next = { ...current };
         delete next[approval.id];

--- a/frontend/src/pages/servers.jsx
+++ b/frontend/src/pages/servers.jsx
@@ -11,7 +11,17 @@ import { Checkbox, Field, Input, Select, Textarea } from "../components/ui/form"
 import { Notice } from "../components/ui/notice";
 import { TerminalBlock } from "../components/ui/terminal-block";
 
-const emptyForm = { name: "", host: "", port: 22, username: "root", ssh_key_id: "", description: "", setup_later: false };
+const emptyForm = {
+  name: "",
+  host: "",
+  port: 22,
+  username: "root",
+  ssh_key_id: "",
+  description: "",
+  startup_input_after_connect: "",
+  force_shell_command: "",
+  setup_later: false,
+};
 
 export function ServersPage() {
   const { servers, sshKeys, loadServers } = useGateway();
@@ -89,6 +99,8 @@ export function ServersPage() {
       username: entry.username || "root",
       ssh_key_id: firstKeyID,
       description: "Imported from host config.",
+      startup_input_after_connect: "",
+      force_shell_command: "",
     });
     setSSHConfigDialog({ open: false, state: "idle", items: [], error: null });
     setDrawer({ open: true, mode: "create", server: null });
@@ -103,6 +115,8 @@ export function ServersPage() {
       username: server.username,
       ssh_key_id: String(server.ssh_key_id),
       description: server.description || "",
+      startup_input_after_connect: server.startup_input_after_connect || "",
+      force_shell_command: server.force_shell_command || "",
       setup_later: false,
     });
     setDrawer({ open: true, mode: "edit", server });
@@ -412,6 +426,38 @@ export function ServersPage() {
             Description
             <Textarea value={form.description} onChange={(event) => setForm({ ...form, description: event.target.value })} rows={3} />
           </Field>
+          <div className="grid gap-3 rounded-lg border border-stone-200 bg-stone-50 p-3 dark-soft-panel">
+            <div>
+              <p className="text-sm font-semibold text-stone-900">Advanced SSH startup</p>
+              <p className="mt-1 text-xs text-stone-500">
+                Optional compatibility settings for appliances that show an interactive menu before a normal shell.
+              </p>
+            </div>
+            <Field>
+              Startup input after connect
+              <Textarea
+                value={form.startup_input_after_connect}
+                onChange={(event) => setForm({ ...form, startup_input_after_connect: event.target.value })}
+                rows={3}
+                className="font-mono text-xs"
+                placeholder={"q\n"}
+              />
+              <span className="text-xs text-stone-500">
+                Sent exactly to the PTY after the shell starts. For some QNAP menus, enter <span className="font-mono">q</span> then a newline.
+              </span>
+            </Field>
+            <Field>
+              Force shell command
+              <Input
+                value={form.force_shell_command}
+                onChange={(event) => setForm({ ...form, force_shell_command: event.target.value })}
+                placeholder="/bin/sh -l"
+              />
+              <span className="text-xs text-stone-500">
+                Leave empty for normal SSH shell startup. Use only when the server needs a specific shell command.
+              </span>
+            </Field>
+          </div>
           {state.state === "error" ? <Notice tone="bad">{state.error}</Notice> : null}
           <Button type="submit" disabled={state.state === "saving" || sshKeys.data.length === 0}>
             {state.state === "saving" ? (form.setup_later ? "Saving..." : "Testing...") : drawer.mode === "edit" ? "Save changes" : "Save server"}
@@ -944,5 +990,7 @@ function serverPayloadFromForm(form) {
     username: form.username,
     ssh_key_id: Number(form.ssh_key_id),
     description: form.description,
+    startup_input_after_connect: form.startup_input_after_connect,
+    force_shell_command: form.force_shell_command,
   };
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "make test",
     "build": "make build",
     "audit": "make audit",
+    "hygiene": "node scripts/secret-scan.js && node scripts/line-ending-check.js",
     "release-check": "make release-check"
   }
 }

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "MIT",

--- a/packages/mcp/resources/aipermission-operator/SKILL.md
+++ b/packages/mcp/resources/aipermission-operator/SKILL.md
@@ -27,6 +27,11 @@ If no server is visible, say that the current token has no accessible servers.
 If `expires_at` is present, treat access as temporary. Finish within that
 maintenance window or ask the operator to extend access.
 
+`list_servers()` is permission-scoped, not a live health check. A visible server
+may still be powered off, unreachable, reject SSH authentication, or require host
+key review. Treat `exec` dial, timeout, authentication, and host-key errors as
+the current reachability signal.
+
 ## Command Reasons
 
 Every `exec` call should include a short `reason`.

--- a/packages/mcp/resources/aipermission-operator/SKILL.md
+++ b/packages/mcp/resources/aipermission-operator/SKILL.md
@@ -77,6 +77,9 @@ stale
 
 If the request is `declined`, read `user_note` and follow the user's correction.
 If the request is `stale`, the approval context changed before execution; send a fresh `exec` request with the current command and reason instead of trying to reuse the old approval.
+If the request is `error`, read the error text. SSH reachability, refused ports,
+authentication failures, and host-key failures are current connection signals;
+do not assume a listed server is live just because `list_servers` returned it.
 
 ## Running Flow
 

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "transport": {
         "type": "stdio"
       }

--- a/scripts/line-ending-check.js
+++ b/scripts/line-ending-check.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const { execFileSync } = require("node:child_process");
+const { readFileSync } = require("node:fs");
+
+const tracked = execFileSync("git", ["ls-files", "-z"], { encoding: "utf8" })
+  .split("\0")
+  .filter(Boolean);
+
+function isShellLike(file, content) {
+  if (file.endsWith(".sh")) return true;
+  const firstLineEnd = content.indexOf("\n");
+  const firstLine = content.slice(0, firstLineEnd === -1 ? content.length : firstLineEnd);
+  return firstLine.startsWith("#!") && /\b(sh|bash|zsh|dash)\b/.test(firstLine);
+}
+
+const findings = [];
+let checked = 0;
+
+for (const file of tracked) {
+  let content;
+  try {
+    content = readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+  if (!isShellLike(file, content)) continue;
+  checked += 1;
+  if (content.includes("\r\n") || /\r(?!\n)/.test(content)) {
+    findings.push(file);
+  }
+}
+
+if (findings.length > 0) {
+  console.error("Line-ending check failed. Shell scripts must use LF line endings:");
+  for (const finding of findings) console.error(`- ${finding}`);
+  console.error("\nRun: git add --renormalize <file>");
+  process.exit(1);
+}
+
+console.log(`Line-ending check passed (${checked} shell-like files checked).`);


### PR DESCRIPTION
## Summary

- add advanced SSH startup settings for menu-based NAS/appliance shells
- harden approval Run behavior so unreachable SSH targets surface a readable terminal error before the prompt closes
- clarify MCP reachability semantics and SSH failure messages
- update Go/frontend/SFTP dependencies with release verification
- add LF line-ending hygiene for Docker shell entrypoints

## Verification

- go test ./...
- frontend npm test && npm run build
- MCP npm test && npm run build
- npm run hygiene
- docker compose config --quiet
- git diff --check
- local Docker Compose smoke: approval_required offline/online SSH preflight

## Notes

Use Rebase and merge when checks are green to preserve individual commits.