### PR TITLE
Release 0.1.12 bulk console commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.1.12] - 2026-06-09
+
+### Added
+
+- Console Bulk command can run one shell command across multiple selected
+  servers from the local UI.
+- Bulk command requires an explicit confirmation phrase, records one manual
+  command request per target server, and runs through the same persistent SSH
+  console path as normal Console commands.
+- Bulk command results show per-server status and selectable captured output,
+  with a compact target search for larger server lists.
+
+### Security
+
+- Bulk command remains local UI only and requires the existing unlocked UI
+  session plus CSRF checks.
+- Bulk command history rows are stored as manual command requests without MCP
+  token identity, so MCP approval and token-scoped history semantics stay
+  separate.
+
 ## [0.1.11] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Implemented:
 - execution rules: `always_run`, `approval_required`, `blocked`
 - global MCP Started/Stopped switch that preserves permissions while blocking live execution
 - persistent web console with live PTY streaming
+- UI bulk command execution across selected servers with per-server history rows
 - MCP bridge with command, console, message, and conservative upload/download transfer tools
 - approval dialog with Run / Decline / note
 - approval-context snapshots that stale old pending commands after permission,

--- a/backend/internal/api/console_bulk_handlers.go
+++ b/backend/internal/api/console_bulk_handlers.go
@@ -1,0 +1,187 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/aipermission/aipermission/backend/internal/servers"
+)
+
+const (
+	bulkConsoleCommandMaxServers  = 25
+	bulkConsoleCommandParallelism = 3
+	bulkConsoleCommandReason      = "bulk console command"
+)
+
+type bulkConsoleCommandRequest struct {
+	ServerIDs    []int64 `json:"server_ids"`
+	Command      string  `json:"command"`
+	Reason       string  `json:"reason"`
+	Confirmation string  `json:"confirmation"`
+}
+
+type bulkConsoleCommandResponse struct {
+	Parallelism int                              `json:"parallelism"`
+	Items       []bulkConsoleCommandResponseItem `json:"items"`
+}
+
+type bulkConsoleCommandResponseItem struct {
+	RequestID  int64  `json:"request_id"`
+	ServerID   int64  `json:"server_id"`
+	ServerName string `json:"server_name"`
+	Status     string `json:"status"`
+}
+
+func (s consoleHandlers) runBulkConsoleCommand(w http.ResponseWriter, r *http.Request) {
+	runtime, ok := s.activeRuntimeOrLocked(w)
+	if !ok {
+		return
+	}
+	var request bulkConsoleCommandRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	request.Command = strings.TrimSpace(request.Command)
+	request.Reason = strings.TrimSpace(request.Reason)
+	if request.Reason == "" {
+		request.Reason = bulkConsoleCommandReason
+	}
+	if err := validateTextLimit("command", request.Command, maxCommandBytes); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validateTextLimit("reason", request.Reason, maxReasonBytes); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	serverIDs, err := normalizeBulkConsoleServerIDs(request.ServerIDs)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	expectedConfirmation := bulkConsoleConfirmation(len(serverIDs))
+	if request.Confirmation != expectedConfirmation {
+		writeError(w, http.StatusBadRequest, "confirmation must be "+expectedConfirmation)
+		return
+	}
+
+	targets := make([]servers.Server, 0, len(serverIDs))
+	for _, serverID := range serverIDs {
+		server, err := runtime.servers.Get(r.Context(), serverID)
+		if err != nil {
+			handleServerError(w, err)
+			return
+		}
+		targets = append(targets, server)
+	}
+
+	items := make([]bulkConsoleCommandResponseItem, 0, len(targets))
+	for _, target := range targets {
+		requestID, err := s.insertCommandRequestWithOptions(r.Context(), runtime, commandRequestInsert{
+			ServerID: target.ID,
+			Source:   commandRequestSourceManual,
+			Command:  request.Command,
+			Reason:   request.Reason,
+			Status:   "running",
+		})
+		if err != nil {
+			writeInternalError(w)
+			return
+		}
+		items = append(items, bulkConsoleCommandResponseItem{
+			RequestID:  requestID,
+			ServerID:   target.ID,
+			ServerName: target.Name,
+			Status:     "running",
+		})
+	}
+
+	s.writeAudit(r.Context(), runtime, "user", nil, 0, "console.bulk_exec.started", map[string]any{
+		"server_count": len(items),
+		"request_ids":  bulkConsoleRequestIDs(items),
+		"command":      request.Command,
+	})
+	s.runBulkConsoleCommands(runtime, request.Command, items)
+
+	writeJSON(w, http.StatusAccepted, bulkConsoleCommandResponse{
+		Parallelism: bulkConsoleCommandParallelism,
+		Items:       items,
+	})
+}
+
+func normalizeBulkConsoleServerIDs(values []int64) ([]int64, error) {
+	if len(values) == 0 {
+		return nil, fmt.Errorf("server_ids is required")
+	}
+	if len(values) > bulkConsoleCommandMaxServers {
+		return nil, fmt.Errorf("server_ids must contain %d servers or fewer", bulkConsoleCommandMaxServers)
+	}
+	seen := map[int64]bool{}
+	result := make([]int64, 0, len(values))
+	for _, value := range values {
+		if value < 1 {
+			return nil, fmt.Errorf("server_ids must contain positive ids")
+		}
+		if seen[value] {
+			return nil, fmt.Errorf("server_ids must not contain duplicates")
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result, nil
+}
+
+func bulkConsoleConfirmation(count int) string {
+	return fmt.Sprintf("RUN ON %d SERVERS", count)
+}
+
+func bulkConsoleRequestIDs(items []bulkConsoleCommandResponseItem) []int64 {
+	ids := make([]int64, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.RequestID)
+	}
+	return ids
+}
+
+func (s *Server) runBulkConsoleCommands(runtime *databaseRuntime, command string, items []bulkConsoleCommandResponseItem) {
+	go func() {
+		sem := make(chan struct{}, bulkConsoleCommandParallelism)
+		var wg sync.WaitGroup
+		for _, item := range items {
+			item := item
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				s.runBulkConsoleCommand(runtime, item.RequestID, item.ServerID, command)
+			}()
+		}
+		wg.Wait()
+	}()
+}
+
+func (s *Server) runBulkConsoleCommand(runtime *databaseRuntime, requestID int64, serverID int64, command string) {
+	ctx, cancel := context.WithTimeout(context.Background(), mcpInitialExecTimeout)
+	defer cancel()
+
+	result, err := runtime.consoleSessions.Exec(ctx, serverID, command)
+	if err != nil {
+		_ = s.finishCommandRequest(context.Background(), runtime, requestID, "error", 0, "", "", 0, sshCommandFailureMessage(err))
+		return
+	}
+	if result.Running {
+		_ = s.setCommandRequestSession(context.Background(), runtime, requestID, result.SessionID)
+		s.finishActiveCommandRequest(runtime, requestID, serverID)
+		return
+	}
+	status := "completed"
+	if result.ExitCode != 0 {
+		status = "failed"
+	}
+	_ = s.finishCommandRequest(context.Background(), runtime, requestID, status, result.SessionID, result.Output, "", result.ExitCode, "")
+}

--- a/backend/internal/api/mcp_command_requests.go
+++ b/backend/internal/api/mcp_command_requests.go
@@ -11,32 +11,55 @@ import (
 	"github.com/aipermission/aipermission/backend/internal/console"
 )
 
+type commandRequestInsert struct {
+	TokenID  *int64
+	ServerID int64
+	Source   string
+	Command  string
+	Reason   string
+	Status   string
+}
+
 func (s *Server) insertCommandRequest(ctx context.Context, runtime *databaseRuntime, tokenID int64, serverID int64, command string, reason string, status string) (int64, error) {
+	return s.insertCommandRequestWithOptions(ctx, runtime, commandRequestInsert{
+		TokenID:  &tokenID,
+		ServerID: serverID,
+		Source:   commandRequestSourceMCP,
+		Command:  command,
+		Reason:   reason,
+		Status:   status,
+	})
+}
+
+func (s *Server) insertCommandRequestWithOptions(ctx context.Context, runtime *databaseRuntime, request commandRequestInsert) (int64, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
-	encryptedCommand, err := runtime.vault.EncryptJSON(command)
+	encryptedCommand, err := runtime.vault.EncryptJSON(request.Command)
 	if err != nil {
 		return 0, fmt.Errorf("encrypt command payload: %w", err)
 	}
+	if request.Source == "" {
+		request.Source = commandRequestSourceMCP
+	}
 	approvalContext := ""
 	approvalContextHash := ""
-	if status == "pending_approval" && tokenID > 0 {
-		approvalContext, approvalContextHash, err = s.buildApprovalContextSnapshot(ctx, runtime, tokenID, serverID, command, now)
+	if request.Source == commandRequestSourceMCP && request.Status == "pending_approval" && request.TokenID != nil && *request.TokenID > 0 {
+		approvalContext, approvalContextHash, err = s.buildApprovalContextSnapshot(ctx, runtime, *request.TokenID, request.ServerID, request.Command, now)
 		if err != nil {
 			return 0, fmt.Errorf("build approval context snapshot: %w", err)
 		}
 	}
-	storedCommand := s.redactForPersistence(ctx, runtime, command)
-	storedReason := s.redactForPersistence(ctx, runtime, reason)
+	storedCommand := s.redactForPersistence(ctx, runtime, request.Command)
+	storedReason := s.redactForPersistence(ctx, runtime, request.Reason)
 	result, err := runtime.database.ExecContext(ctx, `
 		INSERT INTO command_requests (token_id, server_id, source, command, encrypted_command, reason, status, approval_context, approval_context_hash, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		tokenID,
-		serverID,
-		commandRequestSourceMCP,
+		nullableInt64(request.TokenID),
+		request.ServerID,
+		request.Source,
 		storedCommand,
 		encryptedCommand,
 		storedReason,
-		status,
+		request.Status,
 		approvalContext,
 		approvalContextHash,
 		now,

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -90,6 +90,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/databases/switch", databases.switchDatabase)
 	s.mux.HandleFunc("POST /api/databases/change-password", databases.changeDatabasePassword)
 	s.mux.HandleFunc("POST /api/console/exec", serverConnections.consoleExec)
+	s.mux.HandleFunc("POST /api/console/bulk-exec", console.runBulkConsoleCommand)
 	s.mux.HandleFunc("GET /api/console/sessions", console.listConsoleSessions)
 	s.mux.HandleFunc("POST /api/console/sessions", console.createConsoleSession)
 	s.mux.HandleFunc("GET /api/console/sessions/{id}", console.getConsoleSession)

--- a/backend/internal/api/routes_test.go
+++ b/backend/internal/api/routes_test.go
@@ -313,6 +313,73 @@ func TestApprovalAndMCPRequestRoutes(t *testing.T) {
 	}
 }
 
+func TestBulkConsoleCommandCreatesManualHistoryRows(t *testing.T) {
+	fixture := newAPITestFixture(t)
+	serverOne := fixture.createKeyAndServer(t, "bulk-one")
+	serverTwo := fixture.createKeyAndServer(t, "bulk-two")
+	if _, err := fixture.db.Exec(`UPDATE servers SET port = 1 WHERE id IN (?, ?)`, serverOne.ID, serverTwo.ID); err != nil {
+		t.Fatalf("move test servers to closed port: %v", err)
+	}
+
+	missingConfirmation := performJSON(fixture.server.Handler(), http.MethodPost, "/api/console/bulk-exec", "", bulkConsoleCommandRequest{
+		ServerIDs: []int64{serverOne.ID, serverTwo.ID},
+		Command:   "hostname",
+		Reason:    "bulk smoke",
+	})
+	if missingConfirmation.Code != http.StatusBadRequest || !strings.Contains(missingConfirmation.Body.String(), "RUN ON 2 SERVERS") {
+		t.Fatalf("bulk command should require exact confirmation, got %d %s", missingConfirmation.Code, missingConfirmation.Body.String())
+	}
+
+	duplicateServer := performJSON(fixture.server.Handler(), http.MethodPost, "/api/console/bulk-exec", "", bulkConsoleCommandRequest{
+		ServerIDs:    []int64{serverOne.ID, serverOne.ID},
+		Command:      "hostname",
+		Reason:       "bulk smoke",
+		Confirmation: "RUN ON 2 SERVERS",
+	})
+	if duplicateServer.Code != http.StatusBadRequest || !strings.Contains(duplicateServer.Body.String(), "duplicates") {
+		t.Fatalf("bulk command should reject duplicate servers, got %d %s", duplicateServer.Code, duplicateServer.Body.String())
+	}
+
+	response := performJSON(fixture.server.Handler(), http.MethodPost, "/api/console/bulk-exec", "", bulkConsoleCommandRequest{
+		ServerIDs:    []int64{serverOne.ID, serverTwo.ID},
+		Command:      "hostname",
+		Reason:       "bulk smoke",
+		Confirmation: "RUN ON 2 SERVERS",
+	})
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("bulk command failed: %d %s", response.Code, response.Body.String())
+	}
+	result := decodeRouteResponse[bulkConsoleCommandResponse](t, response.Body.Bytes())
+	if result.Parallelism != bulkConsoleCommandParallelism || len(result.Items) != 2 {
+		t.Fatalf("unexpected bulk command response: %#v", result)
+	}
+
+	var rows int
+	if err := fixture.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM command_requests
+		WHERE source = 'manual'
+			AND token_id IS NULL
+			AND encrypted_command <> ''
+			AND command = 'hostname'
+			AND reason = 'bulk smoke'
+			AND status IN ('running', 'error')`,
+	).Scan(&rows); err != nil {
+		t.Fatalf("count bulk command requests: %v", err)
+	}
+	if rows != 2 {
+		t.Fatalf("expected two manual bulk command rows, got %d", rows)
+	}
+
+	var auditRows int
+	if err := fixture.db.QueryRow(`SELECT COUNT(*) FROM audit_logs WHERE action = 'console.bulk_exec.started'`).Scan(&auditRows); err != nil {
+		t.Fatalf("count bulk command audit: %v", err)
+	}
+	if auditRows != 1 {
+		t.Fatalf("expected one bulk audit event, got %d", auditRows)
+	}
+}
+
 func TestHistoryAndAuditPaginationSearchAndDetail(t *testing.T) {
 	fixture := newAPITestFixture(t)
 	ctx := context.Background()

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -143,6 +143,56 @@ The UI asks the user to verify and approve the fingerprint. `POST /api/ssh-host-
 
 `DELETE /api/servers/{id}?remove_key=true` first connects with the server's gateway key, removes remote `~/.ssh/authorized_keys` entries containing that public key blob, then deletes the local record. This handles changed comments or authorized_keys options. If remote cleanup fails or removes zero entries, the local record is kept.
 
+## Console Commands
+
+```txt
+POST /api/console/bulk-exec
+GET  /api/console/sessions
+POST /api/console/sessions
+GET  /api/console/sessions/{id}
+POST /api/console/sessions/{id}/input
+POST /api/console/sessions/{id}/close
+GET  /api/console/sessions/{id}/attach
+POST /api/console/servers/{id}/restart
+```
+
+`POST /api/console/bulk-exec` runs one local-UI command across selected servers.
+It is not an MCP tool. The command runs through each target server's persistent
+SSH console session and creates one `source: "manual"` command history row per
+server.
+
+The request body requires an exact confirmation string based on the selected
+server count:
+
+```json
+{
+  "server_ids": [3, 4, 7],
+  "command": "apt update",
+  "reason": "weekly package metadata refresh",
+  "confirmation": "RUN ON 3 SERVERS"
+}
+```
+
+The backend validates duplicate IDs, command size, and confirmation text before
+creating history rows. Execution is limited to a small parallelism window so a
+large server selection does not fan out all SSH sessions at once. The response
+returns the command request IDs; poll `GET /api/approvals/{id}` or use the
+History page for per-server output, exit code, error, and status:
+
+```json
+{
+  "parallelism": 3,
+  "items": [
+    {
+      "request_id": 101,
+      "server_id": 3,
+      "server_name": "worker-1",
+      "status": "running"
+    }
+  ]
+}
+```
+
 ## File Transfers
 
 ```txt

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aipermission-frontend",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.5",
         "@xterm/addon-fit": "^0.11.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aipermission-frontend",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/components/console/bulk-command-dialog.jsx
+++ b/frontend/src/components/console/bulk-command-dialog.jsx
@@ -1,0 +1,337 @@
+import { useEffect, useMemo, useState } from "react";
+import { Copy, RefreshCcw, TerminalSquare } from "lucide-react";
+import { apiGet, apiPost } from "../../lib/api";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Dialog } from "../ui/dialog";
+import { Notice } from "../ui/notice";
+import { TerminalBlock } from "../ui/terminal-block";
+
+const terminalStatuses = new Set(["completed", "failed", "error", "declined", "stale", "untracked"]);
+
+export function BulkCommandDialog({ open, servers, selectedServer, onClose, onRefresh }) {
+  const [selected, setSelected] = useState({});
+  const [command, setCommand] = useState("");
+  const [reason, setReason] = useState("");
+  const [confirmation, setConfirmation] = useState("");
+  const [targetQuery, setTargetQuery] = useState("");
+  const [runState, setRunState] = useState({ state: "idle", error: null, items: [], parallelism: 3 });
+  const [selectedResultID, setSelectedResultID] = useState(null);
+
+  const visibleServers = useMemo(() => {
+    const query = targetQuery.trim().toLowerCase();
+    if (!query) return servers;
+    return servers.filter((server) => `${server.name} ${server.username} ${server.host}`.toLowerCase().includes(query));
+  }, [servers, targetQuery]);
+  const selectedIDs = useMemo(
+    () => servers.filter((server) => selected[server.id]).map((server) => Number(server.id)),
+    [servers, selected]
+  );
+  const confirmationText = selectedIDs.length > 0 ? `RUN ON ${selectedIDs.length} SERVERS` : "RUN ON 0 SERVERS";
+  const canRun = selectedIDs.length > 0 && command.trim() && confirmation === confirmationText && runState.state !== "starting";
+  const hasActiveItems = runState.items.some((item) => !terminalStatuses.has(item.status));
+
+  useEffect(() => {
+    if (!open) return;
+    const initial = {};
+    if (selectedServer?.id) {
+      initial[selectedServer.id] = true;
+    }
+    setSelected(initial);
+    setCommand("");
+    setReason("");
+    setConfirmation("");
+    setTargetQuery("");
+    setRunState({ state: "idle", error: null, items: [], parallelism: 3 });
+    setSelectedResultID(null);
+  }, [open, selectedServer?.id]);
+
+  useEffect(() => {
+    if (!open || !hasActiveItems) return undefined;
+    const timer = window.setInterval(() => {
+      void refreshRequests();
+    }, 2500);
+    return () => window.clearInterval(timer);
+  }, [open, hasActiveItems, runState.items.map((item) => `${item.request_id}:${item.status}`).join(",")]);
+
+  function toggleServer(serverID) {
+    setSelected((current) => ({ ...current, [serverID]: !current[serverID] }));
+    setConfirmation("");
+  }
+
+  function setAllServers(value) {
+    const next = {};
+    if (value) {
+      servers.forEach((server) => {
+        next[server.id] = true;
+      });
+    }
+    setSelected(next);
+    setConfirmation("");
+  }
+
+  function copyConfirmationText() {
+    if (typeof navigator === "undefined" || !navigator.clipboard) return;
+    void navigator.clipboard.writeText(confirmationText);
+  }
+
+  async function startBulkCommand(event) {
+    event.preventDefault();
+    if (!canRun) return;
+    setRunState((current) => ({ ...current, state: "starting", error: null }));
+    setSelectedResultID(null);
+    try {
+      const data = await apiPost("/api/console/bulk-exec", {
+        server_ids: selectedIDs,
+        command: command.trim(),
+        reason: reason.trim(),
+        confirmation,
+      });
+      setRunState({
+        state: "running",
+        error: null,
+        items: (data.items || []).map((item) => ({ ...item, status: item.status || "running" })),
+        parallelism: data.parallelism || 3,
+      });
+      await onRefresh?.();
+      window.setTimeout(() => void refreshRequests(), 1000);
+    } catch (error) {
+      setRunState((current) => ({ ...current, state: "error", error: error.message }));
+    }
+  }
+
+  async function refreshRequests() {
+    if (runState.items.length === 0) return;
+    try {
+      const details = await Promise.all(
+        runState.items.map(async (item) => {
+          try {
+            const detail = await apiGet(`/api/approvals/${item.request_id}`);
+            return { ...item, ...detail, request_id: item.request_id };
+          } catch (error) {
+            return { ...item, status: "error", error: error.message };
+          }
+        })
+      );
+      setRunState((current) => ({ ...current, state: details.some((item) => !terminalStatuses.has(item.status)) ? "running" : "done", items: details, error: null }));
+      await onRefresh?.();
+    } catch (error) {
+      setRunState((current) => ({ ...current, state: "error", error: error.message }));
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      title="Bulk command"
+      description="Run one shell command across selected servers."
+      onClose={onClose}
+      size="wide"
+      className="h-[calc(100vh-100px)] !w-[100vw] !min-w-[1024px] !max-w-[1600px] grid-rows-[auto_minmax(0,1fr)]"
+      closeOnOverlay={false}
+      autoFocusClose={false}
+      bodyClassName="grid min-h-0 gap-4 overflow-hidden"
+    >
+      <form className="grid h-full min-h-0 gap-4 lg:grid-cols-[minmax(260px,340px)_minmax(0,1fr)]" onSubmit={startBulkCommand}>
+        <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-3">
+          <div className="grid gap-3">
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold text-stone-950">Targets</p>
+                <p className="text-xs text-stone-500">{selectedIDs.length} selected</p>
+              </div>
+              <div className="flex gap-2">
+                <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={() => setAllServers(true)}>
+                  All
+                </Button>
+                <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={() => setAllServers(false)}>
+                  None
+                </Button>
+              </div>
+            </div>
+            <input
+              className="h-9 rounded-md border border-stone-300 px-3 text-sm outline-none focus:border-emerald-700"
+              value={targetQuery}
+              onChange={(event) => setTargetQuery(event.target.value)}
+              placeholder="Search servers"
+            />
+          </div>
+          <div className="min-h-0 overflow-auto rounded-md border border-stone-200">
+            {visibleServers.map((server) => (
+              <label key={server.id} className="flex cursor-pointer items-start gap-3 border-b border-stone-100 px-3 py-2 last:border-b-0 hover:bg-stone-50">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 accent-emerald-800"
+                  checked={Boolean(selected[server.id])}
+                  onChange={() => toggleServer(server.id)}
+                />
+                <span className="min-w-0">
+                  <span className="block truncate text-sm font-semibold text-stone-900">{server.name}</span>
+                  <span className="block truncate text-xs text-stone-500">
+                    {server.username}@{server.host}:{server.port}
+                  </span>
+                </span>
+              </label>
+            ))}
+            {visibleServers.length === 0 ? <p className="px-3 py-6 text-center text-sm text-stone-500">No matching servers.</p> : null}
+          </div>
+        </section>
+
+        <section className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-4">
+          <div className="grid gap-3">
+            <label className="grid gap-1 text-sm font-semibold text-stone-700">
+              Command
+              <textarea
+                className="h-32 resize-none rounded-md border border-stone-300 px-3 py-2 font-mono text-sm font-normal outline-none focus:border-emerald-700"
+                value={command}
+                onChange={(event) => setCommand(event.target.value)}
+                placeholder="apt update"
+              />
+            </label>
+            <label className="grid gap-1 text-sm font-semibold text-stone-700">
+              Reason
+              <input
+                className="h-10 rounded-md border border-stone-300 px-3 text-sm font-normal outline-none focus:border-emerald-700"
+                value={reason}
+                onChange={(event) => setReason(event.target.value)}
+                placeholder="optional"
+              />
+            </label>
+            <Notice tone="warn" className="flex h-10 items-center overflow-hidden px-3 py-0 text-xs">
+              <span className="min-w-0 truncate">
+                Type <span className="font-mono font-semibold">{confirmationText}</span>
+                <button
+                  type="button"
+                  className="ml-1 inline-grid h-5 w-5 place-items-center align-[-3px] text-amber-900 hover:text-amber-700"
+                  title="Copy confirmation phrase"
+                  onClick={copyConfirmationText}
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </button>{" "}
+                before starting. Runs {runState.parallelism} servers at a time.
+              </span>
+            </Notice>
+            <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+              <input
+                className="h-10 rounded-md border border-stone-300 px-3 font-mono text-sm outline-none focus:border-emerald-700"
+                value={confirmation}
+                onChange={(event) => setConfirmation(event.target.value)}
+                placeholder={confirmationText}
+              />
+              <Button type="submit" disabled={!canRun}>
+                <TerminalSquare className="h-4 w-4" />
+                Run selected
+              </Button>
+            </div>
+            {runState.error ? <Notice tone="bad">{runState.error}</Notice> : null}
+          </div>
+
+          <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-3">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-stone-950">Results</p>
+                <p className="text-xs text-stone-500">{runState.items.length > 0 ? resultSummary(runState.items) : "Results appear here after the command starts."}</p>
+              </div>
+              <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={refreshRequests} disabled={runState.items.length === 0}>
+                <RefreshCcw className="h-3.5 w-3.5" />
+                Refresh
+              </Button>
+            </div>
+            {runState.items.length > 0 ? (
+              <div className="grid min-h-0 gap-3 lg:grid-cols-[minmax(180px,230px)_minmax(0,1fr)]">
+                <div className="min-h-0 overflow-auto rounded-md border border-stone-200">
+                  {runState.items.map((item) => (
+                    <BulkCommandResultRow
+                      key={item.request_id}
+                      item={item}
+                      selected={selectedResultID === item.request_id}
+                      onSelect={() => setSelectedResultID((current) => (current === item.request_id ? null : item.request_id))}
+                    />
+                  ))}
+                </div>
+                <BulkCommandResultDetail item={runState.items.find((item) => item.request_id === selectedResultID)} />
+              </div>
+            ) : (
+              <div className="grid min-h-0 place-items-center rounded-md border border-dashed border-stone-300 bg-stone-50 p-6 text-center text-sm text-stone-500">
+                Choose targets, enter a command, and run it to see per-server status and output.
+              </div>
+            )}
+          </section>
+        </section>
+      </form>
+    </Dialog>
+  );
+}
+
+function BulkCommandResultRow({ item, selected, onSelect }) {
+  return (
+    <button
+      type="button"
+      className={`grid w-full gap-1 border-b border-stone-100 px-3 py-2 text-left last:border-b-0 hover:bg-stone-50 ${
+        selected ? "border-l-4 border-l-emerald-700 bg-emerald-50 pl-2" : "border-l-4 border-l-transparent"
+      }`}
+      onClick={onSelect}
+    >
+      <span className="flex min-w-0 items-center justify-between gap-2">
+        <span className="truncate text-sm font-semibold text-stone-950">{item.server_name}</span>
+        <Badge tone={statusTone(item.status)} className="shrink-0 px-2 py-0.5 text-[11px]">
+          {statusLabel(item.status)}
+        </Badge>
+      </span>
+      <span className="flex items-center justify-between gap-2 text-xs text-stone-500">
+        <span>#{item.request_id}</span>
+        {typeof item.exit_code === "number" ? <span>exit {item.exit_code}</span> : <span>running</span>}
+      </span>
+    </button>
+  );
+}
+
+function BulkCommandResultDetail({ item }) {
+  if (!item) {
+    return (
+      <div className="grid min-h-0 place-items-center rounded-md border border-dashed border-stone-300 bg-stone-50 p-5 text-center text-sm text-stone-500">
+        Select a result on the left to inspect its captured console output.
+      </div>
+    );
+  }
+  const output = item.stdout || item.stderr || item.error || "";
+  return (
+    <article className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-2 rounded-md border border-stone-200 p-3">
+      <div className="flex min-w-0 items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold text-stone-950">{item.server_name}</p>
+          <p className="text-xs text-stone-500">Request #{item.request_id}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {typeof item.exit_code === "number" ? <Badge tone="neutral">exit {item.exit_code}</Badge> : null}
+          <Badge tone={statusTone(item.status)}>{statusLabel(item.status)}</Badge>
+        </div>
+      </div>
+      <TerminalBlock surface="log" className="min-h-0 p-3 text-xs">
+        {output || "No output captured yet."}
+      </TerminalBlock>
+    </article>
+  );
+}
+
+function resultSummary(items) {
+  const running = items.filter((item) => !terminalStatuses.has(item.status)).length;
+  const failed = items.filter((item) => item.status === "failed" || item.status === "error").length;
+  const done = items.length - running;
+  if (running > 0) return `${done}/${items.length} finished, ${running} running`;
+  if (failed > 0) return `${done}/${items.length} finished, ${failed} failed`;
+  return `${done}/${items.length} finished`;
+}
+
+function statusLabel(status) {
+  if (status === "pending_approval") return "pending";
+  if (status === "untracked") return "not tracked";
+  return status || "running";
+}
+
+function statusTone(status) {
+  if (status === "completed") return "good";
+  if (status === "running" || status === "pending_approval") return "warn";
+  if (status === "failed" || status === "error" || status === "declined" || status === "stale") return "bad";
+  return "neutral";
+}

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -69,9 +69,9 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.1\.11"/);
-  assert.match(releaseSource, /SSH compatibility polish/);
-  assert.match(releaseSource, /Windows checkouts preserve LF line endings/);
+  assert.match(releaseSource, /appVersion = "0\.1\.12"/);
+  assert.match(releaseSource, /Bulk console commands/);
+  assert.match(releaseSource, /Bulk command requires an explicit confirmation phrase/);
 });
 
 test("Sidebar exposes explicit MCP runtime start and stop controls", () => {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -21,6 +21,7 @@ const sshKeysSource = readFileSync(join(currentDir, "..", "pages", "ssh-keys.jsx
 const fileTransferDialogSource = readFileSync(join(currentDir, "..", "components", "console", "file-transfer-dialog.jsx"), "utf8");
 const fileTransferBrowserSource = readFileSync(join(currentDir, "..", "components", "console", "file-transfer-browser-dialog.jsx"), "utf8");
 const fileTransferConfirmSource = readFileSync(join(currentDir, "..", "components", "console", "file-transfer-confirm-dialogs.jsx"), "utf8");
+const bulkCommandDialogSource = readFileSync(join(currentDir, "..", "components", "console", "bulk-command-dialog.jsx"), "utf8");
 const transferCenterSource = readFileSync(join(currentDir, "..", "components", "transfer-center.jsx"), "utf8");
 const tokenPermissionPanelSource = readFileSync(join(currentDir, "..", "components", "console", "token-permission-panel.jsx"), "utf8");
 const permissionDialogSource = readFileSync(join(currentDir, "..", "components", "tokens", "permission-dialog.jsx"), "utf8");
@@ -198,6 +199,14 @@ test("Console exposes stuck command recovery controls", () => {
   assert.match(consolePageSource, /Looks stuck\? Restart opens a fresh SSH session/);
   assert.match(consolePageSource, /commandPreview/);
   assert.match(consolePageSource, /Restart/);
+});
+
+test("Console exposes bulk command execution controls", () => {
+  assert.match(consolePageSource, /BulkCommandDialog/);
+  assert.match(consolePageSource, /Bulk/);
+  assert.match(bulkCommandDialogSource, /\/api\/console\/bulk-exec/);
+  assert.match(bulkCommandDialogSource, /RUN ON \$\{selectedIDs\.length\} SERVERS/);
+  assert.match(bulkCommandDialogSource, /Run selected/);
 });
 
 test("Settings page exposes history label management", () => {

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,27 @@
-export const appVersion = "0.1.11";
+export const appVersion = "0.1.12";
 
 export const changelogEntries = [
+  {
+    version: "0.1.12",
+    label: "Bulk console commands",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Console Bulk command can run one shell command across multiple selected servers from the local UI.",
+          "Bulk command requires an explicit confirmation phrase and records one manual command request per target server.",
+          "Bulk results show per-server status with selectable captured output and compact target search.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "Bulk command remains local UI only and requires the unlocked UI session plus CSRF checks.",
+          "Bulk command history stays separate from MCP token-scoped approval history.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.1.11",
     label: "SSH compatibility polish",

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Circle, Clock, Files, MessageSquare, PanelLeftClose, PanelLeftOpen, RefreshCcw, Server, Square, TerminalSquare, XCircle } from "lucide-react";
+import { AlertTriangle, Circle, Clock, Files, ListChecks, MessageSquare, PanelLeftClose, PanelLeftOpen, RefreshCcw, Server, Square, TerminalSquare, XCircle } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { apiGet, apiPost } from "../lib/api";
@@ -9,6 +9,7 @@ import { CountBadge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { Notice } from "../components/ui/notice";
 import { ApprovalDialog } from "../components/console/approval-dialog";
+import { BulkCommandDialog } from "../components/console/bulk-command-dialog";
 import { FileTransferDialog } from "../components/console/file-transfer-dialog";
 import { MessagesDialog } from "../components/console/messages-dialog";
 import { NoLiveSession } from "../components/console/no-live-session";
@@ -24,6 +25,7 @@ export function ConsolePage() {
     approvals,
     messages,
     loadTokens,
+    loadApprovals,
     loadMessages,
     markMessagesRead,
     consoleSessions,
@@ -53,6 +55,7 @@ export function ConsolePage() {
   const [serversCompact, setServersCompact] = useState(false);
   const [tokensCompact, setTokensCompact] = useState(false);
   const [fileTransferOpen, setFileTransferOpen] = useState(false);
+  const [bulkCommandOpen, setBulkCommandOpen] = useState(false);
   const [restartAction, setRestartAction] = useState({ state: "idle", error: null });
   const [now, setNow] = useState(Date.now());
 
@@ -406,6 +409,17 @@ export function ConsolePage() {
               type="button"
               variant="ghost"
               className={`h-9 border px-3 ${theme === "light" ? "border-stone-300 text-stone-800 hover:bg-stone-100" : "border-stone-600 text-stone-100 hover:bg-stone-700"}`}
+              onClick={() => setBulkCommandOpen(true)}
+              disabled={servers.data.length === 0}
+              title="Run one command across selected servers"
+            >
+              <ListChecks className="h-3.5 w-3.5" />
+              Bulk
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              className={`h-9 border px-3 ${theme === "light" ? "border-stone-300 text-stone-800 hover:bg-stone-100" : "border-stone-600 text-stone-100 hover:bg-stone-700"}`}
               onClick={() => setFileTransferOpen(true)}
               disabled={!selectedServer}
               title="Upload or download one file"
@@ -517,6 +531,13 @@ export function ConsolePage() {
         open={fileTransferOpen}
         server={selectedServer}
         onClose={() => setFileTransferOpen(false)}
+      />
+      <BulkCommandDialog
+        open={bulkCommandOpen}
+        servers={servers.data}
+        selectedServer={selectedServer}
+        onClose={() => setBulkCommandOpen(false)}
+        onRefresh={loadApprovals}
       />
       <MessagesDialog
         open={messagesOpen}


### PR DESCRIPTION
## Summary

- add local UI bulk command execution across selected servers
- add compact two-panel bulk result review UI
- document REST behavior and prepare 0.1.12 changelog/release metadata

## Safety

- requires unlocked UI session and CSRF like other mutating UI routes
- creates manual command request history rows without MCP token identity
- requires an explicit confirmation phrase before execution

## Verification

- backend: go test ./...
- backend: go vet ./...
- frontend: npm test
- frontend: npm run build
- docker compose up -d --build
- curl -fsS http://127.0.0.1:3210/health

Please use Rebase and merge after checks pass so the release keeps separate commits.