### PR TITLE
Refactor SSH through connector groundwork

### DIFF
--- a/backend/internal/actions/doc.go
+++ b/backend/internal/actions/doc.go
@@ -1,0 +1,7 @@
+// Package actions contains the generic connector action service skeleton.
+//
+// It is deliberately small and not wired into the current SSH runtime yet. The
+// package establishes the future flow from a target reference to a connector
+// prepared action without making target IDs ambiguous between legacy SSH server
+// IDs and connector targets.
+package actions

--- a/backend/internal/actions/service.go
+++ b/backend/internal/actions/service.go
@@ -1,0 +1,113 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+var (
+	ErrTargetNotFound       = errors.New("target not found")
+	ErrConnectorUnavailable = errors.New("connector unavailable")
+)
+
+// TargetResolver resolves a stable target reference into the public target and
+// selected credential profile used for a connector action.
+//
+// A future resolver can map refs like "ssh:12" or "postgres:main-readonly"
+// without making numeric IDs ambiguous.
+type TargetResolver interface {
+	ResolveActionTarget(ctx context.Context, targetRef string) (ResolvedTarget, error)
+}
+
+// ResolvedTarget is the non-secret target/profile pair for one action request.
+type ResolvedTarget struct {
+	Target  connectors.TargetView
+	Profile connectors.CredentialProfileView
+}
+
+// PrepareRequest is the gateway-facing request to prepare a connector action.
+type PrepareRequest struct {
+	Source    string
+	TargetRef string
+
+	ActionName string
+	Input      map[string]any
+	Reason     string
+	CreatedAt  time.Time
+}
+
+// PreparedRequest is ready for permission evaluation and approval.
+type PreparedRequest struct {
+	Target    connectors.TargetView
+	Profile   connectors.CredentialProfileView
+	Action    connectors.PreparedAction
+	Requested PrepareRequest
+}
+
+// Service owns the generic target -> connector -> prepared action boundary.
+type Service struct {
+	registry *connectors.Registry
+	targets  TargetResolver
+}
+
+// NewService creates a generic connector action service.
+func NewService(registry *connectors.Registry, targets TargetResolver) *Service {
+	return &Service{registry: registry, targets: targets}
+}
+
+// Prepare resolves the target/profile, finds the connector, and asks the
+// connector to prepare an action without executing it.
+func (s *Service) Prepare(ctx context.Context, request PrepareRequest) (PreparedRequest, error) {
+	if s == nil || s.registry == nil || s.targets == nil {
+		return PreparedRequest{}, fmt.Errorf("action service is not configured")
+	}
+	if request.TargetRef == "" {
+		return PreparedRequest{}, fmt.Errorf("target_ref is required")
+	}
+	if !connectors.ValidIdentifier(request.ActionName) {
+		return PreparedRequest{}, fmt.Errorf("invalid action name %q", request.ActionName)
+	}
+
+	resolved, err := s.targets.ResolveActionTarget(ctx, request.TargetRef)
+	if err != nil {
+		return PreparedRequest{}, err
+	}
+	if resolved.Target.ConnectorKind == "" {
+		return PreparedRequest{}, fmt.Errorf("target %q has no connector kind", request.TargetRef)
+	}
+
+	connector, ok := s.registry.Get(resolved.Target.ConnectorKind)
+	if !ok {
+		return PreparedRequest{}, fmt.Errorf("%w: %s", ErrConnectorUnavailable, resolved.Target.ConnectorKind)
+	}
+
+	createdAt := request.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	actionRequest := connectors.ActionRequest{
+		Source:     request.Source,
+		Target:     resolved.Target,
+		Profile:    resolved.Profile,
+		ActionName: request.ActionName,
+		Input:      request.Input,
+		Reason:     request.Reason,
+		CreatedAt:  createdAt,
+	}
+
+	prepared, err := connector.PrepareAction(ctx, actionRequest)
+	if err != nil {
+		return PreparedRequest{}, err
+	}
+
+	return PreparedRequest{
+		Target:    resolved.Target,
+		Profile:   resolved.Profile,
+		Action:    prepared,
+		Requested: request,
+	}, nil
+}

--- a/backend/internal/actions/service_test.go
+++ b/backend/internal/actions/service_test.go
@@ -1,0 +1,157 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+type fakeResolver struct {
+	target  connectors.TargetView
+	profile connectors.CredentialProfileView
+	err     error
+	seenRef string
+}
+
+func (r *fakeResolver) ResolveActionTarget(_ context.Context, targetRef string) (ResolvedTarget, error) {
+	r.seenRef = targetRef
+	if r.err != nil {
+		return ResolvedTarget{}, r.err
+	}
+	return ResolvedTarget{Target: r.target, Profile: r.profile}, nil
+}
+
+type prepareConnector struct {
+	kind string
+	seen connectors.ActionRequest
+	err  error
+}
+
+func (c *prepareConnector) Kind() string                    { return c.kind }
+func (c *prepareConnector) Label() string                   { return "Test" }
+func (c *prepareConnector) Version() string                 { return "0.1" }
+func (c *prepareConnector) TargetSchema() connectors.Schema { return connectors.Schema{} }
+func (c *prepareConnector) CredentialSchemas() []connectors.CredentialSchema {
+	return nil
+}
+func (c *prepareConnector) GetHelp(context.Context, connectors.TargetView) (connectors.ConnectorHelp, error) {
+	return connectors.ConnectorHelp{}, nil
+}
+func (c *prepareConnector) GetActionList(context.Context, connectors.TargetView) ([]connectors.ActionDefinition, error) {
+	return nil, nil
+}
+func (c *prepareConnector) PrepareAction(_ context.Context, req connectors.ActionRequest) (connectors.PreparedAction, error) {
+	c.seen = req
+	if c.err != nil {
+		return connectors.PreparedAction{}, c.err
+	}
+	return connectors.PreparedAction{
+		ConnectorKind: c.kind,
+		TargetRef:     req.Target.Ref,
+		ProfileID:     req.Profile.ID,
+		ActionName:    req.ActionName,
+		Risk:          connectors.RiskRead,
+		Title:         "Prepared",
+	}, nil
+}
+func (c *prepareConnector) ExecuteAction(context.Context, connectors.RuntimeContext, connectors.PreparedAction) (connectors.ActionResult, error) {
+	return connectors.ActionResult{}, nil
+}
+
+func TestServicePrepareResolvesTargetAndConnector(t *testing.T) {
+	registry := connectors.NewRegistry()
+	connector := &prepareConnector{kind: "postgres"}
+	if err := registry.Register(connector); err != nil {
+		t.Fatalf("register connector: %v", err)
+	}
+
+	resolver := &fakeResolver{
+		target: connectors.TargetView{
+			ID:            7,
+			Ref:           "postgres:main",
+			ConnectorKind: "postgres",
+			Name:          "Main DB",
+		},
+		profile: connectors.CredentialProfileView{
+			ID:     11,
+			Kind:   "password",
+			Label:  "readonly",
+			Public: map[string]any{"username": "app_readonly"},
+		},
+	}
+	service := NewService(registry, resolver)
+	createdAt := time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC)
+
+	prepared, err := service.Prepare(context.Background(), PrepareRequest{
+		Source:     "mcp",
+		TargetRef:  "postgres:main",
+		ActionName: "query_readonly",
+		Input:      map[string]any{"sql": "select 1"},
+		Reason:     "smoke",
+		CreatedAt:  createdAt,
+	})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if resolver.seenRef != "postgres:main" {
+		t.Fatalf("resolver saw ref %q", resolver.seenRef)
+	}
+	if connector.seen.ActionName != "query_readonly" {
+		t.Fatalf("connector saw action %q", connector.seen.ActionName)
+	}
+	if connector.seen.Profile.Label != "readonly" {
+		t.Fatalf("connector saw profile %#v", connector.seen.Profile)
+	}
+	if !connector.seen.CreatedAt.Equal(createdAt) {
+		t.Fatalf("created_at = %s", connector.seen.CreatedAt)
+	}
+	if prepared.Action.ProfileID != 11 || prepared.Action.TargetRef != "postgres:main" {
+		t.Fatalf("prepared action mismatch: %#v", prepared.Action)
+	}
+}
+
+func TestServicePrepareRejectsInvalidInput(t *testing.T) {
+	service := NewService(connectors.NewRegistry(), &fakeResolver{})
+
+	if _, err := service.Prepare(context.Background(), PrepareRequest{ActionName: "query_readonly"}); err == nil {
+		t.Fatal("expected missing target_ref error")
+	}
+	if _, err := service.Prepare(context.Background(), PrepareRequest{TargetRef: "postgres:main", ActionName: "bad-action"}); err == nil {
+		t.Fatal("expected invalid action name error")
+	}
+}
+
+func TestServicePrepareReturnsConnectorUnavailable(t *testing.T) {
+	resolver := &fakeResolver{
+		target: connectors.TargetView{
+			Ref:           "redis:cache",
+			ConnectorKind: "redis",
+		},
+	}
+	service := NewService(connectors.NewRegistry(), resolver)
+
+	_, err := service.Prepare(context.Background(), PrepareRequest{
+		TargetRef:  "redis:cache",
+		ActionName: "get_key",
+	})
+	if !errors.Is(err, ErrConnectorUnavailable) {
+		t.Fatalf("expected ErrConnectorUnavailable, got %v", err)
+	}
+}
+
+func TestServicePreparePropagatesResolverError(t *testing.T) {
+	want := errors.New("resolver failed")
+	service := NewService(connectors.NewRegistry(), &fakeResolver{err: want})
+
+	_, err := service.Prepare(context.Background(), PrepareRequest{
+		TargetRef:  "postgres:main",
+		ActionName: "get_tables",
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("expected resolver error, got %v", err)
+	}
+}

--- a/backend/internal/api/approvals.go
+++ b/backend/internal/api/approvals.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aipermission/aipermission/backend/internal/actions"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
 	"github.com/aipermission/aipermission/backend/internal/console"
 )
 
@@ -178,6 +181,20 @@ func (s approvalHandlers) runApproval(w http.ResponseWriter, r *http.Request) {
 		})
 		writeError(w, http.StatusConflict, driftReason+"; ask the AI to send a fresh request")
 		return
+	}
+	prepared, err := runtime.prepareConnectorAction(r.Context(), actions.PrepareRequest{
+		Source:     item.Source,
+		TargetRef:  connectortargets.SSHTargetRef(item.ServerID),
+		ActionName: sshconnector.ActionExec,
+		Input:      map[string]any{"command": command},
+		Reason:     item.Reason,
+	})
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	if preparedCommand, ok := prepared.Action.Payload["command"].(string); ok {
+		command = preparedCommand
 	}
 	if request.UserNote != "" && item.TokenID != nil {
 		_, err := s.insertMessage(r.Context(), runtime, createMessageRequest{

--- a/backend/internal/api/connector_actions.go
+++ b/backend/internal/api/connector_actions.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aipermission/aipermission/backend/internal/actions"
+	"github.com/aipermission/aipermission/backend/internal/connectors/builtin"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
+)
+
+func (runtime *databaseRuntime) prepareConnectorAction(ctx context.Context, request actions.PrepareRequest) (actions.PreparedRequest, error) {
+	if runtime == nil || runtime.database == nil {
+		return actions.PreparedRequest{}, fmt.Errorf("database runtime is not available")
+	}
+	registry, err := builtin.NewRegistry()
+	if err != nil {
+		return actions.PreparedRequest{}, err
+	}
+	service := actions.NewService(registry, connectortargets.NewResolver(runtime.database))
+	return service.Prepare(ctx, request)
+}

--- a/backend/internal/api/connector_actions_test.go
+++ b/backend/internal/api/connector_actions_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/actions"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
+	dbpkg "github.com/aipermission/aipermission/backend/internal/db"
+)
+
+func TestRuntimePrepareConnectorActionUsesLegacySSHResolver(t *testing.T) {
+	database := openAPITestDB(t)
+	keyID := insertAPITestSSHKey(t, database, "main")
+	serverID := insertAPITestServer(t, database, keyID)
+	runtime := &databaseRuntime{database: database}
+
+	prepared, err := runtime.prepareConnectorAction(context.Background(), actions.PrepareRequest{
+		Source:     "mcp",
+		TargetRef:  connectortargets.SSHTargetRef(serverID),
+		ActionName: sshconnector.ActionExec,
+		Input:      map[string]any{"command": "uptime"},
+		Reason:     "smoke",
+		CreatedAt:  time.Date(2026, 6, 9, 12, 30, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("prepare connector action: %v", err)
+	}
+
+	if prepared.Action.ConnectorKind != sshconnector.Kind {
+		t.Fatalf("connector kind = %q", prepared.Action.ConnectorKind)
+	}
+	if prepared.Action.TargetRef != connectortargets.SSHTargetRef(serverID) {
+		t.Fatalf("target ref = %q", prepared.Action.TargetRef)
+	}
+	if prepared.Action.ProfileID != keyID {
+		t.Fatalf("profile id = %d", prepared.Action.ProfileID)
+	}
+	if prepared.Action.Payload["command"] != "uptime" {
+		t.Fatalf("payload = %#v", prepared.Action.Payload)
+	}
+}
+
+func openAPITestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	database, err := dbpkg.OpenEncrypted(filepath.Join(t.TempDir(), "test.db"), "test-password")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = database.Close()
+	})
+	return database
+}
+
+func insertAPITestSSHKey(t *testing.T, database *sql.DB, name string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	result, err := database.Exec(`
+		INSERT INTO ssh_keys (name, key_type, public_key, encrypted_private_key, fingerprint, created_at, updated_at)
+		VALUES (?, 'ed25519', 'ssh-ed25519 AAAATEST aipermission-test', 'encrypted', 'SHA256:test', ?, ?)`,
+		name,
+		now,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("insert ssh key: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("ssh key id: %v", err)
+	}
+	return id
+}
+
+func insertAPITestServer(t *testing.T, database *sql.DB, sshKeyID int64) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	result, err := database.Exec(`
+		INSERT INTO servers (name, host, port, username, ssh_key_id, description, created_at, updated_at)
+		VALUES ('core-1', '10.0.0.10', 22, 'root', ?, 'test server', ?, ?)`,
+		sshKeyID,
+		now,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("insert server: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("server id: %v", err)
+	}
+	return id
+}

--- a/backend/internal/api/file_transfer_handlers.go
+++ b/backend/internal/api/file_transfer_handlers.go
@@ -686,7 +686,7 @@ func (s fileTransferHandlers) startUploadBatch(w http.ResponseWriter, r *http.Re
 	if !ok {
 		return
 	}
-	batch, serverID, overwrite, ok := s.createUploadBatchFromMultipart(w, r, runtime, filetransfer.SourceUI, nil, nil)
+	batch, serverID, overwrite, ok := s.createUploadBatchFromMultipart(w, r, runtime, filetransfer.SourceUI, nil, nil, nil)
 	if !ok {
 		return
 	}
@@ -700,7 +700,7 @@ func (s fileTransferHandlers) startUploadBatch(w http.ResponseWriter, r *http.Re
 	writeJSON(w, http.StatusAccepted, batch)
 }
 
-func (s fileTransferHandlers) createUploadBatchFromMultipart(w http.ResponseWriter, r *http.Request, runtime *databaseRuntime, source string, status *string, authorize func(serverID int64) bool) (filetransfer.BatchRecord, int64, bool, bool) {
+func (s fileTransferHandlers) createUploadBatchFromMultipart(w http.ResponseWriter, r *http.Request, runtime *databaseRuntime, source string, status *string, authorize func(serverID int64) bool, prepare func(serverID int64, remoteDir string, fileNames []string, overwrite bool) bool) (filetransfer.BatchRecord, int64, bool, bool) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxFileTransferUploadBytes)
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid multipart upload")
@@ -738,10 +738,26 @@ func (s fileTransferHandlers) createUploadBatchFromMultipart(w http.ResponseWrit
 		writeError(w, http.StatusBadRequest, "cannot upload more than 100 files at once")
 		return filetransfer.BatchRecord{}, 0, false, false
 	}
-	requests := make([]filetransfer.CreateRequest, 0, len(headers))
-	tempPaths := []string{}
+	fileNames := make([]string, 0, len(headers))
+	remotePaths := make([]string, 0, len(headers))
 	seenRemotePaths := map[string]bool{}
 	for _, header := range headers {
+		fileName := safeFileName(header.Filename)
+		remotePath := joinRemoteFilePath(remoteDir, fileName)
+		if seenRemotePaths[remotePath] {
+			writeError(w, http.StatusBadRequest, "upload queue contains duplicate remote paths")
+			return filetransfer.BatchRecord{}, 0, false, false
+		}
+		seenRemotePaths[remotePath] = true
+		fileNames = append(fileNames, fileName)
+		remotePaths = append(remotePaths, remotePath)
+	}
+	if prepare != nil && !prepare(serverID, remoteDir, fileNames, overwrite) {
+		return filetransfer.BatchRecord{}, 0, false, false
+	}
+	requests := make([]filetransfer.CreateRequest, 0, len(headers))
+	tempPaths := []string{}
+	for i, header := range headers {
 		file, err := header.Open()
 		if err != nil {
 			cleanupTempPaths(tempPaths)
@@ -756,18 +772,10 @@ func (s fileTransferHandlers) createUploadBatchFromMultipart(w http.ResponseWrit
 			return filetransfer.BatchRecord{}, 0, false, false
 		}
 		tempPaths = append(tempPaths, tempPath)
-		fileName := safeFileName(header.Filename)
-		remotePath := joinRemoteFilePath(remoteDir, fileName)
-		if seenRemotePaths[remotePath] {
-			cleanupTempPaths(tempPaths)
-			writeError(w, http.StatusBadRequest, "upload queue contains duplicate remote paths")
-			return filetransfer.BatchRecord{}, 0, false, false
-		}
-		seenRemotePaths[remotePath] = true
 		requests = append(requests, filetransfer.CreateRequest{
-			LocalPath:  fileName,
-			RemotePath: remotePath,
-			FileName:   fileName,
+			LocalPath:  fileNames[i],
+			RemotePath: remotePaths[i],
+			FileName:   fileNames[i],
 			SizeBytes:  size,
 			TempPath:   tempPath,
 		})

--- a/backend/internal/api/mcp.go
+++ b/backend/internal/api/mcp.go
@@ -345,6 +345,15 @@ func (s mcpHandlers) mcpReadConsole(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	if _, err := auth.runtime.prepareConnectorAction(r.Context(), actions.PrepareRequest{
+		Source:     commandRequestSourceMCP,
+		TargetRef:  connectortargets.SSHTargetRef(serverID),
+		ActionName: sshconnector.ActionReadConsole,
+		Input:      map[string]any{"tail_bytes": tail},
+	}); err != nil {
+		writeInternalError(w)
+		return
+	}
 
 	sessions, err := auth.runtime.consoleSessions.List(r.Context(), serverID)
 	if err != nil {

--- a/backend/internal/api/mcp.go
+++ b/backend/internal/api/mcp.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aipermission/aipermission/backend/internal/actions"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
 	"github.com/aipermission/aipermission/backend/internal/console"
 	"github.com/aipermission/aipermission/backend/internal/tokens"
 )
@@ -121,6 +124,20 @@ func (s mcpHandlers) mcpExec(w http.ResponseWriter, r *http.Request) {
 			PolicyWarnings: policyWarnings,
 		})
 		return
+	}
+	prepared, err := auth.runtime.prepareConnectorAction(r.Context(), actions.PrepareRequest{
+		Source:     commandRequestSourceMCP,
+		TargetRef:  connectortargets.SSHTargetRef(request.ServerID),
+		ActionName: sshconnector.ActionExec,
+		Input:      map[string]any{"command": request.Command},
+		Reason:     request.Reason,
+	})
+	if err != nil {
+		writeInternalError(w)
+		return
+	}
+	if command, ok := prepared.Action.Payload["command"].(string); ok {
+		request.Command = command
 	}
 	if rule == tokens.RuleApprovalRequired {
 		id, err := s.insertCommandRequest(r.Context(), auth.runtime, auth.TokenID, request.ServerID, request.Command, request.Reason, "pending_approval")

--- a/backend/internal/api/mcp_bulk.go
+++ b/backend/internal/api/mcp_bulk.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/aipermission/aipermission/backend/internal/actions"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
 	"github.com/aipermission/aipermission/backend/internal/tokens"
 )
 
@@ -83,12 +86,27 @@ func (s mcpHandlers) mcpBulkExec(w http.ResponseWriter, r *http.Request) {
 			items = append(items, item)
 			continue
 		}
+		command := request.Command
+		prepared, err := auth.runtime.prepareConnectorAction(r.Context(), actions.PrepareRequest{
+			Source:     commandRequestSourceMCP,
+			TargetRef:  connectortargets.SSHTargetRef(serverID),
+			ActionName: sshconnector.ActionExec,
+			Input:      map[string]any{"command": command},
+			Reason:     request.Reason,
+		})
+		if err != nil {
+			writeInternalError(w)
+			return
+		}
+		if preparedCommand, ok := prepared.Action.Payload["command"].(string); ok {
+			command = preparedCommand
+		}
 
 		status := "running"
 		if rule == tokens.RuleApprovalRequired {
 			status = "pending_approval"
 		}
-		requestID, err := s.insertCommandRequest(r.Context(), auth.runtime, auth.TokenID, serverID, request.Command, request.Reason, status)
+		requestID, err := s.insertCommandRequest(r.Context(), auth.runtime, auth.TokenID, serverID, command, request.Reason, status)
 		if err != nil {
 			writeInternalError(w)
 			return
@@ -102,7 +120,7 @@ func (s mcpHandlers) mcpBulkExec(w http.ResponseWriter, r *http.Request) {
 		if rule == tokens.RuleApprovalRequired {
 			s.writeAudit(r.Context(), auth.runtime, "mcp", int64Ptr(auth.TokenID), serverID, "mcp.bulk_exec.approval_pending", map[string]any{
 				"request_id":            requestID,
-				"command":               request.Command,
+				"command":               command,
 				"reason":                request.Reason,
 				"approval_context_hash": item.ApprovalContextHash,
 			})
@@ -111,14 +129,14 @@ func (s mcpHandlers) mcpBulkExec(w http.ResponseWriter, r *http.Request) {
 
 		s.writeAudit(r.Context(), auth.runtime, "mcp", int64Ptr(auth.TokenID), serverID, "mcp.bulk_exec.running", map[string]any{
 			"request_id": requestID,
-			"command":    request.Command,
+			"command":    command,
 			"reason":     request.Reason,
 		})
 		runItems = append(runItems, mcpBulkExecRunItem{
 			RequestID:  requestID,
 			ServerID:   serverID,
 			ServerName: serverName,
-			Command:    request.Command,
+			Command:    command,
 			Reason:     request.Reason,
 			TokenID:    auth.TokenID,
 		})

--- a/backend/internal/api/mcp_console_handlers.go
+++ b/backend/internal/api/mcp_console_handlers.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/aipermission/aipermission/backend/internal/actions"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
 	"github.com/aipermission/aipermission/backend/internal/tokens"
 )
 
@@ -44,6 +47,14 @@ func (s mcpHandlers) mcpRestartConsoleSession(w http.ResponseWriter, r *http.Req
 			ServerID: request.ServerID,
 			Error:    "This token is blocked from restarting this server console session",
 		})
+		return
+	}
+	if _, err := auth.runtime.prepareConnectorAction(r.Context(), actions.PrepareRequest{
+		Source:     commandRequestSourceMCP,
+		TargetRef:  connectortargets.SSHTargetRef(request.ServerID),
+		ActionName: sshconnector.ActionRestartConsoleSession,
+	}); err != nil {
+		writeInternalError(w)
 		return
 	}
 

--- a/backend/internal/api/mcp_file_transfers.go
+++ b/backend/internal/api/mcp_file_transfers.go
@@ -436,6 +436,21 @@ func (s mcpHandlers) mcpStartFileUpload(w http.ResponseWriter, r *http.Request) 
 			initialStatus = filetransfer.StatusPendingApproval
 		}
 		return true
+	}, func(nextServerID int64, remoteDir string, fileNames []string, nextOverwrite bool) bool {
+		if _, err := auth.runtime.prepareConnectorAction(r.Context(), actions.PrepareRequest{
+			Source:     commandRequestSourceMCP,
+			TargetRef:  connectortargets.SSHTargetRef(nextServerID),
+			ActionName: sshconnector.ActionUploadFiles,
+			Input: map[string]any{
+				"local_paths": fileNames,
+				"remote_dir":  remoteDir,
+				"overwrite":   nextOverwrite,
+			},
+		}); err != nil {
+			writeInternalError(w)
+			return false
+		}
+		return true
 	})
 	if !ok {
 		return

--- a/backend/internal/api/mcp_file_transfers.go
+++ b/backend/internal/api/mcp_file_transfers.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aipermission/aipermission/backend/internal/actions"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
 	"github.com/aipermission/aipermission/backend/internal/execution"
 	"github.com/aipermission/aipermission/backend/internal/filetransfer"
 	"github.com/aipermission/aipermission/backend/internal/tokens"
@@ -303,6 +306,15 @@ func (s mcpHandlers) mcpBrowseRemoteFiles(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if _, err := auth.runtime.prepareConnectorAction(r.Context(), actions.PrepareRequest{
+		Source:     commandRequestSourceMCP,
+		TargetRef:  connectortargets.SSHTargetRef(request.ServerID),
+		ActionName: sshconnector.ActionBrowseRemoteFiles,
+		Input:      map[string]any{"path": remotePath},
+	}); err != nil {
+		writeInternalError(w)
+		return
+	}
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 	server, privateKey, err := fileTransferHandlers{s.Server}.serverSSHMaterialFromRuntime(ctx, auth.runtime, request.ServerID)
@@ -348,6 +360,18 @@ func (s mcpHandlers) mcpStartFileDownload(w http.ResponseWriter, r *http.Request
 	initialStatus := filetransfer.StatusPending
 	if permission.Rule == tokens.RuleApprovalRequired {
 		initialStatus = filetransfer.StatusPendingApproval
+	}
+	if _, err := auth.runtime.prepareConnectorAction(r.Context(), actions.PrepareRequest{
+		Source:     commandRequestSourceMCP,
+		TargetRef:  connectortargets.SSHTargetRef(request.ServerID),
+		ActionName: sshconnector.ActionStartFileDownload,
+		Input: map[string]any{
+			"remote_paths": request.RemotePaths,
+			"archive_name": request.ArchiveName,
+		},
+	}); err != nil {
+		writeInternalError(w)
+		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 	defer cancel()

--- a/backend/internal/architecture/import_boundaries_test.go
+++ b/backend/internal/architecture/import_boundaries_test.go
@@ -1,0 +1,61 @@
+package architecture
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const modulePath = "github.com/aipermission/aipermission/backend"
+
+func TestConnectorGroundworkImportBoundaries(t *testing.T) {
+	packages := []string{
+		modulePath + "/internal/connectors",
+		modulePath + "/internal/actions",
+	}
+	forbidden := []string{
+		modulePath + "/internal/api",
+		modulePath + "/internal/config",
+		modulePath + "/internal/db",
+		modulePath + "/internal/execution",
+		modulePath + "/internal/filetransfer",
+		modulePath + "/internal/servers",
+		modulePath + "/internal/sshconfig",
+		modulePath + "/internal/sshkeys",
+		modulePath + "/internal/tokens",
+		modulePath + "/internal/vault",
+	}
+
+	for _, pkg := range packages {
+		imports := packageDependencies(t, pkg)
+		for _, forbiddenImport := range forbidden {
+			if imports[forbiddenImport] {
+				t.Fatalf("%s must not import %s", pkg, forbiddenImport)
+			}
+		}
+	}
+}
+
+func packageDependencies(t *testing.T, pkg string) map[string]bool {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-deps", "-f", "{{.ImportPath}}", pkg)
+	cmd.Dir = "../.."
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("go list %s failed: %v\n%s", pkg, err, string(exitErr.Stderr))
+		}
+		t.Fatalf("go list %s failed: %v", pkg, err)
+	}
+
+	imports := make(map[string]bool)
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line == pkg {
+			continue
+		}
+		imports[line] = true
+	}
+	return imports
+}

--- a/backend/internal/architecture/import_boundaries_test.go
+++ b/backend/internal/architecture/import_boundaries_test.go
@@ -12,6 +12,7 @@ func TestConnectorGroundworkImportBoundaries(t *testing.T) {
 	packages := []string{
 		modulePath + "/internal/connectors",
 		modulePath + "/internal/actions",
+		modulePath + "/internal/connectortargets",
 	}
 	forbidden := []string{
 		modulePath + "/internal/api",

--- a/backend/internal/connectors/README.md
+++ b/backend/internal/connectors/README.md
@@ -1,0 +1,30 @@
+# Connectors
+
+`internal/connectors` defines the small internal contract for future
+connector-shaped targets.
+
+The package is intentionally inert in the current SSH runtime. It introduces
+shared vocabulary and types only:
+
+- connector
+- target
+- credential profile
+- action definition
+- prepared action
+- action result
+- registry
+
+The gateway core remains responsible for token authentication, permission
+rules, approval, redaction, history, and audit. Connectors describe available
+actions and execute only after the gateway has allowed the action.
+
+The initial design goal is:
+
+```text
+Connector knows the system.
+Gateway knows permission.
+AI knows only actions.
+```
+
+Do not add connector implementations here until the SSH behavior-preserving
+adapter boundary is ready.

--- a/backend/internal/connectors/builtin/registry.go
+++ b/backend/internal/connectors/builtin/registry.go
@@ -1,0 +1,29 @@
+// Package builtin registers connector implementations shipped with
+// AIPermission.
+package builtin
+
+import (
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+)
+
+// RegisterAll adds all built-in connectors to the provided registry.
+func RegisterAll(registry *connectors.Registry) error {
+	for _, connector := range []connectors.Connector{
+		sshconnector.New(),
+	} {
+		if err := registry.Register(connector); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NewRegistry returns a registry populated with all built-in connectors.
+func NewRegistry() (*connectors.Registry, error) {
+	registry := connectors.NewRegistry()
+	if err := RegisterAll(registry); err != nil {
+		return nil, err
+	}
+	return registry, nil
+}

--- a/backend/internal/connectors/builtin/registry_test.go
+++ b/backend/internal/connectors/builtin/registry_test.go
@@ -1,0 +1,39 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+)
+
+func TestNewRegistryIncludesSSHConnector(t *testing.T) {
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+
+	connector, ok := registry.Get(sshconnector.Kind)
+	if !ok {
+		t.Fatal("expected ssh connector")
+	}
+	if connector.Label() != sshconnector.Label {
+		t.Fatalf("label = %q", connector.Label())
+	}
+
+	infos := registry.List()
+	if len(infos) != 1 || infos[0].Kind != sshconnector.Kind {
+		t.Fatalf("unexpected connector list: %#v", infos)
+	}
+}
+
+func TestRegisterAllPropagatesRegistryErrors(t *testing.T) {
+	registry := connectors.NewRegistry()
+	if err := registry.Register(sshconnector.New()); err != nil {
+		t.Fatalf("seed ssh: %v", err)
+	}
+
+	if err := RegisterAll(registry); err == nil {
+		t.Fatal("expected duplicate registration error")
+	}
+}

--- a/backend/internal/connectors/connector.go
+++ b/backend/internal/connectors/connector.go
@@ -1,0 +1,58 @@
+package connectors
+
+import "context"
+
+// Connector is the required contract for connector-shaped targets.
+//
+// GetHelp, GetActionList, and PrepareAction must be side-effect-free and should
+// not need raw secret access. ExecuteAction receives RuntimeContext only after
+// core permission and approval rules allow execution.
+type Connector interface {
+	Kind() string
+	Label() string
+	Version() string
+
+	TargetSchema() Schema
+	CredentialSchemas() []CredentialSchema
+
+	GetHelp(ctx context.Context, target TargetView) (ConnectorHelp, error)
+	GetActionList(ctx context.Context, target TargetView) ([]ActionDefinition, error)
+
+	PrepareAction(ctx context.Context, req ActionRequest) (PreparedAction, error)
+	ExecuteAction(ctx context.Context, runtime RuntimeContext, action PreparedAction) (ActionResult, error)
+}
+
+// TestableConnector is optional because some connectors cannot test a
+// connection without side effects or expensive setup.
+type TestableConnector interface {
+	TestConnection(ctx context.Context, runtime RuntimeContext) (TestResult, error)
+}
+
+// SecretAccessor resolves connector credential secrets at runtime.
+type SecretAccessor interface {
+	GetSecret(ctx context.Context, name string) (string, error)
+}
+
+// EventSink lets long-running connectors emit progress without writing
+// history/audit directly.
+type EventSink interface {
+	Emit(ctx context.Context, event ActionEvent) error
+}
+
+// RuntimeContext is available only to execution/test paths. It intentionally
+// separates public target/profile metadata from secret access.
+type RuntimeContext struct {
+	Target  TargetView
+	Profile CredentialProfileView
+
+	Secrets SecretAccessor
+	Events  EventSink
+}
+
+// ActionEvent is a structured, redaction-ready progress event.
+type ActionEvent struct {
+	Phase   string         `json:"phase"`
+	Level   string         `json:"level,omitempty"`
+	Message string         `json:"message"`
+	Data    map[string]any `json:"data,omitempty"`
+}

--- a/backend/internal/connectors/doc.go
+++ b/backend/internal/connectors/doc.go
@@ -1,0 +1,8 @@
+// Package connectors defines the small internal contract used by
+// connector-shaped targets.
+//
+// The package is intentionally transport-agnostic. It does not know about SSH,
+// Postgres, Redis, or API recipes. Concrete connectors describe actions and
+// execute approved actions; the gateway core remains responsible for token
+// authentication, permission rules, approval, redaction, history, and audit.
+package connectors

--- a/backend/internal/connectors/registry.go
+++ b/backend/internal/connectors/registry.go
@@ -1,0 +1,70 @@
+package connectors
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+var identifierPattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// Registry stores connector implementations by kind.
+type Registry struct {
+	byKind map[string]Connector
+}
+
+// NewRegistry creates an empty connector registry.
+func NewRegistry() *Registry {
+	return &Registry{byKind: make(map[string]Connector)}
+}
+
+// Register adds one connector. Connector kinds are stable lowercase
+// identifiers such as "ssh", "postgres", or "http_recipe".
+func (r *Registry) Register(connector Connector) error {
+	if connector == nil {
+		return fmt.Errorf("connector is nil")
+	}
+	kind := connector.Kind()
+	if !ValidIdentifier(kind) {
+		return fmt.Errorf("invalid connector kind %q", kind)
+	}
+	if _, exists := r.byKind[kind]; exists {
+		return fmt.Errorf("connector kind %q already registered", kind)
+	}
+	r.byKind[kind] = connector
+	return nil
+}
+
+// Get returns a connector by kind.
+func (r *Registry) Get(kind string) (Connector, bool) {
+	connector, ok := r.byKind[kind]
+	return connector, ok
+}
+
+// List returns connector metadata in stable order.
+func (r *Registry) List() []ConnectorInfo {
+	infos := make([]ConnectorInfo, 0, len(r.byKind))
+	for kind, connector := range r.byKind {
+		infos = append(infos, ConnectorInfo{
+			Kind:    kind,
+			Label:   connector.Label(),
+			Version: connector.Version(),
+		})
+	}
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].Kind < infos[j].Kind
+	})
+	return infos
+}
+
+// ConnectorInfo is safe to expose in local UI/API metadata.
+type ConnectorInfo struct {
+	Kind    string `json:"kind"`
+	Label   string `json:"label"`
+	Version string `json:"version"`
+}
+
+// ValidIdentifier validates connector kinds and action names.
+func ValidIdentifier(value string) bool {
+	return identifierPattern.MatchString(value)
+}

--- a/backend/internal/connectors/registry_test.go
+++ b/backend/internal/connectors/registry_test.go
@@ -1,0 +1,95 @@
+package connectors
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeConnector struct {
+	kind    string
+	label   string
+	version string
+}
+
+func (f fakeConnector) Kind() string                          { return f.kind }
+func (f fakeConnector) Label() string                         { return f.label }
+func (f fakeConnector) Version() string                       { return f.version }
+func (f fakeConnector) TargetSchema() Schema                  { return Schema{} }
+func (f fakeConnector) CredentialSchemas() []CredentialSchema { return nil }
+func (f fakeConnector) GetHelp(context.Context, TargetView) (ConnectorHelp, error) {
+	return ConnectorHelp{ConnectorID: f.kind, Connector: f.label}, nil
+}
+func (f fakeConnector) GetActionList(context.Context, TargetView) ([]ActionDefinition, error) {
+	return []ActionDefinition{{Name: "example", Risk: RiskRead}}, nil
+}
+func (f fakeConnector) PrepareAction(context.Context, ActionRequest) (PreparedAction, error) {
+	return PreparedAction{ConnectorKind: f.kind, ActionName: "example"}, nil
+}
+func (f fakeConnector) ExecuteAction(context.Context, RuntimeContext, PreparedAction) (ActionResult, error) {
+	return ActionResult{Status: ResultCompleted}, nil
+}
+
+func TestRegistryRegisterAndList(t *testing.T) {
+	registry := NewRegistry()
+
+	if err := registry.Register(fakeConnector{kind: "postgres", label: "Postgres", version: "0.1"}); err != nil {
+		t.Fatalf("register postgres: %v", err)
+	}
+	if err := registry.Register(fakeConnector{kind: "ssh", label: "SSH", version: "0.1"}); err != nil {
+		t.Fatalf("register ssh: %v", err)
+	}
+
+	if connector, ok := registry.Get("ssh"); !ok || connector.Label() != "SSH" {
+		t.Fatalf("expected ssh connector, got %v ok=%v", connector, ok)
+	}
+
+	got := registry.List()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 connectors, got %d", len(got))
+	}
+	if got[0].Kind != "postgres" || got[1].Kind != "ssh" {
+		t.Fatalf("expected stable kind order, got %#v", got)
+	}
+}
+
+func TestRegistryRejectsInvalidConnector(t *testing.T) {
+	registry := NewRegistry()
+
+	if err := registry.Register(nil); err == nil {
+		t.Fatal("expected nil connector error")
+	}
+	if err := registry.Register(fakeConnector{kind: "Bad-Kind"}); err == nil {
+		t.Fatal("expected invalid kind error")
+	}
+}
+
+func TestRegistryRejectsDuplicateKind(t *testing.T) {
+	registry := NewRegistry()
+
+	if err := registry.Register(fakeConnector{kind: "ssh", label: "SSH", version: "0.1"}); err != nil {
+		t.Fatalf("register ssh: %v", err)
+	}
+	if err := registry.Register(fakeConnector{kind: "ssh", label: "SSH again", version: "0.2"}); err == nil {
+		t.Fatal("expected duplicate kind error")
+	}
+}
+
+func TestValidIdentifier(t *testing.T) {
+	tests := map[string]bool{
+		"ssh":         true,
+		"postgres":    true,
+		"http_recipe": true,
+		"redis2":      true,
+		"":            false,
+		"SSH":         false,
+		"2redis":      false,
+		"http-recipe": false,
+		"api.recipe":  false,
+	}
+
+	for value, want := range tests {
+		if got := ValidIdentifier(value); got != want {
+			t.Fatalf("ValidIdentifier(%q) = %v, want %v", value, got, want)
+		}
+	}
+}

--- a/backend/internal/connectors/schema.go
+++ b/backend/internal/connectors/schema.go
@@ -1,0 +1,59 @@
+package connectors
+
+// FieldType describes a primitive UI/API schema field type.
+type FieldType string
+
+const (
+	FieldString          FieldType = "string"
+	FieldSecret          FieldType = "secret"
+	FieldMultiline       FieldType = "multiline"
+	FieldMultilineSecret FieldType = "multiline_secret"
+	FieldNumber          FieldType = "number"
+	FieldBoolean         FieldType = "boolean"
+	FieldSelect          FieldType = "select"
+	FieldJSON            FieldType = "json"
+	FieldFileText        FieldType = "file_text"
+	FieldFileBase64      FieldType = "file_base64"
+)
+
+// FieldOption describes a selectable field value.
+type FieldOption struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+// Field describes one connector target, credential, or action input field.
+type Field struct {
+	Name        string        `json:"name"`
+	Label       string        `json:"label"`
+	Type        FieldType     `json:"type"`
+	Required    bool          `json:"required,omitempty"`
+	Secret      bool          `json:"secret,omitempty"`
+	Description string        `json:"description,omitempty"`
+	Default     any           `json:"default,omitempty"`
+	Options     []FieldOption `json:"options,omitempty"`
+}
+
+// Schema is a small declarative shape used for target forms, credential forms,
+// and action inputs.
+type Schema struct {
+	Fields []Field `json:"fields"`
+}
+
+// CredentialSchema describes one credential profile kind supported by a
+// connector.
+type CredentialSchema struct {
+	Kind        string `json:"kind"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+	Schema      Schema `json:"schema"`
+}
+
+// OutputHint gives core/UI a connector-provided hint for rendering and
+// redaction. Core still owns the actual redaction behavior.
+type OutputHint struct {
+	Format          string   `json:"format,omitempty"`
+	SensitiveFields []string `json:"sensitive_fields,omitempty"`
+	MaxRows         int      `json:"max_rows,omitempty"`
+	MaxBytes        int      `json:"max_bytes,omitempty"`
+}

--- a/backend/internal/connectors/ssh/ssh.go
+++ b/backend/internal/connectors/ssh/ssh.go
@@ -1,0 +1,298 @@
+// Package sshconnector defines the SSH connector contract without wiring it
+// into the current runtime path yet.
+package sshconnector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+const (
+	Kind    = "ssh"
+	Label   = "SSH"
+	Version = "0.1"
+
+	ActionExec                  = "exec"
+	ActionReadConsole           = "read_console"
+	ActionRestartConsoleSession = "restart_console_session"
+
+	defaultConsoleTailBytes = 20000
+	maxConsoleTailBytes     = 100000
+)
+
+var (
+	ErrUnsupportedAction = errors.New("unsupported ssh connector action")
+	ErrExecutionNotWired = errors.New("ssh connector execution is not wired yet")
+)
+
+// Connector describes the current SSH feature set as a connector-shaped target.
+// Existing MCP/API handlers still own execution until the connector runtime is
+// introduced.
+type Connector struct{}
+
+func New() Connector {
+	return Connector{}
+}
+
+func (Connector) Kind() string {
+	return Kind
+}
+
+func (Connector) Label() string {
+	return Label
+}
+
+func (Connector) Version() string {
+	return Version
+}
+
+func (Connector) TargetSchema() connectors.Schema {
+	return connectors.Schema{Fields: []connectors.Field{
+		{
+			Name:        "host",
+			Label:       "Host",
+			Type:        connectors.FieldString,
+			Required:    true,
+			Description: "DNS name or IP address of the SSH target.",
+		},
+		{
+			Name:        "port",
+			Label:       "Port",
+			Type:        connectors.FieldNumber,
+			Required:    true,
+			Default:     22,
+			Description: "SSH port.",
+		},
+		{
+			Name:        "description",
+			Label:       "Description",
+			Type:        connectors.FieldMultiline,
+			Description: "Non-secret operator notes. This may be visible to AI clients.",
+		},
+		{
+			Name:        "startup_input_after_connect",
+			Label:       "Startup input after connect",
+			Type:        connectors.FieldString,
+			Description: "Optional text sent after PTY connect for menu-based devices such as NAS appliances.",
+		},
+	}}
+}
+
+func (Connector) CredentialSchemas() []connectors.CredentialSchema {
+	return []connectors.CredentialSchema{
+		{
+			Kind:        "private_key",
+			Label:       "SSH private key",
+			Description: "Gateway-managed or imported SSH private key. Passphrases are used only during import and are not stored.",
+			Schema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "username",
+					Label:       "Username",
+					Type:        connectors.FieldString,
+					Required:    true,
+					Description: "Remote SSH username for this credential profile.",
+				},
+				{
+					Name:        "private_key",
+					Label:       "Private key",
+					Type:        connectors.FieldMultilineSecret,
+					Required:    true,
+					Secret:      true,
+					Description: "Private key material stored through the encrypted vault layer.",
+				},
+				{
+					Name:        "public_key",
+					Label:       "Public key",
+					Type:        connectors.FieldMultiline,
+					Description: "Public key line used for remote authorized_keys installation.",
+				},
+			}},
+		},
+	}
+}
+
+func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (connectors.ConnectorHelp, error) {
+	title := "SSH target"
+	if target.Name != "" {
+		title = "SSH target: " + target.Name
+	}
+	return connectors.ConnectorHelp{
+		Title:       title,
+		Summary:     "Run bounded non-interactive shell commands through AIPermission's local SSH gateway.",
+		Connector:   Label,
+		ConnectorID: Kind,
+		Usage: []string{
+			"Use exec for shell commands. Include a short reason so the operator can approve or audit the action.",
+			"Use read_console only for always-run targets when you need live persistent console output.",
+			"Use restart_console_session when a persistent console appears stuck before sending more commands.",
+			"Prefer bounded output: tail -n, journalctl --no-pager -n, docker logs --tail, or redirect full output to a temp file.",
+		},
+		Warnings: []string{
+			"SSH commands execute on the target shell after token permission and approval checks.",
+			"Avoid printing secrets. Redaction is best-effort and cannot make secret output safe.",
+			"list_servers style target metadata is not a live health check; execution errors are the reachability signal.",
+		},
+	}, nil
+}
+
+func (Connector) GetActionList(context.Context, connectors.TargetView) ([]connectors.ActionDefinition, error) {
+	return []connectors.ActionDefinition{
+		{
+			Name:        ActionExec,
+			Label:       "Run command",
+			Description: "Run a non-interactive command in the target's persistent SSH console.",
+			Category:    "command",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "command",
+					Label:       "Command",
+					Type:        connectors.FieldMultiline,
+					Required:    true,
+					Description: "Shell command to run on the target.",
+				},
+			}},
+			OutputHint: connectors.OutputHint{Format: "terminal", MaxBytes: 100000},
+		},
+		{
+			Name:        ActionReadConsole,
+			Label:       "Read console",
+			Description: "Read the latest persistent SSH console transcript.",
+			Category:    "console",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "tail_bytes",
+					Label:       "Tail bytes",
+					Type:        connectors.FieldNumber,
+					Default:     defaultConsoleTailBytes,
+					Description: "Maximum trailing transcript bytes to return.",
+				},
+			}},
+			OutputHint: connectors.OutputHint{Format: "terminal", MaxBytes: maxConsoleTailBytes},
+		},
+		{
+			Name:        ActionRestartConsoleSession,
+			Label:       "Restart console session",
+			Description: "Close the gateway-owned persistent SSH console session so the next action reconnects.",
+			Category:    "console",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{},
+			OutputHint:  connectors.OutputHint{Format: "json"},
+		},
+	}, nil
+}
+
+func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) (connectors.PreparedAction, error) {
+	base := connectors.PreparedAction{
+		ConnectorKind: Kind,
+		TargetRef:     req.Target.Ref,
+		ProfileID:     req.Profile.ID,
+		ActionName:    req.ActionName,
+		ContextMaterial: map[string]any{
+			"connector_kind": Kind,
+			"target_ref":     req.Target.Ref,
+			"profile_id":     req.Profile.ID,
+			"action_name":    req.ActionName,
+		},
+	}
+
+	switch req.ActionName {
+	case ActionExec:
+		command := strings.TrimSpace(stringInput(req.Input, "command"))
+		if command == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("%s command is required", ActionExec)
+		}
+		base.Risk = connectors.RiskWrite
+		base.Title = "Run SSH command"
+		base.Summary = targetSummary(req.Target, "Run a shell command")
+		base.Preview = map[string]any{
+			"command": command,
+			"reason":  strings.TrimSpace(req.Reason),
+		}
+		base.Payload = map[string]any{
+			"command": command,
+			"reason":  strings.TrimSpace(req.Reason),
+		}
+		base.ContextMaterial["command"] = command
+		base.ContextMaterial["reason"] = strings.TrimSpace(req.Reason)
+		return base, nil
+	case ActionReadConsole:
+		tail := intInput(req.Input, "tail_bytes", defaultConsoleTailBytes)
+		if tail < 1 {
+			tail = defaultConsoleTailBytes
+		}
+		if tail > maxConsoleTailBytes {
+			tail = maxConsoleTailBytes
+		}
+		base.Risk = connectors.RiskRead
+		base.Title = "Read SSH console"
+		base.Summary = targetSummary(req.Target, "Read the latest console transcript")
+		base.Preview = map[string]any{"tail_bytes": tail}
+		base.Payload = map[string]any{"tail_bytes": tail}
+		base.ContextMaterial["tail_bytes"] = tail
+		return base, nil
+	case ActionRestartConsoleSession:
+		base.Risk = connectors.RiskWrite
+		base.Title = "Restart SSH console session"
+		base.Summary = targetSummary(req.Target, "Restart the persistent console session")
+		base.Preview = map[string]any{}
+		base.Payload = map[string]any{}
+		return base, nil
+	default:
+		return connectors.PreparedAction{}, fmt.Errorf("%w: %s", ErrUnsupportedAction, req.ActionName)
+	}
+}
+
+func (Connector) ExecuteAction(context.Context, connectors.RuntimeContext, connectors.PreparedAction) (connectors.ActionResult, error) {
+	return connectors.ActionResult{}, ErrExecutionNotWired
+}
+
+func targetSummary(target connectors.TargetView, action string) string {
+	if target.Name == "" {
+		return action + " on SSH target."
+	}
+	return action + " on " + target.Name + "."
+}
+
+func stringInput(input map[string]any, name string) string {
+	if input == nil {
+		return ""
+	}
+	value, ok := input[name]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func intInput(input map[string]any, name string, fallback int) int {
+	if input == nil {
+		return fallback
+	}
+	value, ok := input[name]
+	if !ok || value == nil {
+		return fallback
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case float32:
+		return int(typed)
+	default:
+		return fallback
+	}
+}

--- a/backend/internal/connectors/ssh/ssh.go
+++ b/backend/internal/connectors/ssh/ssh.go
@@ -19,6 +19,9 @@ const (
 	ActionExec                  = "exec"
 	ActionReadConsole           = "read_console"
 	ActionRestartConsoleSession = "restart_console_session"
+	ActionBrowseRemoteFiles     = "browse_remote_files"
+	ActionStartFileDownload     = "start_file_download"
+	ActionUploadFiles           = "upload_files"
 
 	defaultConsoleTailBytes = 20000
 	maxConsoleTailBytes     = 100000
@@ -129,6 +132,8 @@ func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (conne
 			"Use exec for shell commands. Include a short reason so the operator can approve or audit the action.",
 			"Use read_console only for always-run targets when you need live persistent console output.",
 			"Use restart_console_session when a persistent console appears stuck before sending more commands.",
+			"Use browse_remote_files before file transfers when the remote path is uncertain.",
+			"Use start_file_download for remote-to-local transfer queues and upload_files for local-to-remote transfer queues.",
 			"Prefer bounded output: tail -n, journalctl --no-pager -n, docker logs --tail, or redirect full output to a temp file.",
 		},
 		Warnings: []string{
@@ -183,6 +188,76 @@ func (Connector) GetActionList(context.Context, connectors.TargetView) ([]connec
 			Risk:        connectors.RiskWrite,
 			InputSchema: connectors.Schema{},
 			OutputHint:  connectors.OutputHint{Format: "json"},
+		},
+		{
+			Name:        ActionBrowseRemoteFiles,
+			Label:       "Browse remote files",
+			Description: "List files in a remote directory before choosing transfer paths.",
+			Category:    "files",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "path",
+					Label:       "Remote path",
+					Type:        connectors.FieldString,
+					Default:     "~",
+					Description: "Remote directory to list.",
+				},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxRows: 500},
+		},
+		{
+			Name:        ActionStartFileDownload,
+			Label:       "Start file download",
+			Description: "Create a remote-to-local file transfer queue.",
+			Category:    "files",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "remote_paths",
+					Label:       "Remote paths",
+					Type:        connectors.FieldJSON,
+					Required:    true,
+					Description: "Array of absolute remote file paths to download.",
+				},
+				{
+					Name:        "archive_name",
+					Label:       "Archive name",
+					Type:        connectors.FieldString,
+					Description: "Optional archive filename for multi-file downloads.",
+				},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json"},
+		},
+		{
+			Name:        ActionUploadFiles,
+			Label:       "Upload files",
+			Description: "Create a local-to-remote file transfer queue.",
+			Category:    "files",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "local_paths",
+					Label:       "Local paths",
+					Type:        connectors.FieldJSON,
+					Required:    true,
+					Description: "Array of local file paths selected by the local client.",
+				},
+				{
+					Name:        "remote_dir",
+					Label:       "Remote directory",
+					Type:        connectors.FieldString,
+					Required:    true,
+					Description: "Remote directory where files should be uploaded.",
+				},
+				{
+					Name:        "overwrite",
+					Label:       "Overwrite",
+					Type:        connectors.FieldBoolean,
+					Description: "Whether existing remote files may be overwritten.",
+				},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json"},
 		},
 	}, nil
 }
@@ -243,6 +318,67 @@ func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) 
 		base.Preview = map[string]any{}
 		base.Payload = map[string]any{}
 		return base, nil
+	case ActionBrowseRemoteFiles:
+		remotePath := strings.TrimSpace(stringInput(req.Input, "path"))
+		if remotePath == "" {
+			remotePath = "~"
+		}
+		base.Risk = connectors.RiskRead
+		base.Title = "Browse remote files"
+		base.Summary = targetSummary(req.Target, "Browse a remote directory")
+		base.Preview = map[string]any{"path": remotePath}
+		base.Payload = map[string]any{"path": remotePath}
+		base.ContextMaterial["path"] = remotePath
+		return base, nil
+	case ActionStartFileDownload:
+		remotePaths := stringSliceInput(req.Input, "remote_paths")
+		if len(remotePaths) == 0 {
+			return connectors.PreparedAction{}, fmt.Errorf("%s remote_paths is required", ActionStartFileDownload)
+		}
+		archiveName := strings.TrimSpace(stringInput(req.Input, "archive_name"))
+		base.Risk = connectors.RiskRead
+		base.Title = "Start SSH file download"
+		base.Summary = targetSummary(req.Target, "Start a remote-to-local transfer queue")
+		base.Preview = map[string]any{
+			"remote_paths": remotePaths,
+			"archive_name": archiveName,
+			"items":        len(remotePaths),
+		}
+		base.Payload = map[string]any{
+			"remote_paths": remotePaths,
+			"archive_name": archiveName,
+		}
+		base.ContextMaterial["remote_paths"] = remotePaths
+		base.ContextMaterial["archive_name"] = archiveName
+		return base, nil
+	case ActionUploadFiles:
+		localPaths := stringSliceInput(req.Input, "local_paths")
+		if len(localPaths) == 0 {
+			return connectors.PreparedAction{}, fmt.Errorf("%s local_paths is required", ActionUploadFiles)
+		}
+		remoteDir := strings.TrimSpace(stringInput(req.Input, "remote_dir"))
+		if remoteDir == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("%s remote_dir is required", ActionUploadFiles)
+		}
+		overwrite := boolInput(req.Input, "overwrite")
+		base.Risk = connectors.RiskWrite
+		base.Title = "Upload SSH files"
+		base.Summary = targetSummary(req.Target, "Start a local-to-remote transfer queue")
+		base.Preview = map[string]any{
+			"local_paths": localPaths,
+			"remote_dir":  remoteDir,
+			"overwrite":   overwrite,
+			"items":       len(localPaths),
+		}
+		base.Payload = map[string]any{
+			"local_paths": localPaths,
+			"remote_dir":  remoteDir,
+			"overwrite":   overwrite,
+		}
+		base.ContextMaterial["local_paths"] = localPaths
+		base.ContextMaterial["remote_dir"] = remoteDir
+		base.ContextMaterial["overwrite"] = overwrite
+		return base, nil
 	default:
 		return connectors.PreparedAction{}, fmt.Errorf("%w: %s", ErrUnsupportedAction, req.ActionName)
 	}
@@ -295,4 +431,53 @@ func intInput(input map[string]any, name string, fallback int) int {
 	default:
 		return fallback
 	}
+}
+
+func boolInput(input map[string]any, name string) bool {
+	if input == nil {
+		return false
+	}
+	value, ok := input[name]
+	if !ok || value == nil {
+		return false
+	}
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), "true")
+	default:
+		return false
+	}
+}
+
+func stringSliceInput(input map[string]any, name string) []string {
+	if input == nil {
+		return nil
+	}
+	value, ok := input[name]
+	if !ok || value == nil {
+		return nil
+	}
+	var raw []string
+	switch typed := value.(type) {
+	case []string:
+		raw = typed
+	case []any:
+		for _, item := range typed {
+			raw = append(raw, strings.TrimSpace(fmt.Sprint(item)))
+		}
+	case string:
+		raw = []string{typed}
+	default:
+		raw = []string{fmt.Sprint(typed)}
+	}
+	clean := make([]string, 0, len(raw))
+	for _, item := range raw {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			clean = append(clean, item)
+		}
+	}
+	return clean
 }

--- a/backend/internal/connectors/ssh/ssh_test.go
+++ b/backend/internal/connectors/ssh/ssh_test.go
@@ -1,0 +1,152 @@
+package sshconnector
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+func TestConnectorMetadataAndSchemas(t *testing.T) {
+	connector := New()
+	if connector.Kind() != Kind || connector.Label() != Label || connector.Version() == "" {
+		t.Fatalf("unexpected metadata kind=%q label=%q version=%q", connector.Kind(), connector.Label(), connector.Version())
+	}
+
+	targetSchema := connector.TargetSchema()
+	if !hasField(targetSchema, "host") || !hasField(targetSchema, "port") {
+		t.Fatalf("expected host and port target fields, got %#v", targetSchema.Fields)
+	}
+
+	credentialSchemas := connector.CredentialSchemas()
+	if len(credentialSchemas) != 1 || credentialSchemas[0].Kind != "private_key" {
+		t.Fatalf("unexpected credential schemas: %#v", credentialSchemas)
+	}
+	if !hasField(credentialSchemas[0].Schema, "username") || !hasField(credentialSchemas[0].Schema, "private_key") {
+		t.Fatalf("expected username and private_key credential fields, got %#v", credentialSchemas[0].Schema.Fields)
+	}
+}
+
+func TestGetHelpAndActionList(t *testing.T) {
+	connector := New()
+	target := connectors.TargetView{Ref: "ssh:core", Name: "core-1", ConnectorKind: Kind}
+
+	help, err := connector.GetHelp(context.Background(), target)
+	if err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	if help.ConnectorID != Kind || help.Title == "" || len(help.Usage) == 0 {
+		t.Fatalf("unexpected help: %#v", help)
+	}
+
+	actions, err := connector.GetActionList(context.Background(), target)
+	if err != nil {
+		t.Fatalf("action list: %v", err)
+	}
+	if len(actions) != 3 {
+		t.Fatalf("expected 3 actions, got %d", len(actions))
+	}
+	if actions[0].Name != ActionExec || actions[0].Risk != connectors.RiskWrite {
+		t.Fatalf("unexpected exec action: %#v", actions[0])
+	}
+	if actions[1].Name != ActionReadConsole || actions[1].Risk != connectors.RiskRead {
+		t.Fatalf("unexpected read_console action: %#v", actions[1])
+	}
+	if actions[2].Name != ActionRestartConsoleSession {
+		t.Fatalf("unexpected restart action: %#v", actions[2])
+	}
+}
+
+func TestPrepareExec(t *testing.T) {
+	connector := New()
+	prepared, err := connector.PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", Name: "worker-2", ConnectorKind: Kind},
+		Profile:    connectors.CredentialProfileView{ID: 42, ConnectorKind: Kind, Kind: "private_key", Label: "root"},
+		ActionName: ActionExec,
+		Input:      map[string]any{"command": " apt update "},
+		Reason:     "maintenance",
+	})
+	if err != nil {
+		t.Fatalf("prepare exec: %v", err)
+	}
+	if prepared.ConnectorKind != Kind || prepared.ActionName != ActionExec || prepared.ProfileID != 42 {
+		t.Fatalf("unexpected prepared action: %#v", prepared)
+	}
+	if got := prepared.Payload["command"]; got != "apt update" {
+		t.Fatalf("command payload = %#v", got)
+	}
+	if prepared.ContextMaterial["reason"] != "maintenance" {
+		t.Fatalf("context material did not include reason: %#v", prepared.ContextMaterial)
+	}
+}
+
+func TestPrepareExecRequiresCommand(t *testing.T) {
+	_, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", ConnectorKind: Kind},
+		ActionName: ActionExec,
+		Input:      map[string]any{"command": "   "},
+	})
+	if err == nil {
+		t.Fatal("expected missing command error")
+	}
+}
+
+func TestPrepareReadConsoleClampsTail(t *testing.T) {
+	prepared, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", ConnectorKind: Kind},
+		ActionName: ActionReadConsole,
+		Input:      map[string]any{"tail_bytes": float64(maxConsoleTailBytes + 5000)},
+	})
+	if err != nil {
+		t.Fatalf("prepare read_console: %v", err)
+	}
+	if got := prepared.Payload["tail_bytes"]; got != maxConsoleTailBytes {
+		t.Fatalf("tail_bytes = %#v, want %d", got, maxConsoleTailBytes)
+	}
+	if prepared.Risk != connectors.RiskRead {
+		t.Fatalf("risk = %q", prepared.Risk)
+	}
+}
+
+func TestPrepareRestartConsoleSession(t *testing.T) {
+	prepared, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", ConnectorKind: Kind},
+		ActionName: ActionRestartConsoleSession,
+	})
+	if err != nil {
+		t.Fatalf("prepare restart: %v", err)
+	}
+	if prepared.Payload == nil || len(prepared.Payload) != 0 {
+		t.Fatalf("expected empty payload map, got %#v", prepared.Payload)
+	}
+	if prepared.Risk != connectors.RiskWrite {
+		t.Fatalf("risk = %q", prepared.Risk)
+	}
+}
+
+func TestPrepareRejectsUnknownAction(t *testing.T) {
+	_, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", ConnectorKind: Kind},
+		ActionName: "upload_file",
+	})
+	if !errors.Is(err, ErrUnsupportedAction) {
+		t.Fatalf("expected ErrUnsupportedAction, got %v", err)
+	}
+}
+
+func TestExecuteActionNotWired(t *testing.T) {
+	_, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{}, connectors.PreparedAction{})
+	if !errors.Is(err, ErrExecutionNotWired) {
+		t.Fatalf("expected ErrExecutionNotWired, got %v", err)
+	}
+}
+
+func hasField(schema connectors.Schema, name string) bool {
+	for _, field := range schema.Fields {
+		if field.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/connectors/ssh/ssh_test.go
+++ b/backend/internal/connectors/ssh/ssh_test.go
@@ -44,8 +44,8 @@ func TestGetHelpAndActionList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("action list: %v", err)
 	}
-	if len(actions) != 3 {
-		t.Fatalf("expected 3 actions, got %d", len(actions))
+	if len(actions) != 6 {
+		t.Fatalf("expected 6 actions, got %d", len(actions))
 	}
 	if actions[0].Name != ActionExec || actions[0].Risk != connectors.RiskWrite {
 		t.Fatalf("unexpected exec action: %#v", actions[0])
@@ -55,6 +55,15 @@ func TestGetHelpAndActionList(t *testing.T) {
 	}
 	if actions[2].Name != ActionRestartConsoleSession {
 		t.Fatalf("unexpected restart action: %#v", actions[2])
+	}
+	if actions[3].Name != ActionBrowseRemoteFiles || actions[3].Risk != connectors.RiskRead {
+		t.Fatalf("unexpected browse action: %#v", actions[3])
+	}
+	if actions[4].Name != ActionStartFileDownload || actions[4].Risk != connectors.RiskRead {
+		t.Fatalf("unexpected download action: %#v", actions[4])
+	}
+	if actions[5].Name != ActionUploadFiles || actions[5].Risk != connectors.RiskWrite {
+		t.Fatalf("unexpected upload action: %#v", actions[5])
 	}
 }
 
@@ -122,6 +131,95 @@ func TestPrepareRestartConsoleSession(t *testing.T) {
 	}
 	if prepared.Risk != connectors.RiskWrite {
 		t.Fatalf("risk = %q", prepared.Risk)
+	}
+}
+
+func TestPrepareBrowseRemoteFilesDefaultsPath(t *testing.T) {
+	prepared, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", ConnectorKind: Kind},
+		ActionName: ActionBrowseRemoteFiles,
+	})
+	if err != nil {
+		t.Fatalf("prepare browse: %v", err)
+	}
+	if got := prepared.Payload["path"]; got != "~" {
+		t.Fatalf("path = %#v", got)
+	}
+}
+
+func TestPrepareStartFileDownload(t *testing.T) {
+	prepared, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", ConnectorKind: Kind},
+		ActionName: ActionStartFileDownload,
+		Input: map[string]any{
+			"remote_paths": []any{"/var/log/syslog", "  /etc/hosts "},
+			"archive_name": "logs.zip",
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare download: %v", err)
+	}
+	paths, ok := prepared.Payload["remote_paths"].([]string)
+	if !ok || len(paths) != 2 || paths[1] != "/etc/hosts" {
+		t.Fatalf("remote_paths = %#v", prepared.Payload["remote_paths"])
+	}
+	if prepared.Preview["items"] != 2 {
+		t.Fatalf("items preview = %#v", prepared.Preview["items"])
+	}
+}
+
+func TestPrepareStartFileDownloadRequiresRemotePaths(t *testing.T) {
+	_, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", ConnectorKind: Kind},
+		ActionName: ActionStartFileDownload,
+		Input:      map[string]any{"remote_paths": []any{"  "}},
+	})
+	if err == nil {
+		t.Fatal("expected missing remote_paths error")
+	}
+}
+
+func TestPrepareUploadFiles(t *testing.T) {
+	prepared, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", ConnectorKind: Kind},
+		ActionName: ActionUploadFiles,
+		Input: map[string]any{
+			"local_paths": []string{"/tmp/report.txt", "/tmp/log.txt"},
+			"remote_dir":  " /home/root ",
+			"overwrite":   "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare upload: %v", err)
+	}
+	if got := prepared.Payload["remote_dir"]; got != "/home/root" {
+		t.Fatalf("remote_dir = %#v", got)
+	}
+	if got := prepared.Payload["overwrite"]; got != true {
+		t.Fatalf("overwrite = %#v", got)
+	}
+	if prepared.Preview["items"] != 2 {
+		t.Fatalf("items preview = %#v", prepared.Preview["items"])
+	}
+}
+
+func TestPrepareUploadFilesRequiresPathsAndRemoteDir(t *testing.T) {
+	_, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", ConnectorKind: Kind},
+		ActionName: ActionUploadFiles,
+		Input:      map[string]any{"local_paths": []string{"/tmp/report.txt"}},
+	})
+	if err == nil {
+		t.Fatal("expected missing remote_dir error")
+	}
+
+	_, err = New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "ssh:worker-2", ConnectorKind: Kind},
+		ActionName: ActionUploadFiles,
+		Input:      map[string]any{"remote_dir": "/home/root"},
+	})
+	if err == nil {
+		t.Fatal("expected missing local_paths error")
 	}
 }
 

--- a/backend/internal/connectors/types.go
+++ b/backend/internal/connectors/types.go
@@ -1,0 +1,138 @@
+package connectors
+
+import "time"
+
+// RiskLevel classifies an action for display, approval previews, and policy
+// presets. It is not a security boundary by itself.
+type RiskLevel string
+
+const (
+	RiskRead                RiskLevel = "read"
+	RiskWrite               RiskLevel = "write"
+	RiskDestructive         RiskLevel = "destructive"
+	RiskCredentialSensitive RiskLevel = "credential_sensitive"
+)
+
+// ResultStatus is the generic lifecycle state for connector action requests.
+type ResultStatus string
+
+const (
+	ResultCompleted       ResultStatus = "completed"
+	ResultFailed          ResultStatus = "failed"
+	ResultCanceled        ResultStatus = "canceled"
+	ResultRunning         ResultStatus = "running"
+	ResultApprovalPending ResultStatus = "approval_pending"
+	ResultBlocked         ResultStatus = "blocked"
+	ResultStale           ResultStatus = "stale"
+)
+
+// ConnectorHelp is AI-readable guidance for one target. It may mention actions,
+// but GetActionList remains the executable contract.
+type ConnectorHelp struct {
+	Title       string   `json:"title"`
+	Summary     string   `json:"summary"`
+	Usage       []string `json:"usage,omitempty"`
+	Warnings    []string `json:"warnings,omitempty"`
+	Connector   string   `json:"connector"`
+	ConnectorID string   `json:"connector_id"`
+}
+
+// TargetView is the public, non-secret view of a configured target.
+type TargetView struct {
+	ID            int64          `json:"id"`
+	Ref           string         `json:"ref"`
+	ConnectorKind string         `json:"connector_kind"`
+	Name          string         `json:"name"`
+	Config        map[string]any `json:"config,omitempty"`
+}
+
+// CredentialProfileView is the public, non-secret view of a credential profile
+// bound to a target.
+type CredentialProfileView struct {
+	ID            int64          `json:"id"`
+	TargetID      int64          `json:"target_id"`
+	ConnectorKind string         `json:"connector_kind"`
+	Kind          string         `json:"kind"`
+	Label         string         `json:"label"`
+	Public        map[string]any `json:"public,omitempty"`
+}
+
+// ActionDefinition is the machine-readable action contract returned by a
+// connector.
+type ActionDefinition struct {
+	Name        string     `json:"name"`
+	Label       string     `json:"label"`
+	Description string     `json:"description"`
+	Category    string     `json:"category,omitempty"`
+	Risk        RiskLevel  `json:"risk"`
+	InputSchema Schema     `json:"input_schema"`
+	OutputHint  OutputHint `json:"output_hint,omitempty"`
+}
+
+// ActionRequest is a side-effect-free request to prepare a target action.
+type ActionRequest struct {
+	Source  string                `json:"source,omitempty"`
+	Target  TargetView            `json:"target"`
+	Profile CredentialProfileView `json:"profile"`
+
+	ActionName string         `json:"action_name"`
+	Input      map[string]any `json:"input,omitempty"`
+	Reason     string         `json:"reason,omitempty"`
+	CreatedAt  time.Time      `json:"created_at,omitempty"`
+}
+
+// PreparedAction is the immutable execution payload produced before permission
+// evaluation and approval. Preview is safe for display; Payload is the raw
+// connector-specific execution payload that core may encrypt for later use.
+type PreparedAction struct {
+	ConnectorKind string    `json:"connector_kind"`
+	TargetRef     string    `json:"target_ref"`
+	ProfileID     int64     `json:"profile_id"`
+	ActionName    string    `json:"action_name"`
+	Risk          RiskLevel `json:"risk"`
+
+	Title   string         `json:"title"`
+	Summary string         `json:"summary"`
+	Preview map[string]any `json:"preview,omitempty"`
+	Payload map[string]any `json:"payload,omitempty"`
+
+	ContextMaterial map[string]any `json:"context_material,omitempty"`
+}
+
+// ActionHandles points callers at follow-up resources for asynchronous actions.
+type ActionHandles struct {
+	RequestID    int64  `json:"request_id,omitempty"`
+	SessionID    int64  `json:"session_id,omitempty"`
+	BatchID      int64  `json:"batch_id,omitempty"`
+	FollowupTool string `json:"followup_tool,omitempty"`
+}
+
+// ActionResult is the connector execution result after core has allowed the
+// action to run.
+type ActionResult struct {
+	Status      ResultStatus   `json:"status"`
+	Output      any            `json:"output,omitempty"`
+	DisplayText string         `json:"display_text,omitempty"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+	Handles     ActionHandles  `json:"handles,omitempty"`
+	Error       string         `json:"error,omitempty"`
+}
+
+// TestStatus is a structured connection-test status.
+type TestStatus string
+
+const (
+	TestOK               TestStatus = "ok"
+	TestFailedAuth       TestStatus = "failed_auth"
+	TestFailedNetwork    TestStatus = "failed_network"
+	TestFailedTLS        TestStatus = "failed_tls"
+	TestFailedPermission TestStatus = "failed_permission"
+	TestUnknownError     TestStatus = "unknown_error"
+)
+
+// TestResult describes an optional connector connection test.
+type TestResult struct {
+	Status  TestStatus     `json:"status"`
+	Message string         `json:"message,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}

--- a/backend/internal/connectortargets/action_service_test.go
+++ b/backend/internal/connectortargets/action_service_test.go
@@ -1,0 +1,82 @@
+package connectortargets
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/actions"
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	"github.com/aipermission/aipermission/backend/internal/connectors/builtin"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+)
+
+func TestActionServicePreparesLegacySSHExec(t *testing.T) {
+	database := openTargetTestDB(t)
+	keyID := insertTargetTestSSHKey(t, database, "main")
+	serverID := insertTargetTestServer(t, database, keyID)
+	registry, err := builtin.NewRegistry()
+	if err != nil {
+		t.Fatalf("builtin registry: %v", err)
+	}
+	service := actions.NewService(registry, NewResolver(database))
+
+	prepared, err := service.Prepare(context.Background(), actions.PrepareRequest{
+		Source:     "mcp",
+		TargetRef:  SSHTargetRef(serverID),
+		ActionName: sshconnector.ActionExec,
+		Input:      map[string]any{"command": "hostname"},
+		Reason:     "smoke",
+		CreatedAt:  time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("prepare legacy ssh exec: %v", err)
+	}
+
+	if prepared.Action.ConnectorKind != sshconnector.Kind {
+		t.Fatalf("connector kind = %q", prepared.Action.ConnectorKind)
+	}
+	if prepared.Action.TargetRef != SSHTargetRef(serverID) {
+		t.Fatalf("target ref = %q", prepared.Action.TargetRef)
+	}
+	if prepared.Action.ProfileID != keyID {
+		t.Fatalf("profile id = %d", prepared.Action.ProfileID)
+	}
+	if prepared.Action.Risk != connectors.RiskWrite {
+		t.Fatalf("risk = %q", prepared.Action.Risk)
+	}
+	if prepared.Action.Payload["command"] != "hostname" {
+		t.Fatalf("payload = %#v", prepared.Action.Payload)
+	}
+}
+
+func TestActionServicePreparesLegacySSHReadConsole(t *testing.T) {
+	database := openTargetTestDB(t)
+	keyID := insertTargetTestSSHKey(t, database, "main")
+	serverID := insertTargetTestServer(t, database, keyID)
+	registry, err := builtin.NewRegistry()
+	if err != nil {
+		t.Fatalf("builtin registry: %v", err)
+	}
+	service := actions.NewService(registry, NewResolver(database))
+
+	prepared, err := service.Prepare(context.Background(), actions.PrepareRequest{
+		Source:     "mcp",
+		TargetRef:  SSHTargetRef(serverID),
+		ActionName: sshconnector.ActionReadConsole,
+		Input:      map[string]any{"tail_bytes": 4096},
+	})
+	if err != nil {
+		t.Fatalf("prepare legacy ssh read_console: %v", err)
+	}
+
+	if prepared.Action.ProfileID != keyID {
+		t.Fatalf("profile id = %d", prepared.Action.ProfileID)
+	}
+	if prepared.Action.Risk != connectors.RiskRead {
+		t.Fatalf("risk = %q", prepared.Action.Risk)
+	}
+	if prepared.Action.Payload["tail_bytes"] != 4096 {
+		t.Fatalf("payload = %#v", prepared.Action.Payload)
+	}
+}

--- a/backend/internal/connectortargets/doc.go
+++ b/backend/internal/connectortargets/doc.go
@@ -1,0 +1,3 @@
+// Package connectortargets adapts persisted target records into connector
+// runtime views.
+package connectortargets

--- a/backend/internal/connectortargets/ssh.go
+++ b/backend/internal/connectortargets/ssh.go
@@ -49,7 +49,7 @@ func (r *Resolver) ResolveActionTarget(ctx context.Context, targetRef string) (a
 	err := r.db.QueryRowContext(ctx, `
 		SELECT
 			s.id, s.name, s.host, s.port, s.username, s.ssh_key_id,
-			COALESCE(k.name, ''), COALESCE(k.key_type, ''), COALESCE(k.fingerprint, ''), COALESCE(k.public_key, ''),
+			COALESCE(k.name, ''), COALESCE(k.key_type, ''), COALESCE(k.fingerprint, ''),
 			s.description, s.startup_input_after_connect, s.force_shell_command
 		FROM servers s
 		LEFT JOIN ssh_keys k ON k.id = s.ssh_key_id
@@ -65,7 +65,6 @@ func (r *Resolver) ResolveActionTarget(ctx context.Context, targetRef string) (a
 		&row.SSHKeyName,
 		&row.SSHKeyType,
 		&row.SSHKeyFingerprint,
-		&row.SSHPublicKey,
 		&row.Description,
 		&row.StartupInputAfterConnect,
 		&row.ForceShellCommand,
@@ -105,7 +104,6 @@ func (r *Resolver) ResolveActionTarget(ctx context.Context, targetRef string) (a
 			"key_name":    row.SSHKeyName,
 			"key_type":    row.SSHKeyType,
 			"fingerprint": row.SSHKeyFingerprint,
-			"public_key":  row.SSHPublicKey,
 		},
 	}
 	return actions.ResolvedTarget{Target: target, Profile: profile}, nil
@@ -121,7 +119,6 @@ type legacySSHServerRow struct {
 	SSHKeyName               string
 	SSHKeyType               string
 	SSHKeyFingerprint        string
-	SSHPublicKey             string
 	Description              string
 	StartupInputAfterConnect string
 	ForceShellCommand        string

--- a/backend/internal/connectortargets/ssh.go
+++ b/backend/internal/connectortargets/ssh.go
@@ -1,0 +1,128 @@
+package connectortargets
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/aipermission/aipermission/backend/internal/actions"
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+)
+
+const sshTargetPrefix = "ssh:"
+
+type Resolver struct {
+	db *sql.DB
+}
+
+func NewResolver(db *sql.DB) *Resolver {
+	return &Resolver{db: db}
+}
+
+func SSHTargetRef(serverID int64) string {
+	return fmt.Sprintf("%s%d", sshTargetPrefix, serverID)
+}
+
+func ParseSSHTargetRef(ref string) (int64, bool) {
+	ref = strings.TrimSpace(ref)
+	if !strings.HasPrefix(ref, sshTargetPrefix) {
+		return 0, false
+	}
+	id, err := strconv.ParseInt(strings.TrimPrefix(ref, sshTargetPrefix), 10, 64)
+	if err != nil || id < 1 {
+		return 0, false
+	}
+	return id, true
+}
+
+func (r *Resolver) ResolveActionTarget(ctx context.Context, targetRef string) (actions.ResolvedTarget, error) {
+	serverID, ok := ParseSSHTargetRef(targetRef)
+	if !ok {
+		return actions.ResolvedTarget{}, actions.ErrTargetNotFound
+	}
+
+	var row legacySSHServerRow
+	err := r.db.QueryRowContext(ctx, `
+		SELECT
+			s.id, s.name, s.host, s.port, s.username, s.ssh_key_id,
+			COALESCE(k.name, ''), COALESCE(k.key_type, ''), COALESCE(k.fingerprint, ''), COALESCE(k.public_key, ''),
+			s.description, s.startup_input_after_connect, s.force_shell_command
+		FROM servers s
+		LEFT JOIN ssh_keys k ON k.id = s.ssh_key_id
+		WHERE s.id = ?`,
+		serverID,
+	).Scan(
+		&row.ID,
+		&row.Name,
+		&row.Host,
+		&row.Port,
+		&row.Username,
+		&row.SSHKeyID,
+		&row.SSHKeyName,
+		&row.SSHKeyType,
+		&row.SSHKeyFingerprint,
+		&row.SSHPublicKey,
+		&row.Description,
+		&row.StartupInputAfterConnect,
+		&row.ForceShellCommand,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return actions.ResolvedTarget{}, actions.ErrTargetNotFound
+	}
+	if err != nil {
+		return actions.ResolvedTarget{}, err
+	}
+	if row.SSHKeyID < 1 || row.SSHKeyName == "" {
+		return actions.ResolvedTarget{}, actions.ErrTargetNotFound
+	}
+
+	target := connectors.TargetView{
+		ID:            row.ID,
+		Ref:           SSHTargetRef(row.ID),
+		ConnectorKind: sshconnector.Kind,
+		Name:          row.Name,
+		Config: map[string]any{
+			"host":                        row.Host,
+			"port":                        row.Port,
+			"description":                 row.Description,
+			"startup_input_after_connect": row.StartupInputAfterConnect,
+			"force_shell_command":         row.ForceShellCommand,
+		},
+	}
+	profile := connectors.CredentialProfileView{
+		ID:            row.SSHKeyID,
+		TargetID:      row.ID,
+		ConnectorKind: sshconnector.Kind,
+		Kind:          "private_key",
+		Label:         row.SSHKeyName,
+		Public: map[string]any{
+			"username":    row.Username,
+			"ssh_key_id":  row.SSHKeyID,
+			"key_name":    row.SSHKeyName,
+			"key_type":    row.SSHKeyType,
+			"fingerprint": row.SSHKeyFingerprint,
+			"public_key":  row.SSHPublicKey,
+		},
+	}
+	return actions.ResolvedTarget{Target: target, Profile: profile}, nil
+}
+
+type legacySSHServerRow struct {
+	ID                       int64
+	Name                     string
+	Host                     string
+	Port                     int
+	Username                 string
+	SSHKeyID                 int64
+	SSHKeyName               string
+	SSHKeyType               string
+	SSHKeyFingerprint        string
+	SSHPublicKey             string
+	Description              string
+	StartupInputAfterConnect string
+	ForceShellCommand        string
+}

--- a/backend/internal/connectortargets/ssh_test.go
+++ b/backend/internal/connectortargets/ssh_test.go
@@ -68,6 +68,9 @@ func TestResolverMapsLegacySSHServerToConnectorViews(t *testing.T) {
 	if resolved.Profile.Public["fingerprint"] != "SHA256:test" {
 		t.Fatalf("fingerprint public metadata missing: %#v", resolved.Profile.Public)
 	}
+	if _, exists := resolved.Profile.Public["public_key"]; exists {
+		t.Fatalf("public key should not be exposed in credential profile metadata: %#v", resolved.Profile.Public)
+	}
 }
 
 func TestResolverReturnsNotFoundForMissingOrInvalidTarget(t *testing.T) {

--- a/backend/internal/connectortargets/ssh_test.go
+++ b/backend/internal/connectortargets/ssh_test.go
@@ -1,0 +1,138 @@
+package connectortargets
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/actions"
+	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
+	appdb "github.com/aipermission/aipermission/backend/internal/db"
+)
+
+func TestSSHTargetRefRoundTrip(t *testing.T) {
+	ref := SSHTargetRef(42)
+	if ref != "ssh:42" {
+		t.Fatalf("ref = %q", ref)
+	}
+	id, ok := ParseSSHTargetRef(ref)
+	if !ok || id != 42 {
+		t.Fatalf("parse = %d ok=%v", id, ok)
+	}
+}
+
+func TestParseSSHTargetRefRejectsInvalidRefs(t *testing.T) {
+	for _, ref := range []string{"", "server:1", "ssh:", "ssh:0", "ssh:not-number"} {
+		if _, ok := ParseSSHTargetRef(ref); ok {
+			t.Fatalf("expected %q to be rejected", ref)
+		}
+	}
+}
+
+func TestResolverMapsLegacySSHServerToConnectorViews(t *testing.T) {
+	database := openTargetTestDB(t)
+	ctx := context.Background()
+	keyID := insertTargetTestSSHKey(t, database, "main")
+	serverID := insertTargetTestServer(t, database, keyID)
+
+	resolved, err := NewResolver(database).ResolveActionTarget(ctx, SSHTargetRef(serverID))
+	if err != nil {
+		t.Fatalf("resolve target: %v", err)
+	}
+
+	if resolved.Target.ID != serverID || resolved.Target.Ref != SSHTargetRef(serverID) {
+		t.Fatalf("unexpected target identity: %#v", resolved.Target)
+	}
+	if resolved.Target.ConnectorKind != sshconnector.Kind {
+		t.Fatalf("connector kind = %q", resolved.Target.ConnectorKind)
+	}
+	if resolved.Target.Config["host"] != "10.0.0.10" || resolved.Target.Config["port"] != 2222 {
+		t.Fatalf("unexpected target config: %#v", resolved.Target.Config)
+	}
+	if resolved.Target.Config["startup_input_after_connect"] != "q" {
+		t.Fatalf("startup input missing: %#v", resolved.Target.Config)
+	}
+
+	if resolved.Profile.ID != keyID || resolved.Profile.TargetID != serverID {
+		t.Fatalf("unexpected profile identity: %#v", resolved.Profile)
+	}
+	if resolved.Profile.ConnectorKind != sshconnector.Kind || resolved.Profile.Kind != "private_key" {
+		t.Fatalf("unexpected profile kind: %#v", resolved.Profile)
+	}
+	if resolved.Profile.Public["username"] != "admin" {
+		t.Fatalf("username public metadata missing: %#v", resolved.Profile.Public)
+	}
+	if resolved.Profile.Public["fingerprint"] != "SHA256:test" {
+		t.Fatalf("fingerprint public metadata missing: %#v", resolved.Profile.Public)
+	}
+}
+
+func TestResolverReturnsNotFoundForMissingOrInvalidTarget(t *testing.T) {
+	database := openTargetTestDB(t)
+	resolver := NewResolver(database)
+
+	for _, ref := range []string{"ssh:999", "postgres:1", "ssh:bad"} {
+		_, err := resolver.ResolveActionTarget(context.Background(), ref)
+		if !errors.Is(err, actions.ErrTargetNotFound) {
+			t.Fatalf("ResolveActionTarget(%q) error = %v", ref, err)
+		}
+	}
+}
+
+func openTargetTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	database, err := appdb.OpenEncrypted(filepath.Join(t.TempDir(), "test.db"), "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = database.Close()
+	})
+	return database
+}
+
+func insertTargetTestSSHKey(t *testing.T, database *sql.DB, name string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	result, err := database.Exec(`
+		INSERT INTO ssh_keys (name, key_type, public_key, encrypted_private_key, fingerprint, created_at, updated_at)
+		VALUES (?, 'ed25519', 'ssh-ed25519 AAAATEST aipermission-test', 'encrypted', 'SHA256:test', ?, ?)`,
+		name,
+		now,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("insert ssh key: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("ssh key id: %v", err)
+	}
+	return id
+}
+
+func insertTargetTestServer(t *testing.T, database *sql.DB, sshKeyID int64) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	result, err := database.Exec(`
+		INSERT INTO servers (
+			name, host, port, username, ssh_key_id, description,
+			startup_input_after_connect, force_shell_command, created_at, updated_at
+		)
+		VALUES ('core-1', '10.0.0.10', 2222, 'admin', ?, 'NAS gateway', 'q', 'bash -l', ?, ?)`,
+		sshKeyID,
+		now,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("insert server: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("server id: %v", err)
+	}
+	return id
+}


### PR DESCRIPTION
## Summary

- add internal connector/action service types and registry groundwork
- adapt existing SSH targets into connector-shaped target/profile views
- route existing SSH MCP paths through connector action preparation while keeping the stable SSH runtime and public MCP surface unchanged

## Validation

- git diff --check main..dev
- cd backend && go test ./...
- cd backend && go test -race ./...
- cd backend && go vet ./...
- make test
- make build
- make audit
- node scripts/secret-scan.js
- cd backend && govulncheck ./...
- local Docker + MCP smoke on test-vps for exec, prompt approval, bulk exec, read_console, restart_console_session, browse/download/upload

## Notes

- No release tag for this internal connector groundwork.
- Generic connector MCP tools remain deferred until the 0.2.0 connector release.