### PR TITLE
Release 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-06-18
+
+### Changed
+
+- Console now shows one row per connector target and keeps credential profiles
+  selectable from the target header, so a Postgres target with multiple
+  profiles no longer looks like multiple databases.
+- Connector token controls now infer Basic, Grouped, or Advanced permission
+  mode from the current action rules instead of always returning to a fixed
+  default view.
+- Postgres Console now keeps profile-scoped sessions and activity easier to
+  inspect when switching between credential profiles.
+
+### Added
+
+- Added Postgres recent-query shortcuts so prior SQL can be loaded back into the
+  editor.
+- Added Postgres request-level SQL actions for loading or copying the SQL from
+  an inspected request.
+
 ## [0.2.2] - 2026-06-17
 
 ### Added

--- a/backend/internal/console/console_session_manager.go
+++ b/backend/internal/console/console_session_manager.go
@@ -106,6 +106,7 @@ func (m *Manager) Create(ctx context.Context, request CreateRequest) (Record, er
 		ctx:       sessionCtx,
 		cancel:    cancel,
 		start:     make(chan struct{}),
+		done:      make(chan struct{}),
 		status:    "connecting",
 		clients:   map[*websocket.Conn]*sync.Mutex{},
 	}
@@ -116,6 +117,8 @@ func (m *Manager) Create(ctx context.Context, request CreateRequest) (Record, er
 	go managed.run()
 	if request.WaitForStart {
 		if err := managed.waitStart(ctx); err != nil {
+			managed.close()
+			_ = managed.waitDone(ctx)
 			return Record{}, err
 		}
 	}

--- a/backend/internal/console/console_session_runtime.go
+++ b/backend/internal/console/console_session_runtime.go
@@ -15,7 +15,12 @@ import (
 )
 
 func (s *managedConsoleSession) run() {
-	defer s.manager.remove(s.id)
+	defer func() {
+		s.manager.remove(s.id)
+		if s.done != nil {
+			close(s.done)
+		}
+	}()
 
 	if s.manager.openRuntime == nil {
 		s.markStarted(fmt.Errorf("console transport is not configured"))
@@ -213,6 +218,18 @@ func (s *managedConsoleSession) waitStart(ctx context.Context) error {
 		err := s.startErr
 		s.mu.Unlock()
 		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *managedConsoleSession) waitDone(ctx context.Context) error {
+	if s == nil || s.done == nil {
+		return nil
+	}
+	select {
+	case <-s.done:
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/backend/internal/console/console_sessions.go
+++ b/backend/internal/console/console_sessions.go
@@ -142,6 +142,7 @@ type managedConsoleSession struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
 	start     chan struct{}
+	done      chan struct{}
 	startOnce sync.Once
 
 	mu            sync.Mutex

--- a/frontend/src/components/console/connector-token-permission-panel.jsx
+++ b/frontend/src/components/console/connector-token-permission-panel.jsx
@@ -46,7 +46,7 @@ export function ConnectorTokenPermissionPanel({
   const [savingKey, setSavingKey] = useState("");
   const [openTokenID, setOpenTokenID] = useState(null);
   const [profileByToken, setProfileByToken] = useState({});
-  const [permissionMode, setPermissionMode] = useState("grouped");
+  const [permissionModeByKey, setPermissionModeByKey] = useState({});
   const compactPanelRef = useRef(null);
   const tokenIDsKey = activeTokens.map((token) => token.id).join(",");
   const load = connectorPermissionState || { state: "idle", data: {}, actionsByTargetRef: {}, error: null };
@@ -158,6 +158,10 @@ export function ConnectorTokenPermissionPanel({
           ]
         : preserved;
       await replaceTokenConnectorPermissions?.(token.id, next);
+      const actions = load.actionsByTargetRef?.[connectorActionCacheKey(selectedTarget, profileID)] || selectedActions;
+      const modeKey = tokenProfileModeKey(token.id, selectedTarget, profileID);
+      const nextMode = inferPermissionMode(next, selectedTarget, profileID, actions);
+      setPermissionModeByKey((current) => ({ ...current, [modeKey]: nextMode }));
     } catch (error) {
       console.error(error);
     } finally {
@@ -196,6 +200,9 @@ export function ConnectorTokenPermissionPanel({
     const lifetimeEditable = activePermissions.some((permission) => effectiveRule(permission) !== "blocked");
     const categoryGroups = groupActions(actions);
     const riskGroups = groupActionsByRisk(actions);
+    const modeKey = tokenProfileModeKey(token.id, selectedTarget, profile.profile_id);
+    const inferredPermissionMode = inferPermissionMode(permissions, selectedTarget, profile.profile_id, actions);
+    const permissionMode = permissionModeByKey[modeKey] || inferredPermissionMode;
     return (
       <div className="grid gap-2">
         <ProfileLifetimeControls
@@ -205,7 +212,7 @@ export function ConnectorTokenPermissionPanel({
           onSetPermanent={() => setProfileLifetime(token, profile.profile_id, "")}
           onSetTemporary={(lifetime) => setProfileLifetime(token, profile.profile_id, expiresAtFromLifetime(lifetime))}
         />
-        {actions.length > 0 ? <PermissionModeTabs value={permissionMode} onChange={setPermissionMode} /> : null}
+        {actions.length > 0 ? <PermissionModeTabs value={permissionMode} onChange={(mode) => setPermissionModeByKey((current) => ({ ...current, [modeKey]: mode }))} /> : null}
         {permissionMode === "basic" && actions.length > 0 ? (
           <PermissionRuleGroup
             title="All operations"
@@ -507,6 +514,21 @@ function ruleForActions(permissions, target, profileID, actions) {
   const unique = new Set(rules);
   if (unique.size <= 1) return rules[0] || "";
   return "mixed";
+}
+
+function inferPermissionMode(permissions, target, profileID, actions) {
+  if (!target || actions.length === 0) return "basic";
+  const allRule = ruleForActions(permissions, target, profileID, actions);
+  if (allRule !== "mixed") return "basic";
+  const riskGroups = groupActionsByRisk(actions).filter((group) => group.actions.length > 0);
+  if (riskGroups.length === 0) return "basic";
+  const groupRules = riskGroups.map((group) => ruleForActions(permissions, target, profileID, group.actions));
+  if (groupRules.every((rule) => rule !== "mixed")) return "grouped";
+  return "advanced";
+}
+
+function tokenProfileModeKey(tokenID, target, profileID) {
+  return `${tokenID}:${target?.connector_kind || ""}:${target?.target_id || ""}:${profileID || ""}`;
 }
 
 function groupActions(actions) {

--- a/frontend/src/connectors/templates/postgres/console.jsx
+++ b/frontend/src/connectors/templates/postgres/console.jsx
@@ -69,6 +69,7 @@ export function PostgresConnectorConsoleTemplate({ target, approvals, theme, ses
       return Number.isFinite(createdAt) && createdAt >= startedAt - 1000;
     });
   }, [rawItems, activeSession.active, activeSession.startedAt]);
+  const recentQueries = useMemo(() => recentPostgresQueries(rawItems), [rawItems]);
   const selected = useMemo(() => {
     if (selectedID) {
       const exact = items.find((item) => Number(item.id) === Number(selectedID));
@@ -195,6 +196,12 @@ export function PostgresConnectorConsoleTemplate({ target, approvals, theme, ses
     setEditorFocusTick((current) => current + 1);
   }
 
+  function loadRecentQuery(query) {
+    if (!query?.sql) return;
+    setSQL(query.sql);
+    setEditorFocusTick((current) => current + 1);
+  }
+
   if (!activeSession.active) {
     return (
       <div className={`grid min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
@@ -212,18 +219,28 @@ export function PostgresConnectorConsoleTemplate({ target, approvals, theme, ses
             <p className="text-xs font-semibold">SQL</p>
             <p className={`truncate text-xs ${mutedClass}`}>{metadataStatusText(metadata)}</p>
           </div>
-          <label className="flex shrink-0 items-center gap-2 text-xs font-semibold">
-            Max rows
-            <input
-              type="number"
-              min="1"
-              max="1000"
-              className={`h-8 w-20 rounded-md border px-2 outline-none ${inputClass}`}
-              value={maxRows}
-              onChange={(event) => setMaxRows(event.target.value)}
-              disabled={!activeSession.active || runState.state === "running"}
-            />
-          </label>
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+            <CopyButton value={sql} variant="outline" className="h-8 px-2 text-xs" iconClassName="h-3.5 w-3.5" title="Copy SQL" disabled={!sql.trim()}>
+              SQL
+            </CopyButton>
+            {recentQueries.length > 0 ? (
+              <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={() => loadRecentQuery(recentQueries[0])} title="Load the most recent query">
+                Last query
+              </Button>
+            ) : null}
+            <label className="flex items-center gap-2 text-xs font-semibold">
+              Max rows
+              <input
+                type="number"
+                min="1"
+                max="1000"
+                className={`h-8 w-20 rounded-md border px-2 outline-none ${inputClass}`}
+                value={maxRows}
+                onChange={(event) => setMaxRows(event.target.value)}
+                disabled={!activeSession.active || runState.state === "running"}
+              />
+            </label>
+          </div>
         </div>
         <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
           <PostgresSQLEditor
@@ -240,6 +257,22 @@ export function PostgresConnectorConsoleTemplate({ target, approvals, theme, ses
           </Button>
         </div>
         {runState.error ? <Notice tone="bad">{runState.error}</Notice> : null}
+        {recentQueries.length > 0 ? (
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <span className={`shrink-0 text-[11px] font-semibold uppercase ${mutedClass}`}>Recent</span>
+            {recentQueries.slice(0, 5).map((query) => (
+              <button
+                key={`${query.id}:${query.preview}`}
+                type="button"
+                className={`max-w-64 truncate rounded-full border px-2.5 py-1 text-left font-mono text-[11px] transition ${theme === "light" ? "border-stone-200 bg-white text-stone-700 hover:bg-stone-100" : "border-stone-700 bg-[#1a1a1a] text-stone-200 hover:bg-stone-800"}`}
+                title={query.sql}
+                onClick={() => loadRecentQuery(query)}
+              >
+                {query.preview}
+              </button>
+            ))}
+          </div>
+        ) : null}
       </form>
 
       <div className={`grid h-full min-h-0 grid-rows-[minmax(0,1fr)] gap-4 overflow-hidden p-4 ${resultView ? "grid-cols-1" : "lg:grid-cols-[320px_minmax(0,1fr)]"}`}>
@@ -777,6 +810,37 @@ function metadataStatusText(metadata) {
       : "No metadata suggestions found. Run bounded read-only SQL through this credential profile.";
   }
   return "Run bounded read-only SQL through this credential profile.";
+}
+
+function recentPostgresQueries(items) {
+  const seen = new Set();
+  return [...(items || [])]
+    .filter((item) => item?.action_name === "query_readonly" && !isAutocompleteMetadataRequest(item))
+    .sort((left, right) => safeTimestamp(right.created_at) - safeTimestamp(left.created_at))
+    .map((item) => ({ id: item.id, sql: actionInputSQL(item), createdAt: item.created_at }))
+    .filter((item) => {
+      if (!item.sql || seen.has(item.sql)) return false;
+      seen.add(item.sql);
+      return true;
+    })
+    .slice(0, 10)
+    .map((item) => ({ ...item, preview: sqlPreview(item.sql) }));
+}
+
+function sqlPreview(sql) {
+  const compact = String(sql || "").replace(/\s+/g, " ").trim();
+  if (compact.length <= 64) return compact;
+  return `${compact.slice(0, 61)}...`;
+}
+
+function actionInputSQL(item) {
+  const input = typeof item?.input === "string" ? parseJSON(item.input) : item?.input;
+  return String(input?.sql || "").trim();
+}
+
+function safeTimestamp(value) {
+  const parsed = Date.parse(value || "");
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function tableBrowserSummary(metadata, rows) {

--- a/frontend/src/connectors/templates/postgres/console.jsx
+++ b/frontend/src/connectors/templates/postgres/console.jsx
@@ -77,6 +77,7 @@ export function PostgresConnectorConsoleTemplate({ target, approvals, theme, ses
     }
     return items[0] || null;
   }, [items, selectedID]);
+  const selectedSQL = selected ? actionInputSQL(selected) : "";
   const browserTables = useMemo(() => filteredTableBrowserRows(metadata.tables, browserSearch), [metadata.tables, browserSearch]);
 
   useEffect(() => {
@@ -356,7 +357,19 @@ export function PostgresConnectorConsoleTemplate({ target, approvals, theme, ses
                 </div>
                 <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
                   {selected.reason ? <p className={`min-w-0 flex-1 truncate text-xs ${mutedClass}`}>Reason: {selected.reason}</p> : <span />}
-                  <ResultViewToggle checked={resultView} onChange={setResultView} theme={theme} />
+                  <div className="flex shrink-0 flex-wrap items-center gap-2">
+                    {selectedSQL ? (
+                      <>
+                        <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={() => loadRecentQuery({ sql: selectedSQL })}>
+                          Load SQL
+                        </Button>
+                        <CopyButton value={selectedSQL} variant="outline" className="h-8 px-2 text-xs" iconClassName="h-3.5 w-3.5" title="Copy request SQL">
+                          SQL
+                        </CopyButton>
+                      </>
+                    ) : null}
+                    <ResultViewToggle checked={resultView} onChange={setResultView} theme={theme} />
+                  </div>
                 </div>
                 {selected.error ? <Notice tone="bad">{selected.error}</Notice> : null}
               </header>

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -227,7 +227,8 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.2"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.3"/);
+  assert.match(releaseSource, /Console profile polish/);
   assert.match(releaseSource, /Postgres management/);
   assert.match(releaseSource, /Maintenance hardening/);
   assert.match(releaseSource, /Updated golang\.org\/x\/crypto to 0\.53\.0/);

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -248,6 +248,8 @@ test("Token permission controls expose temporary grant lifetimes", () => {
   assert.match(connectorTokenPermissionPanelSource, /Basic/);
   assert.match(connectorTokenPermissionPanelSource, /Grouped/);
   assert.match(connectorTokenPermissionPanelSource, /Advanced/);
+  assert.match(connectorTokenPermissionPanelSource, /inferPermissionMode/);
+  assert.match(connectorTokenPermissionPanelSource, /tokenProfileModeKey/);
   assert.match(connectorTokenPermissionPanelSource, /All operations/);
   assert.match(connectorTokenPermissionPanelSource, /connectorActionRiskOrder/);
   assert.match(connectorTokenPermissionPanelSource, /connectorActionRiskGroupLabel/);

--- a/frontend/src/lib/connector-permissions.js
+++ b/frontend/src/lib/connector-permissions.js
@@ -2,11 +2,15 @@ import { effectiveRule } from "./permissions";
 
 const profileStoragePrefix = "aipermission.console.profile";
 
+export function connectorTargetKey(target) {
+  if (!target) return "";
+  return `${target.connector_kind || "connector"}:${target.target_id || target.id || ""}`;
+}
+
 export function profilesForConnectorTarget(targets, selectedTarget) {
   if (!selectedTarget) return [];
-  const profiles = targets.filter(
-    (target) => target.connector_kind === selectedTarget.connector_kind && Number(target.target_id) === Number(selectedTarget.target_id)
-  );
+  const selectedKey = connectorTargetKey(selectedTarget);
+  const profiles = targets.filter((target) => connectorTargetKey(target) === selectedKey);
   return profiles.length > 0 ? profiles : [selectedTarget];
 }
 

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,27 @@
-export const appVersion = "0.2.2";
+export const appVersion = "0.2.3";
 
 export const changelogEntries = [
+  {
+    version: "0.2.3",
+    label: "Console profile polish",
+    sections: [
+      {
+        title: "Changed",
+        items: [
+          "Console shows one row per connector target and keeps credential profiles selectable from the target header.",
+          "Connector token controls infer Basic, Grouped, or Advanced permission mode from the current rules.",
+          "Postgres Console keeps profile-scoped sessions and activity easier to inspect when switching profiles.",
+        ],
+      },
+      {
+        title: "Added",
+        items: [
+          "Postgres Console includes recent-query shortcuts for loading prior SQL back into the editor.",
+          "Postgres request details can load or copy the SQL from the inspected request.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.2",
     label: "Postgres management",

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { apiGet, apiPost } from "../lib/api";
 import {
+  connectorTargetKey,
   currentConnectorTargetProfilePermissions,
   effectiveConnectorTargetProfilePermissions,
   profilesForConnectorTarget,
@@ -13,6 +14,7 @@ import { effectiveRule, permissionLifetimeLabel } from "../lib/permissions";
 import { useConnectorPermissions } from "../lib/use-connector-permissions";
 import { CountBadge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
+import { Select } from "../components/ui/form";
 import { Notice } from "../components/ui/notice";
 import { ConnectorActionApprovalDialog } from "../components/console/connector-action-approval-dialog";
 import { ConnectorActivityDialog } from "../components/console/connector-activity-dialog";
@@ -71,6 +73,7 @@ export function ConsolePage() {
   const [newSessionError, setNewSessionError] = useState("");
   const [now, setNow] = useState(Date.now());
   const [structuredSessionsByTarget, setStructuredSessionsByTarget] = useState({});
+  const [selectedProfileByTarget, setSelectedProfileByTarget] = useState({});
 
   const selectedTargetRef = searchParams.get("target");
   const sessions = consoleSessions.data || [];
@@ -114,6 +117,7 @@ export function ConsolePage() {
     allowTargetFallback: false,
   });
   const selectedTargetProfiles = useMemo(() => profilesForConnectorTarget(targetItems, selectedTarget), [targetItems, selectedTarget?.connector_kind, selectedTarget?.target_id]);
+  const targetRows = useMemo(() => consoleTargetRows(targetItems, selectedTarget, selectedProfileByTarget), [targetItems, selectedTarget?.ref, selectedProfileByTarget]);
   const selectedTokenOptions = useMemo(() => {
     if (!selectedTarget) return [];
     return tokens.data.filter((token) => {
@@ -149,13 +153,14 @@ export function ConsolePage() {
   const consoleBannerCount = (showAlwaysRunWarning ? 1 : 0) + (selectedRunningRequest ? 1 : 0) + (newSessionError ? 1 : 0);
   const filteredTargets = useMemo(() => {
     const query = targetSearch.trim().toLowerCase();
-    return targetItems.filter((target) => {
+    return targetRows.filter((target) => {
       if (!query) return true;
-      return [targetDisplayName(target), targetSubtitle(target), target.connector_kind, target.profile_label, target.ref]
+      const profiles = profilesForConnectorTarget(targetItems, target);
+      return [targetDisplayName(target), targetSubtitle(target), target.connector_kind, target.ref, ...profiles.map((profile) => profile.profile_label)]
         .filter(Boolean)
         .some((value) => String(value).toLowerCase().includes(query));
     });
-  }, [targetItems, targetSearch]);
+  }, [targetRows, targetItems, targetSearch]);
 
   useEffect(() => {
     if (targetItems.length === 0 || !defaultTargetRef) return;
@@ -163,6 +168,14 @@ export function ConsolePage() {
       setSearchParams({ target: selectedTarget?.ref || defaultTargetRef }, { replace: true });
     }
   }, [targetItems, selectedTargetRef, selectedTarget?.ref, defaultTargetRef, setSearchParams]);
+
+  useEffect(() => {
+    if (!selectedTarget?.profile_id) return;
+    const key = connectorTargetKey(selectedTarget);
+    setSelectedProfileByTarget((current) => (
+      String(current[key] || "") === String(selectedTarget.profile_id) ? current : { ...current, [key]: Number(selectedTarget.profile_id) }
+    ));
+  }, [selectedTarget?.connector_kind, selectedTarget?.target_id, selectedTarget?.profile_id]);
 
   useEffect(() => {
     if (tokens.state !== "ready") return;
@@ -217,8 +230,23 @@ export function ConsolePage() {
     }
   }, [activeConnectorApprovalID, pendingConnectorApprovals.map((approval) => approval.id).join(","), selectedPendingConnectorApprovals.map((approval) => approval.id).join(","), dismissedConnectorApprovalIDs, selectedPendingConnectorApprovals.length, connectorApprovalAction.state]);
 
-  function selectTarget(targetRef) {
-    setSearchParams({ target: targetRef });
+  function selectTarget(target) {
+    if (!target) return;
+    const key = connectorTargetKey(target);
+    const profiles = profilesForConnectorTarget(targetItems, target);
+    const selectedProfileID = selectedProfileByTarget[key] || target.profile_id;
+    const profileTarget = profiles.find((profile) => Number(profile.profile_id) === Number(selectedProfileID)) || profiles[0] || target;
+    setSearchParams({ target: profileTarget.ref });
+  }
+
+  function selectTargetProfile(profileID) {
+    if (!selectedTarget) return;
+    const nextID = Number(profileID);
+    if (!Number.isFinite(nextID) || nextID <= 0) return;
+    const profileTarget = selectedTargetProfiles.find((profile) => Number(profile.profile_id) === Number(nextID));
+    if (!profileTarget) return;
+    setSelectedProfileByTarget((current) => ({ ...current, [connectorTargetKey(selectedTarget)]: nextID }));
+    setSearchParams({ target: profileTarget.ref });
   }
 
   function openConnectorApproval(approval) {
@@ -398,7 +426,7 @@ export function ConsolePage() {
               <h3 className="flex items-center gap-2 text-sm font-semibold">
                 <Database className="h-4 w-4" />
                 Connectors
-                <span className="rounded-full bg-stone-100 px-2 py-0.5 text-xs font-medium text-stone-500">{targetItems.length}</span>
+                <span className="rounded-full bg-stone-100 px-2 py-0.5 text-xs font-medium text-stone-500">{targetRows.length}</span>
               </h3>
               <Button type="button" variant="ghost" className="h-9 w-9 px-0" title="Collapse connectors" onClick={() => setTargetsCompact(true)}>
                 <PanelLeftClose className="h-4 w-4" />
@@ -417,8 +445,9 @@ export function ConsolePage() {
           ) : null}
           {filteredTargets.map((target) => (
             <TargetListItem
-              key={target.ref}
+              key={connectorTargetKey(target)}
               target={target}
+              profileTargets={profilesForConnectorTarget(targetItems, target)}
               liveConsoleTargets={liveConsoleTargets}
               sessions={sessions}
               selectedTarget={selectedTarget}
@@ -430,7 +459,7 @@ export function ConsolePage() {
             />
           ))}
           {targets.state === "ready" && targetItems.length === 0 && !targetsCompact ? <Notice>No targets yet.</Notice> : null}
-          {targets.state === "ready" && targetItems.length > 0 && filteredTargets.length === 0 && !targetsCompact ? <Notice>No connectors match that search.</Notice> : null}
+          {targets.state === "ready" && targetRows.length > 0 && filteredTargets.length === 0 && !targetsCompact ? <Notice>No connectors match that search.</Notice> : null}
           {targets.state === "error" && !targetsCompact ? <Notice tone="bad">{targets.error}</Notice> : null}
         </div>
       </aside>
@@ -465,6 +494,22 @@ export function ConsolePage() {
                 </p>
               ) : null}
             </div>
+            {selectedTargetProfiles.length > 1 ? (
+              <label className={`ml-2 hidden min-w-36 max-w-48 shrink-0 items-center gap-2 text-xs font-semibold lg:flex ${theme === "light" ? "text-stone-600" : "text-stone-300"}`}>
+                Profile
+                <Select
+                  className={`h-8 ${theme === "light" ? "" : "border-stone-700 bg-[#1e1e1e] text-stone-100"}`}
+                  value={selectedTarget?.profile_id ? String(selectedTarget.profile_id) : ""}
+                  onChange={(event) => selectTargetProfile(event.target.value)}
+                >
+                  {selectedTargetProfiles.map((profile) => (
+                    <option key={profile.profile_id} value={profile.profile_id}>
+                      {targetProfileLabel(profile)}
+                    </option>
+                  ))}
+                </Select>
+              </label>
+            ) : null}
           </div>
           <div className="flex shrink-0 gap-2">
             {selectedPendingConnectorApprovals.length > 0 ? (
@@ -625,6 +670,7 @@ export function ConsolePage() {
 
 function TargetListItem({
   target,
+  profileTargets,
   liveConsoleTargets,
   sessions,
   selectedTarget,
@@ -637,12 +683,14 @@ function TargetListItem({
   const runtimeID = targetUsesLiveConsole(target) ? target.runtime_id : null;
   const runtimeTarget = runtimeID ? liveConsoleTargets.data.find((item) => Number(item.id) === Number(runtimeID)) : null;
   const session = runtimeID ? latestSessionForRuntime(sessions, runtimeID) || emptySession : emptySession;
-  const active = selectedTarget && selectedTarget.ref === target.ref;
-  const connectorPendingCount = pendingConnectorApprovals.filter((approval) => approval.target_ref === target.ref).length;
-  const connectorRunningCount = connectorActionApprovals.data.filter((approval) => approval.status === "running" && approval.target_ref === target.ref).length;
+  const active = selectedTarget && connectorTargetKey(selectedTarget) === connectorTargetKey(target);
+  const refs = new Set((profileTargets?.length ? profileTargets : [target]).map((profile) => profile.ref));
+  const runtimeIDs = new Set((profileTargets?.length ? profileTargets : [target]).map((profile) => profile.runtime_id).filter(Boolean).map((id) => Number(id)));
+  const connectorPendingCount = pendingConnectorApprovals.filter((approval) => refs.has(approval.target_ref)).length;
+  const connectorRunningCount = connectorActionApprovals.data.filter((approval) => approval.status === "running" && refs.has(approval.target_ref)).length;
   const pendingCount = connectorPendingCount;
   const runningCount = connectorRunningCount;
-  const unreadCount = runtimeID ? unreadMessages.filter((message) => Number(message.runtime_id) === Number(runtimeID)).length : 0;
+  const unreadCount = runtimeIDs.size > 0 ? unreadMessages.filter((message) => runtimeIDs.has(Number(message.runtime_id))).length : 0;
   const attentionCount = pendingCount + unreadCount;
   const status = selectedTargetStatus({ target, session, pendingCount, runningCount });
   const kindLabel = target.connector_kind;
@@ -656,7 +704,7 @@ function TargetListItem({
       className={`${targetsCompact ? "grid h-10 w-10 place-items-center px-0 py-0" : "grid gap-1.5 px-3 py-2 text-left"} rounded-md transition ${
         active ? "bg-emerald-950 text-white" : "text-stone-700 hover:bg-stone-100"
       }`}
-      onClick={() => onSelect(target.ref)}
+      onClick={() => onSelect(target)}
     >
       {targetsCompact ? (
         <span className="relative grid h-full w-full place-items-center">
@@ -680,6 +728,9 @@ function TargetListItem({
           <span className="flex min-w-0 gap-1.5">
             <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase ${badgeClass}`}>{kindLabel}</span>
             <span className={`truncate rounded-full border px-2 py-0.5 text-[10px] font-semibold ${badgeClass}`}>{profileLabel}</span>
+            {profileTargets?.length > 1 ? (
+              <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${badgeClass}`}>{profileTargets.length} profiles</span>
+            ) : null}
           </span>
         </>
       )}
@@ -761,6 +812,25 @@ function formatDuration(ms) {
 
 function newStructuredConsoleSession() {
   return { active: true, startedAt: new Date().toISOString() };
+}
+
+function consoleTargetRows(targets, selectedTarget, selectedProfileByTarget = {}) {
+  const rows = [];
+  const byKey = new Map();
+  for (const target of targets) {
+    const key = connectorTargetKey(target);
+    if (!byKey.has(key)) {
+      byKey.set(key, []);
+      rows.push({ key, first: target });
+    }
+    byKey.get(key).push(target);
+  }
+  return rows.map(({ key, first }) => {
+    const profiles = byKey.get(key) || [first];
+    if (selectedTarget && connectorTargetKey(selectedTarget) === key) return selectedTarget;
+    const preferredID = selectedProfileByTarget[key];
+    return profiles.find((profile) => Number(profile.profile_id) === Number(preferredID)) || profiles[0] || first;
+  });
 }
 
 function defaultConsoleTargetRef(targets, unreadMessages, pendingConnectorApprovals) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,7 +2564,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- consolidate Console connector rows so multiple credential profiles stay under one target
- infer Basic, Grouped, or Advanced token permission mode from current connector rules
- add Postgres recent-query shortcuts plus request-level Load SQL / Copy SQL actions
- align changelog, in-app release notes, and MCP package metadata for v0.2.3

## Validation

- node scripts/secret-scan.js
- make test
- make build
- make audit
- docker compose config --quiet
- cd frontend && npm test
- cd frontend && npm run build
- cd packages/mcp && npm test
- cd packages/mcp && npm run build
- cd packages/mcp && npm audit --omit=dev --audit-level=moderate
- cd packages/mcp && npm pack --dry-run
