### PR TITLE
feat: add Redis connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-06-18
+
+### Added
+
+- Added Redis as a built-in connector with Direct and Over SSH connection
+  modes through the shared connector permission, approval, history, and audit
+  pipeline.
+- Added Redis actions for `ping`, `info`, bounded `scan_keys`, `get_key`,
+  `set_string`, `expire_key`, and explicit `delete_keys`.
+- Added a Redis Console key browser with SCAN search, key inspection, string
+  editing, TTL updates, and multi-key delete.
+
+### Changed
+
+- Added a generic network transport capability so protocol connectors can open
+  direct TCP connections or delegate to reviewed connector transports such as
+  SSH without importing SSH-specific code.
+- Updated connector docs and MCP package docs to describe Redis as a built-in
+  connector.
+
 ## [0.2.3] - 2026-06-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ AIPermission is intentionally designed as a local developer gateway.
 
 - The gateway runs on the developer's own machine.
 - Remote systems are connector targets reached from that local gateway.
-- SSH and Postgres are built-in connector types, not separate product modes.
+- SSH, Postgres, and Redis are built-in connector types, not separate product modes.
 - The web UI, REST API, and MCP API are not designed to be shared on a LAN.
 - The project does not support running the gateway as a remote hosted service.
 - The project provides a local browser session after database unlock, not multi-user web auth, team RBAC, or public network hardening.
@@ -115,14 +115,18 @@ Implemented:
 - Docker Compose local runtime
 - Go backend with SQLite storage
 - React web UI
-- connector target/profile/action pipeline for SSH, Postgres, and future local
+- connector target/profile/action pipeline for SSH, Postgres, Redis, and future local
   integrations
+- generic connector network transport so protocol connectors can use Direct or
+  reviewed Over SSH TCP paths without importing SSH-specific code
 - connector template architecture for target forms, credential forms, list rows,
   console/activity surfaces, and connector-owned operations
 - built-in SSH connector with persistent shell, file transfer, remote browsing,
   host-key approval, and command actions
 - built-in Postgres connector with schema/table inspection, bounded read-only
   SQL actions, managed scoped database-user provisioning, and SQL backup/restore
+- built-in Redis connector with Direct and Over SSH connection modes, bounded
+  key scanning, key inspection, string writes, TTL updates, and explicit deletes
 - gateway-generated SSH keys (`ed25519` and `rsa`)
 - explicit existing SSH private key import into the encrypted local vault
 - SSH host import from OpenSSH config files for prefilling connector targets
@@ -136,7 +140,7 @@ Implemented:
 - global MCP Started/Stopped switch that preserves permissions while blocking live execution
 - persistent web console with live PTY streaming
 - UI bulk SSH command execution across selected connector targets with per-target history rows
-- MCP bridge with connector action tools for SSH, Postgres, and future local integrations
+- MCP bridge with connector action tools for SSH, Postgres, Redis, and future local integrations
 - approval dialog with Run / Decline / note
 - approval-context snapshots that stale old pending connector actions after
   permission, connector target, credential profile, connector metadata, or
@@ -294,7 +298,7 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-The MCP surface is connector-first. SSH, Postgres, and future integrations use
+The MCP surface is connector-first. SSH, Postgres, Redis, and future integrations use
 the same target/profile/action permission pipeline. `list_connector_targets` is
 permission-scoped, not a live health check. Current reachability is learned when
 the connector action actually runs and returns a dial, timeout, authentication,
@@ -303,6 +307,9 @@ host-key, credential, or service error.
 For SSH, call `get_connector_actions(target_ref)` to discover actions such as
 `exec`, `read_console`, `restart_console_session`, `browse_remote_files`, and
 `start_file_download`.
+
+For Redis, call `get_connector_actions(target_ref)` to discover actions such as
+`scan_keys`, `get_key`, `set_string`, `expire_key`, and `delete_keys`.
 
 If an action returns `approval_pending` or `running`, the response includes an
 `assistant_hint` telling the AI to poll `get_connector_action_request` until the

--- a/backend/internal/api/connector_actions_test.go
+++ b/backend/internal/api/connector_actions_test.go
@@ -56,12 +56,19 @@ func TestRuntimePrepareConnectorActionUsesSSHConnectorProfile(t *testing.T) {
 }
 
 func TestConnectorRuntimeCapabilitiesAreKindScoped(t *testing.T) {
-	if capabilities := connectorRuntimeCapabilitiesFor(postgresconnector.Kind, &Server{}, &databaseRuntime{}); capabilities != nil {
-		t.Fatalf("postgres should not receive ssh runtime capabilities: %#v", capabilities)
+	capabilities := connectorRuntimeCapabilitiesFor(postgresconnector.Kind, &Server{}, &databaseRuntime{})
+	if capabilities == nil || capabilities.RuntimeCapability(connectors.NetworkTransportCapabilityName) == nil {
+		t.Fatalf("postgres should receive generic network transport capability: %#v", capabilities)
 	}
-	capabilities := connectorRuntimeCapabilitiesFor(sshconnector.Kind, &Server{}, &databaseRuntime{})
+	if capabilities.RuntimeCapability(sshconnector.RuntimeServiceName) != nil {
+		t.Fatalf("postgres should not receive ssh live runtime capability: %#v", capabilities)
+	}
+	capabilities = connectorRuntimeCapabilitiesFor(sshconnector.Kind, &Server{}, &databaseRuntime{})
 	if capabilities == nil || capabilities.RuntimeCapability(sshconnector.RuntimeServiceName) == nil {
 		t.Fatalf("ssh runtime capability missing: %#v", capabilities)
+	}
+	if capabilities.RuntimeCapability(connectors.NetworkTransportCapabilityName) == nil {
+		t.Fatalf("ssh generic network transport capability missing: %#v", capabilities)
 	}
 }
 

--- a/backend/internal/api/connector_api_adapters.go
+++ b/backend/internal/api/connector_api_adapters.go
@@ -25,11 +25,20 @@ func (c connectorRuntimeCapabilities) RuntimeCapability(name string) connectors.
 }
 
 func connectorRuntimeCapabilitiesFor(kind string, server *Server, runtime *databaseRuntime) connectors.RuntimeCapabilityResolver {
-	adapter := connectorRuntimeAdapterFor(kind)
-	if adapter == nil {
-		return nil
+	capabilities := connectorRuntimeCapabilities{}
+	if server != nil && runtime != nil {
+		transport := connectorNetworkTransport{server: server, runtime: runtime}
+		capabilities[transport.ConnectorRuntimeCapability()] = transport
 	}
-	capabilities := connectorRuntimeCapabilities(adapter.RuntimeCapabilities(server, runtime))
+	adapter := connectorRuntimeAdapterFor(kind)
+	if adapter != nil {
+		for name, capability := range adapter.RuntimeCapabilities(server, runtime) {
+			if name == "" || capability == nil {
+				continue
+			}
+			capabilities[name] = capability
+		}
+	}
 	if len(capabilities) == 0 {
 		return nil
 	}

--- a/backend/internal/api/connector_network_transport.go
+++ b/backend/internal/api/connector_network_transport.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/connectorapi"
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
+)
+
+const connectorNetworkDialTimeout = 12 * time.Second
+
+type connectorNetworkTransport struct {
+	server  *Server
+	runtime *databaseRuntime
+}
+
+func (connectorNetworkTransport) ConnectorRuntimeCapability() string {
+	return connectors.NetworkTransportCapabilityName
+}
+
+func (transport connectorNetworkTransport) DialConnectorTCP(ctx context.Context, request connectors.NetworkDialRequest) (net.Conn, error) {
+	mode := strings.TrimSpace(request.Mode)
+	if mode == "" {
+		mode = "direct"
+	}
+	address, err := networkDialAddress(request.Host, request.Port)
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, connectorNetworkDialTimeout)
+	defer cancel()
+	switch mode {
+	case "direct":
+		var dialer net.Dialer
+		return dialer.DialContext(ctx, "tcp", address)
+	case "over_ssh":
+		targetRef := strings.TrimSpace(request.TransportTargetRef)
+		if targetRef == "" {
+			return nil, fmt.Errorf("transport target ref is required for over_ssh")
+		}
+		kind, _, _, ok := connectortargets.ParseConnectorTargetRef(targetRef)
+		if !ok {
+			return nil, connectortargets.ErrInvalidTargetRef
+		}
+		adapter, _ := connectorAPIAdapterFor(kind).(connectorapi.TCPTransportAdapter)
+		if adapter == nil {
+			return nil, fmt.Errorf("%s connector does not expose TCP transport", kind)
+		}
+		return adapter.DialConnectorTCP(ctx, transport.server, transport.runtime, targetRef, "tcp", address)
+	default:
+		return nil, fmt.Errorf("unsupported connection mode %q", mode)
+	}
+}
+
+func networkDialAddress(host string, port int) (string, error) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "", fmt.Errorf("host is required")
+	}
+	if port < 1 || port > 65535 {
+		return "", fmt.Errorf("port must be between 1 and 65535")
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port)), nil
+}

--- a/backend/internal/api/routes_test.go
+++ b/backend/internal/api/routes_test.go
@@ -186,10 +186,11 @@ func TestConnectorCatalogRoutes(t *testing.T) {
 		t.Fatalf("list connectors failed: %d %s", listResponse.Code, listResponse.Body.String())
 	}
 	listBody := listResponse.Body.String()
-	if !strings.Contains(listBody, `"kind":"postgres"`) || !strings.Contains(listBody, `"kind":"ssh"`) {
+	if !strings.Contains(listBody, `"kind":"postgres"`) || !strings.Contains(listBody, `"kind":"redis"`) || !strings.Contains(listBody, `"kind":"ssh"`) {
 		t.Fatalf("connector list missing built-ins: %s", listBody)
 	}
-	if strings.Index(listBody, `"kind":"postgres"`) > strings.Index(listBody, `"kind":"ssh"`) {
+	if strings.Index(listBody, `"kind":"postgres"`) > strings.Index(listBody, `"kind":"redis"`) ||
+		strings.Index(listBody, `"kind":"redis"`) > strings.Index(listBody, `"kind":"ssh"`) {
 		t.Fatalf("connector list should be stable by kind: %s", listBody)
 	}
 
@@ -210,7 +211,7 @@ func TestConnectorCatalogRoutes(t *testing.T) {
 	if response := performJSON(handler, http.MethodGet, "/api/connectors/bad-kind", "", nil); response.Code != http.StatusBadRequest {
 		t.Fatalf("invalid connector kind should be bad request, got %d", response.Code)
 	}
-	if response := performJSON(handler, http.MethodGet, "/api/connectors/redis", "", nil); response.Code != http.StatusNotFound {
+	if response := performJSON(handler, http.MethodGet, "/api/connectors/example", "", nil); response.Code != http.StatusNotFound {
 		t.Fatalf("unknown connector should be not found, got %d", response.Code)
 	}
 }
@@ -483,7 +484,7 @@ func TestConnectorTargetRoutesStoreSecretsOnlyInVaultPayload(t *testing.T) {
 	}
 
 	unsupportedTarget := performJSON(handler, http.MethodPost, "/api/connector-targets", "", createConnectorTargetRequest{
-		ConnectorKind: "redis",
+		ConnectorKind: "example",
 		Name:          "cache",
 	})
 	if unsupportedTarget.Code != http.StatusBadRequest {

--- a/backend/internal/connectorapi/registry.go
+++ b/backend/internal/connectorapi/registry.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -169,6 +170,14 @@ type LiveConsoleTargetAdapter interface {
 // the generic live console manager.
 type LiveConsoleTransportAdapter interface {
 	OpenLiveConsole(ctx context.Context, server GatewayServer, runtime GatewayRuntime, runtimeID int64, rows int, cols int) (*console.RuntimeSession, error)
+}
+
+// TCPTransportAdapter lets one connector provide a reviewed TCP transport for
+// another connector without exposing connector-specific material to core or to
+// the caller. The provider connector owns credential resolution and transport
+// setup; the caller connector owns the protocol spoken over the returned conn.
+type TCPTransportAdapter interface {
+	DialConnectorTCP(ctx context.Context, server GatewayServer, runtime GatewayRuntime, targetRef string, network string, address string) (net.Conn, error)
 }
 
 type TransferProgress func(transferred int64, total int64)

--- a/backend/internal/connectors/README.md
+++ b/backend/internal/connectors/README.md
@@ -1,7 +1,7 @@
 # Connectors
 
 `internal/connectors` defines the internal contract for connector-shaped
-targets. SSH, Postgres, and future API/Redis integrations use the same gateway
+targets. SSH, Postgres, Redis, and future API integrations use the same gateway
 pipeline:
 
 ```text
@@ -125,7 +125,7 @@ receive `TargetLifecycleGateway` or `CredentialResourceGateway`. Do not create
 connector-local copies of those interfaces. Extending the adapter surface should
 mean extending `connectorapi` once and updating every affected adapter.
 
-New connectors such as Redis or HTTP API connectors should follow the
+New connectors such as HTTP API connectors should follow the
 target/profile/action path by default. If they need a capability beyond the
 shared action runner, design a reusable adapter contract first instead of
 adding connector-specific command tables, file-transfer tables, draft-test route
@@ -170,13 +170,17 @@ metadata icons during frontend tests.
 
 Built-in connectors may depend on runtime packages for their own transport.
 SSH uses SSH key, persistent terminal, and SFTP primitives. Postgres uses
-database connection and query primitives. Those transport details stay inside
+database connection and query primitives. Redis uses a bounded RESP client and
+the shared network transport capability. Those transport details stay inside
 the connector implementation; page-level UI, MCP tools, token permissions,
 history, and audit use the shared target/profile/action vocabulary.
 
 `RuntimeContext.Capabilities` is reserved for gateway-owned runtime adapters.
-A connector receives only typed capabilities for its own kind. Do not use it as
-a general escape hatch for arbitrary gateway internals.
+A connector receives only typed capabilities such as `network_transport` or
+reviewed runtime-adapter services. Do not use it as a general escape hatch for
+arbitrary gateway internals. `network_transport` can open a direct TCP
+connection or delegate to another connector's reviewed TCP transport adapter
+such as SSH; protocol connectors still own their own protocol code.
 
 The 0.2 connector line is a clean database baseline. Do not add runtime
 fallbacks for pre-0.2 preview schemas; important old data belongs in the
@@ -184,16 +188,16 @@ separate versioned migration helper, not in gateway runtime code.
 
 ## Adding A Connector
 
-For a new connector such as Redis:
+For a new connector:
 
-1. Add `internal/connectors/redis` with a small implementation of the connector
+1. Add `internal/connectors/<kind>` with a small implementation of the connector
    contract.
 2. Register it in the backend connector registry. Runtime-backed connectors
    also add their adapter side-effect import in that same built-in registry
    file; do not create a hidden second adapter registration list.
 3. Store target/profile data through `internal/connectortargets`; do not create
    connector-specific permission tables.
-4. Add frontend templates under `frontend/src/connectors/templates/redis`.
+4. Add frontend templates under `frontend/src/connectors/templates/<kind>`.
 5. Add `metadata.json` and `index.jsx` so the frontend registry/catalog can
    discover the template folder.
 6. Update built-in registry/tests and frontend smoke/runtime tests that assert

--- a/backend/internal/connectors/builtin/registry.go
+++ b/backend/internal/connectors/builtin/registry.go
@@ -5,6 +5,7 @@ package builtin
 import (
 	"github.com/aipermission/aipermission/backend/internal/connectors"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
+	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"
 	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
 	_ "github.com/aipermission/aipermission/backend/internal/connectors/ssh/apiadapter"
 )
@@ -13,6 +14,7 @@ import (
 func RegisterAll(registry *connectors.Registry) error {
 	for _, connector := range []connectors.Connector{
 		postgresconnector.New(),
+		redisconnector.New(),
 		sshconnector.New(),
 	} {
 		if err := registry.Register(connector); err != nil {

--- a/backend/internal/connectors/builtin/registry_test.go
+++ b/backend/internal/connectors/builtin/registry_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aipermission/aipermission/backend/internal/connectors"
 	"github.com/aipermission/aipermission/backend/internal/connectors/connectortest"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
+	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"
 	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
 )
 
@@ -23,6 +24,13 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	if postgres.Label() != postgresconnector.Label {
 		t.Fatalf("postgres label = %q", postgres.Label())
 	}
+	redis, ok := registry.Get(redisconnector.Kind)
+	if !ok {
+		t.Fatal("expected redis connector")
+	}
+	if redis.Label() != redisconnector.Label {
+		t.Fatalf("redis label = %q", redis.Label())
+	}
 
 	connector, ok := registry.Get(sshconnector.Kind)
 	if !ok {
@@ -33,7 +41,7 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	}
 
 	infos := registry.List()
-	if len(infos) != 2 || infos[0].Kind != postgresconnector.Kind || infos[1].Kind != sshconnector.Kind {
+	if len(infos) != 3 || infos[0].Kind != postgresconnector.Kind || infos[1].Kind != redisconnector.Kind || infos[2].Kind != sshconnector.Kind {
 		t.Fatalf("unexpected connector list: %#v", infos)
 	}
 }
@@ -106,6 +114,28 @@ func builtInDeterminismSamples(t *testing.T, kind string) (connectors.TargetView
 				postgresconnector.ActionGetTables:     {"schema": "public", "include_system": false},
 				postgresconnector.ActionDescribeTable: {"schema": "public", "table": "users"},
 				postgresconnector.ActionQueryReadonly: {"sql": "select 1", "max_rows": 1},
+			}
+	case redisconnector.Kind:
+		return connectors.TargetView{
+				ID:            3,
+				Ref:           "redis:3:30",
+				ConnectorKind: redisconnector.Kind,
+				Name:          "cache",
+				Config:        map[string]any{"connection_mode": "direct", "host": "127.0.0.1", "port": 6379, "database": 0},
+			}, connectors.CredentialProfileView{
+				ID:            30,
+				TargetID:      3,
+				ConnectorKind: redisconnector.Kind,
+				Kind:          "username_password",
+				Label:         "default",
+			}, map[string]map[string]any{
+				redisconnector.ActionPing:       {},
+				redisconnector.ActionInfo:       {"section": "server"},
+				redisconnector.ActionScanKeys:   {"pattern": "*", "limit": 10},
+				redisconnector.ActionGetKey:     {"key": "app:test"},
+				redisconnector.ActionSetString:  {"key": "app:test", "value": "hello", "ttl_seconds": 60},
+				redisconnector.ActionExpireKey:  {"key": "app:test", "ttl_seconds": 60},
+				redisconnector.ActionDeleteKeys: {"keys": []any{"app:test"}},
 			}
 	case sshconnector.Kind:
 		return connectors.TargetView{

--- a/backend/internal/connectors/connector.go
+++ b/backend/internal/connectors/connector.go
@@ -1,6 +1,9 @@
 package connectors
 
-import "context"
+import (
+	"context"
+	"net"
+)
 
 // Connector is the required contract for connector-shaped targets.
 //
@@ -102,6 +105,29 @@ type EventSink interface {
 // should normally not need a runtime capability.
 type RuntimeCapability interface {
 	ConnectorRuntimeCapability() string
+}
+
+const NetworkTransportCapabilityName = "network_transport"
+
+// NetworkDialRequest describes a connector-owned network connection request.
+//
+// Connectors use this capability when the endpoint may be reached either
+// directly from the local gateway or through another reviewed connector-backed
+// transport such as SSH. The connector remains responsible for its protocol;
+// the gateway only opens the TCP pipe.
+type NetworkDialRequest struct {
+	Mode               string
+	Host               string
+	Port               int
+	TransportTargetRef string
+}
+
+// NetworkTransport is a generic TCP transport capability injected by the
+// gateway. It intentionally exposes net.Conn rather than connector internals so
+// protocol connectors such as Redis can stay independent from SSH.
+type NetworkTransport interface {
+	RuntimeCapability
+	DialConnectorTCP(ctx context.Context, request NetworkDialRequest) (net.Conn, error)
 }
 
 // RuntimeCapabilityResolver resolves reviewed connector-owned capabilities

--- a/backend/internal/connectors/redis/client.go
+++ b/backend/internal/connectors/redis/client.go
@@ -1,0 +1,192 @@
+package redisconnector
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const redisCommandTimeout = 10 * time.Second
+
+type respKind byte
+
+const (
+	respSimpleString respKind = '+'
+	respError        respKind = '-'
+	respInteger      respKind = ':'
+	respBulkString   respKind = '$'
+	respArray        respKind = '*'
+)
+
+type respValue struct {
+	kind   respKind
+	text   string
+	number int64
+	array  []respValue
+	null   bool
+}
+
+type redisClient struct {
+	conn   net.Conn
+	reader *bufio.Reader
+}
+
+func newRedisClient(conn net.Conn) *redisClient {
+	return &redisClient{conn: conn, reader: bufio.NewReader(conn)}
+}
+
+func (client *redisClient) Close() error {
+	if client == nil || client.conn == nil {
+		return nil
+	}
+	return client.conn.Close()
+}
+
+func (client *redisClient) Do(args ...string) (respValue, error) {
+	if client == nil || client.conn == nil {
+		return respValue{}, fmt.Errorf("redis connection is not open")
+	}
+	if len(args) == 0 {
+		return respValue{}, fmt.Errorf("redis command is required")
+	}
+	_ = client.conn.SetDeadline(time.Now().Add(redisCommandTimeout))
+	var payload bytes.Buffer
+	payload.WriteByte('*')
+	payload.WriteString(strconv.Itoa(len(args)))
+	payload.WriteString("\r\n")
+	for _, arg := range args {
+		payload.WriteByte('$')
+		payload.WriteString(strconv.Itoa(len(arg)))
+		payload.WriteString("\r\n")
+		payload.WriteString(arg)
+		payload.WriteString("\r\n")
+	}
+	if _, err := client.conn.Write(payload.Bytes()); err != nil {
+		return respValue{}, err
+	}
+	value, err := readRESPValue(client.reader)
+	if err != nil {
+		return respValue{}, err
+	}
+	if value.kind == respError {
+		return respValue{}, fmt.Errorf("redis error: %s", value.text)
+	}
+	return value, nil
+}
+
+func readRESPValue(reader *bufio.Reader) (respValue, error) {
+	prefix, err := reader.ReadByte()
+	if err != nil {
+		return respValue{}, err
+	}
+	switch respKind(prefix) {
+	case respSimpleString:
+		text, err := readRESPLine(reader)
+		return respValue{kind: respSimpleString, text: text}, err
+	case respError:
+		text, err := readRESPLine(reader)
+		return respValue{kind: respError, text: text}, err
+	case respInteger:
+		text, err := readRESPLine(reader)
+		if err != nil {
+			return respValue{}, err
+		}
+		number, err := strconv.ParseInt(text, 10, 64)
+		if err != nil {
+			return respValue{}, err
+		}
+		return respValue{kind: respInteger, number: number}, nil
+	case respBulkString:
+		text, err := readRESPLine(reader)
+		if err != nil {
+			return respValue{}, err
+		}
+		size, err := strconv.Atoi(text)
+		if err != nil {
+			return respValue{}, err
+		}
+		if size < 0 {
+			return respValue{kind: respBulkString, null: true}, nil
+		}
+		buf := make([]byte, size+2)
+		if _, err := io.ReadFull(reader, buf); err != nil {
+			return respValue{}, err
+		}
+		if !bytes.HasSuffix(buf, []byte("\r\n")) {
+			return respValue{}, fmt.Errorf("invalid redis bulk string terminator")
+		}
+		return respValue{kind: respBulkString, text: string(buf[:size])}, nil
+	case respArray:
+		text, err := readRESPLine(reader)
+		if err != nil {
+			return respValue{}, err
+		}
+		count, err := strconv.Atoi(text)
+		if err != nil {
+			return respValue{}, err
+		}
+		if count < 0 {
+			return respValue{kind: respArray, null: true}, nil
+		}
+		items := make([]respValue, 0, count)
+		for i := 0; i < count; i++ {
+			item, err := readRESPValue(reader)
+			if err != nil {
+				return respValue{}, err
+			}
+			items = append(items, item)
+		}
+		return respValue{kind: respArray, array: items}, nil
+	default:
+		return respValue{}, fmt.Errorf("unsupported redis response prefix %q", prefix)
+	}
+}
+
+func readRESPLine(reader *bufio.Reader) (string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r"), nil
+}
+
+func respString(value respValue) string {
+	switch value.kind {
+	case respSimpleString, respBulkString:
+		if value.null {
+			return ""
+		}
+		return value.text
+	case respInteger:
+		return strconv.FormatInt(value.number, 10)
+	default:
+		return value.text
+	}
+}
+
+func respStringSlice(value respValue) []string {
+	if value.kind != respArray {
+		return nil
+	}
+	out := make([]string, 0, len(value.array))
+	for _, item := range value.array {
+		out = append(out, respString(item))
+	}
+	return out
+}
+
+func respStringMap(value respValue) map[string]string {
+	if value.kind != respArray {
+		return nil
+	}
+	out := map[string]string{}
+	for index := 0; index+1 < len(value.array); index += 2 {
+		out[respString(value.array[index])] = respString(value.array[index+1])
+	}
+	return out
+}

--- a/backend/internal/connectors/redis/redis.go
+++ b/backend/internal/connectors/redis/redis.go
@@ -1,0 +1,888 @@
+// Package redisconnector defines the Redis connector contract.
+package redisconnector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+const (
+	Kind    = "redis"
+	Label   = "Redis"
+	Version = "0.2"
+
+	ActionPing       = "ping"
+	ActionInfo       = "info"
+	ActionScanKeys   = "scan_keys"
+	ActionGetKey     = "get_key"
+	ActionSetString  = "set_string"
+	ActionExpireKey  = "expire_key"
+	ActionDeleteKeys = "delete_keys"
+
+	defaultRedisHost      = "127.0.0.1"
+	defaultRedisPort      = 6379
+	defaultScanLimit      = 100
+	maxScanLimit          = 1000
+	defaultValueLimit     = 256
+	maxValueLimit         = 1000
+	defaultMaxValueBytes  = 128 << 10
+	maxValueBytes         = 512 << 10
+	maxRedisCommandReason = 2000
+)
+
+var (
+	ErrUnsupportedAction = errors.New("unsupported redis connector action")
+	ErrMissingTransport  = errors.New("redis connector network transport is unavailable")
+	ErrMissingSecret     = errors.New("redis connector credential is missing required secret")
+	ErrInvalidConfig     = errors.New("redis connector target config is invalid")
+)
+
+// Connector describes Redis as a connector-shaped target with bounded key
+// browsing and explicit write/destructive actions.
+type Connector struct{}
+
+func New() Connector {
+	return Connector{}
+}
+
+func (Connector) Kind() string {
+	return Kind
+}
+
+func (Connector) Label() string {
+	return Label
+}
+
+func (Connector) Version() string {
+	return Version
+}
+
+func (Connector) TargetSchema() connectors.Schema {
+	return connectors.Schema{Fields: []connectors.Field{
+		{
+			Name:        "connection_mode",
+			Label:       "Connection mode",
+			Type:        connectors.FieldSelect,
+			Required:    true,
+			Default:     "direct",
+			Description: "Connect directly from the local gateway, or tunnel through an SSH connector profile.",
+			Options: []connectors.FieldOption{
+				{Value: "direct", Label: "Direct"},
+				{Value: "over_ssh", Label: "Over SSH"},
+			},
+		},
+		{
+			Name:        "host",
+			Label:       "Host",
+			Type:        connectors.FieldString,
+			Required:    true,
+			Default:     defaultRedisHost,
+			Description: "Redis host as seen by the selected connection mode. For Over SSH this is usually 127.0.0.1 on the remote server.",
+		},
+		{
+			Name:        "port",
+			Label:       "Port",
+			Type:        connectors.FieldNumber,
+			Required:    true,
+			Default:     defaultRedisPort,
+			Description: "Redis TCP port.",
+		},
+		{
+			Name:        "database",
+			Label:       "Database",
+			Type:        connectors.FieldNumber,
+			Default:     0,
+			Description: "Redis logical database number.",
+		},
+		{
+			Name:        "transport_target_ref",
+			Label:       "SSH transport target",
+			Type:        connectors.FieldString,
+			Description: "Connector target ref used when connection_mode is over_ssh.",
+		},
+	}}
+}
+
+func (Connector) CredentialSchemas() []connectors.CredentialSchema {
+	return []connectors.CredentialSchema{
+		{
+			Kind:        "username_password",
+			Label:       "Username and password",
+			Description: "Redis ACL username and password stored through the encrypted vault layer. Leave both empty for local unauthenticated Redis.",
+			Schema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "username",
+					Label:       "Username",
+					Type:        connectors.FieldString,
+					Description: "Optional Redis ACL username.",
+				},
+				{
+					Name:        "password",
+					Label:       "Password",
+					Type:        connectors.FieldSecret,
+					Secret:      true,
+					Description: "Optional Redis password.",
+				},
+			}},
+		},
+	}
+}
+
+func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (connectors.ConnectorHelp, error) {
+	title := "Redis target"
+	if strings.TrimSpace(target.Name) != "" {
+		title = "Redis target: " + target.Name
+	}
+	return connectors.ConnectorHelp{
+		Title:       title,
+		Summary:     "Browse Redis keys and run bounded key operations through AIPermission approval rules.",
+		Connector:   Label,
+		ConnectorID: Kind,
+		Usage: []string{
+			"Use scan_keys before reading key values when the key name is unknown.",
+			"Use get_key to read a bounded value preview by key type.",
+			"Use set_string only for intentional string writes; non-string mutations should be explicit future actions.",
+			"Use delete_keys carefully; it is destructive and should normally require approval.",
+		},
+		Warnings: []string{
+			"Redis values may contain secrets. Redaction is best-effort; avoid intentionally reading secrets unless the operator approved that access.",
+			"scan_keys uses SCAN, not KEYS, and returns bounded batches.",
+			"Redis credential profiles decide what the Redis server itself allows.",
+		},
+	}, nil
+}
+
+func (Connector) GetActionList(context.Context, connectors.TargetView, connectors.CredentialProfileView) ([]connectors.ActionDefinition, error) {
+	return []connectors.ActionDefinition{
+		{
+			Name:        ActionPing,
+			Label:       "Ping",
+			Description: "Check Redis connectivity and selected database access.",
+			Category:    "metadata",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{},
+			OutputHint:  connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+		{
+			Name:        ActionInfo,
+			Label:       "Server info",
+			Description: "Read bounded Redis INFO metadata.",
+			Category:    "metadata",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "section", Label: "Section", Type: connectors.FieldString, Description: "Optional INFO section such as server, clients, memory, stats, or keyspace."},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 128 << 10},
+		},
+		{
+			Name:        ActionScanKeys,
+			Label:       "Scan keys",
+			Description: "List Redis keys with SCAN using a bounded count.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "pattern", Label: "Pattern", Type: connectors.FieldString, Default: "*", Description: "MATCH pattern for SCAN."},
+				{Name: "cursor", Label: "Cursor", Type: connectors.FieldString, Description: "Optional cursor returned by a previous scan."},
+				{Name: "limit", Label: "Limit", Type: connectors.FieldNumber, Default: defaultScanLimit, Description: "Maximum keys to return."},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxRows: maxScanLimit},
+		},
+		{
+			Name:        ActionGetKey,
+			Label:       "Read key",
+			Description: "Read a bounded Redis key preview by type.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
+				{Name: "limit", Label: "Collection limit", Type: connectors.FieldNumber, Default: defaultValueLimit},
+				{Name: "max_bytes", Label: "Max bytes", Type: connectors.FieldNumber, Default: defaultMaxValueBytes},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: maxValueBytes},
+		},
+		{
+			Name:        ActionSetString,
+			Label:       "Set string",
+			Description: "Set a Redis string value with optional TTL.",
+			Category:    "write",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
+				{Name: "value", Label: "Value", Type: connectors.FieldMultiline, Required: true},
+				{Name: "ttl_seconds", Label: "TTL seconds", Type: connectors.FieldNumber, Description: "Optional positive TTL."},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+		{
+			Name:        ActionExpireKey,
+			Label:       "Set TTL",
+			Description: "Set or clear a Redis key TTL.",
+			Category:    "write",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
+				{Name: "ttl_seconds", Label: "TTL seconds", Type: connectors.FieldNumber, Required: true, Description: "Positive seconds, or -1 to persist."},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+		{
+			Name:        ActionDeleteKeys,
+			Label:       "Delete keys",
+			Description: "Delete one or more Redis keys.",
+			Category:    "destructive",
+			Risk:        connectors.RiskDestructive,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "keys", Label: "Keys", Type: connectors.FieldJSON, Required: true, Description: "JSON array of key names."},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxRows: 1000},
+		},
+	}, nil
+}
+
+func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) (connectors.PreparedAction, error) {
+	input := copyMap(req.Input)
+	risk := connectors.RiskRead
+	title := ""
+	summary := ""
+	switch req.ActionName {
+	case ActionPing:
+		title = "Ping Redis"
+		summary = "Check Redis connectivity."
+	case ActionInfo:
+		section := strings.TrimSpace(stringValue(input, "section"))
+		title = "Read Redis INFO"
+		if section != "" {
+			title = "Read Redis INFO " + section
+		}
+		summary = "Read bounded Redis metadata."
+	case ActionScanKeys:
+		pattern := normalizeStringDefault(input, "pattern", "*")
+		limit := normalizeInt(input, "limit", defaultScanLimit, 1, maxScanLimit)
+		input["pattern"] = pattern
+		input["limit"] = limit
+		title = "Scan Redis keys"
+		summary = fmt.Sprintf("Scan keys matching %q with limit %d.", pattern, limit)
+	case ActionGetKey:
+		key := strings.TrimSpace(stringValue(input, "key"))
+		if key == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("key is required")
+		}
+		input["key"] = key
+		input["limit"] = normalizeInt(input, "limit", defaultValueLimit, 1, maxValueLimit)
+		input["max_bytes"] = normalizeInt(input, "max_bytes", defaultMaxValueBytes, 1, maxValueBytes)
+		title = "Read Redis key"
+		summary = key
+	case ActionSetString:
+		risk = connectors.RiskWrite
+		key := strings.TrimSpace(stringValue(input, "key"))
+		if key == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("key is required")
+		}
+		if _, ok := input["value"]; !ok {
+			return connectors.PreparedAction{}, fmt.Errorf("value is required")
+		}
+		input["key"] = key
+		input["ttl_seconds"] = normalizeInt(input, "ttl_seconds", 0, 0, 31_536_000)
+		title = "Set Redis string"
+		summary = key
+	case ActionExpireKey:
+		risk = connectors.RiskWrite
+		key := strings.TrimSpace(stringValue(input, "key"))
+		if key == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("key is required")
+		}
+		ttl := normalizeInt(input, "ttl_seconds", 0, -1, 31_536_000)
+		if ttl == 0 {
+			return connectors.PreparedAction{}, fmt.Errorf("ttl_seconds is required")
+		}
+		input["key"] = key
+		input["ttl_seconds"] = ttl
+		title = "Set Redis TTL"
+		summary = key
+	case ActionDeleteKeys:
+		risk = connectors.RiskDestructive
+		keys, err := normalizeKeys(input["keys"])
+		if err != nil {
+			return connectors.PreparedAction{}, err
+		}
+		input["keys"] = keys
+		title = "Delete Redis keys"
+		summary = fmt.Sprintf("Delete %d Redis key(s).", len(keys))
+	default:
+		return connectors.PreparedAction{}, ErrUnsupportedAction
+	}
+	if len(req.Reason) > maxRedisCommandReason {
+		return connectors.PreparedAction{}, fmt.Errorf("reason is too large")
+	}
+	return connectors.PreparedAction{
+		ConnectorKind: Kind,
+		TargetRef:     req.Target.Ref,
+		ProfileID:     req.Profile.ID,
+		ActionName:    req.ActionName,
+		Risk:          risk,
+		Title:         title,
+		Summary:       summary,
+		Preview:       input,
+		Payload:       input,
+		ContextMaterial: map[string]any{
+			"target":          req.Target.Name,
+			"profile":         req.Profile.Label,
+			"connection_mode": connectionMode(req.Target),
+			"database":        redisDatabase(req.Target),
+		},
+	}, nil
+}
+
+func (Connector) ExecuteAction(ctx context.Context, runtime connectors.RuntimeContext, action connectors.PreparedAction) (connectors.ActionResult, error) {
+	client, err := openRedisClient(ctx, runtime)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	defer client.Close()
+	switch action.ActionName {
+	case ActionPing:
+		return executePing(client)
+	case ActionInfo:
+		return executeInfo(client, action.Payload)
+	case ActionScanKeys:
+		return executeScanKeys(client, action.Payload)
+	case ActionGetKey:
+		return executeGetKey(client, action.Payload)
+	case ActionSetString:
+		return executeSetString(client, action.Payload)
+	case ActionExpireKey:
+		return executeExpireKey(client, action.Payload)
+	case ActionDeleteKeys:
+		return executeDeleteKeys(client, action.Payload)
+	default:
+		return connectors.ActionResult{}, ErrUnsupportedAction
+	}
+}
+
+func (connector Connector) TestConnection(ctx context.Context, runtime connectors.RuntimeContext) (connectors.TestResult, error) {
+	client, err := openRedisClient(ctx, runtime)
+	if err != nil {
+		return connectors.TestResult{Status: classifyRedisTestError(err), Message: err.Error()}, nil
+	}
+	defer client.Close()
+	value, err := client.Do("PING")
+	if err != nil {
+		return connectors.TestResult{Status: classifyRedisTestError(err), Message: err.Error()}, nil
+	}
+	return connectors.TestResult{
+		Status:  connectors.TestOK,
+		Message: "Redis connection ok.",
+		Details: map[string]any{
+			"response": respString(value),
+			"database": redisDatabase(runtime.Target),
+		},
+	}, nil
+}
+
+func openRedisClient(ctx context.Context, runtime connectors.RuntimeContext) (*redisClient, error) {
+	transport, _ := runtime.Capability(connectors.NetworkTransportCapabilityName).(connectors.NetworkTransport)
+	if transport == nil {
+		return nil, ErrMissingTransport
+	}
+	conn, err := transport.DialConnectorTCP(ctx, connectors.NetworkDialRequest{
+		Mode:               connectionMode(runtime.Target),
+		Host:               redisHost(runtime.Target),
+		Port:               redisPort(runtime.Target),
+		TransportTargetRef: strings.TrimSpace(stringValue(runtime.Target.Config, "transport_target_ref")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	client := newRedisClient(conn)
+	if err := authenticateRedis(ctx, runtime, client); err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+	if database := redisDatabase(runtime.Target); database > 0 {
+		if _, err := client.Do("SELECT", strconv.Itoa(database)); err != nil {
+			_ = client.Close()
+			return nil, err
+		}
+	}
+	return client, nil
+}
+
+func authenticateRedis(ctx context.Context, runtime connectors.RuntimeContext, client *redisClient) error {
+	username := strings.TrimSpace(stringValue(runtime.Profile.Public, "username"))
+	password, err := runtime.Secrets.GetSecret(ctx, "password")
+	if err != nil {
+		password = ""
+	}
+	password = strings.TrimSpace(password)
+	if username == "" && password == "" {
+		return nil
+	}
+	if password == "" {
+		return ErrMissingSecret
+	}
+	if username != "" {
+		_, err = client.Do("AUTH", username, password)
+	} else {
+		_, err = client.Do("AUTH", password)
+	}
+	return err
+}
+
+func executePing(client *redisClient) (connectors.ActionResult, error) {
+	value, err := client.Do("PING")
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	response := respString(value)
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      map[string]any{"response": response},
+		DisplayText: response,
+	}, nil
+}
+
+func executeInfo(client *redisClient, input map[string]any) (connectors.ActionResult, error) {
+	section := strings.TrimSpace(stringValue(input, "section"))
+	args := []string{"INFO"}
+	if section != "" {
+		args = append(args, section)
+	}
+	value, err := client.Do(args...)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	info := truncateString(respString(value), maxValueBytes)
+	parsed := parseRedisInfo(info)
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      map[string]any{"section": section, "info": parsed, "raw": info},
+		DisplayText: info,
+	}, nil
+}
+
+func executeScanKeys(client *redisClient, input map[string]any) (connectors.ActionResult, error) {
+	pattern := normalizeStringDefault(input, "pattern", "*")
+	cursor := normalizeStringDefault(input, "cursor", "0")
+	limit := normalizeInt(input, "limit", defaultScanLimit, 1, maxScanLimit)
+	keys := []string{}
+	nextCursor := cursor
+	for len(keys) < limit {
+		args := []string{"SCAN", nextCursor, "MATCH", pattern, "COUNT", strconv.Itoa(min(limit-len(keys), 100))}
+		value, err := client.Do(args...)
+		if err != nil {
+			return connectors.ActionResult{}, err
+		}
+		if value.kind != respArray || len(value.array) != 2 {
+			return connectors.ActionResult{}, fmt.Errorf("unexpected SCAN response")
+		}
+		nextCursor = respString(value.array[0])
+		keys = append(keys, respStringSlice(value.array[1])...)
+		if nextCursor == "0" {
+			break
+		}
+	}
+	if len(keys) > limit {
+		keys = keys[:limit]
+	}
+	sort.Strings(keys)
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"pattern":     pattern,
+			"cursor":      cursor,
+			"next_cursor": nextCursor,
+			"keys":        keys,
+			"count":       len(keys),
+			"complete":    nextCursor == "0",
+		},
+		DisplayText: strings.Join(keys, "\n"),
+	}, nil
+}
+
+func executeGetKey(client *redisClient, input map[string]any) (connectors.ActionResult, error) {
+	key := strings.TrimSpace(stringValue(input, "key"))
+	if key == "" {
+		return connectors.ActionResult{}, fmt.Errorf("key is required")
+	}
+	limit := normalizeInt(input, "limit", defaultValueLimit, 1, maxValueLimit)
+	maxBytes := normalizeInt(input, "max_bytes", defaultMaxValueBytes, 1, maxValueBytes)
+	keyType, err := redisKeyType(client, key)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	ttl := int64(-2)
+	if ttlValue, err := client.Do("PTTL", key); err == nil {
+		ttl = ttlValue.number
+	}
+	output := map[string]any{"key": key, "type": keyType, "ttl_ms": ttl}
+	switch keyType {
+	case "none":
+		output["exists"] = false
+	case "string":
+		value, err := client.Do("GET", key)
+		if err != nil {
+			return connectors.ActionResult{}, err
+		}
+		text := truncateString(respString(value), maxBytes)
+		output["value"] = text
+		output["truncated"] = len(respString(value)) > maxBytes
+	case "hash":
+		value, err := client.Do("HGETALL", key)
+		if err != nil {
+			return connectors.ActionResult{}, err
+		}
+		output["value"] = limitStringMap(respStringMap(value), limit, maxBytes)
+	case "list":
+		value, err := client.Do("LRANGE", key, "0", strconv.Itoa(limit-1))
+		if err != nil {
+			return connectors.ActionResult{}, err
+		}
+		output["value"] = limitStrings(respStringSlice(value), limit, maxBytes)
+	case "set":
+		output["value"], _ = redisScanCollection(client, "SSCAN", key, limit, maxBytes)
+	case "zset":
+		value, err := client.Do("ZRANGE", key, "0", strconv.Itoa(limit-1), "WITHSCORES")
+		if err != nil {
+			return connectors.ActionResult{}, err
+		}
+		output["value"] = scorePairs(respStringSlice(value), maxBytes)
+	default:
+		output["value"] = fmt.Sprintf("Preview for Redis type %q is not supported yet.", keyType)
+	}
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      output,
+		DisplayText: redisKeyDisplay(output),
+	}, nil
+}
+
+func executeSetString(client *redisClient, input map[string]any) (connectors.ActionResult, error) {
+	key := strings.TrimSpace(stringValue(input, "key"))
+	value := fmt.Sprint(input["value"])
+	if key == "" {
+		return connectors.ActionResult{}, fmt.Errorf("key is required")
+	}
+	args := []string{"SET", key, value}
+	if ttl := normalizeInt(input, "ttl_seconds", 0, 0, 31_536_000); ttl > 0 {
+		args = append(args, "EX", strconv.Itoa(ttl))
+	}
+	response, err := client.Do(args...)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      map[string]any{"key": key, "response": respString(response)},
+		DisplayText: fmt.Sprintf("Set Redis key %q.", key),
+	}, nil
+}
+
+func executeExpireKey(client *redisClient, input map[string]any) (connectors.ActionResult, error) {
+	key := strings.TrimSpace(stringValue(input, "key"))
+	ttl := normalizeInt(input, "ttl_seconds", 0, -1, 31_536_000)
+	if key == "" {
+		return connectors.ActionResult{}, fmt.Errorf("key is required")
+	}
+	var value respValue
+	var err error
+	if ttl < 0 {
+		value, err = client.Do("PERSIST", key)
+	} else {
+		value, err = client.Do("EXPIRE", key, strconv.Itoa(ttl))
+	}
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      map[string]any{"key": key, "changed": value.number == 1, "ttl_seconds": ttl},
+		DisplayText: fmt.Sprintf("Updated TTL for Redis key %q.", key),
+	}, nil
+}
+
+func executeDeleteKeys(client *redisClient, input map[string]any) (connectors.ActionResult, error) {
+	keys, err := normalizeKeys(input["keys"])
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	args := append([]string{"DEL"}, keys...)
+	value, err := client.Do(args...)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"keys":    keys,
+			"deleted": value.number,
+		},
+		DisplayText: fmt.Sprintf("Deleted %d Redis key(s).", value.number),
+	}, nil
+}
+
+func redisKeyType(client *redisClient, key string) (string, error) {
+	value, err := client.Do("TYPE", key)
+	if err != nil {
+		return "", err
+	}
+	return respString(value), nil
+}
+
+func redisScanCollection(client *redisClient, command string, key string, limit int, maxBytes int) ([]string, error) {
+	cursor := "0"
+	items := []string{}
+	for len(items) < limit {
+		value, err := client.Do(command, key, cursor, "COUNT", strconv.Itoa(min(limit-len(items), 100)))
+		if err != nil {
+			return nil, err
+		}
+		if value.kind != respArray || len(value.array) != 2 {
+			return nil, fmt.Errorf("unexpected %s response", command)
+		}
+		cursor = respString(value.array[0])
+		items = append(items, limitStrings(respStringSlice(value.array[1]), limit-len(items), maxBytes)...)
+		if cursor == "0" {
+			break
+		}
+	}
+	return items, nil
+}
+
+func parseRedisInfo(raw string) map[string]any {
+	sections := map[string]any{}
+	current := "default"
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "# ") {
+			current = strings.TrimSpace(strings.TrimPrefix(line, "# "))
+			if _, ok := sections[current]; !ok {
+				sections[current] = map[string]string{}
+			}
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		bucket, _ := sections[current].(map[string]string)
+		if bucket == nil {
+			bucket = map[string]string{}
+			sections[current] = bucket
+		}
+		bucket[parts[0]] = parts[1]
+	}
+	return sections
+}
+
+func redisKeyDisplay(output map[string]any) string {
+	encoded := fmt.Sprintf("%v", output["value"])
+	return truncateString(encoded, 4000)
+}
+
+func scorePairs(values []string, maxBytes int) []map[string]string {
+	out := []map[string]string{}
+	for index := 0; index+1 < len(values); index += 2 {
+		out = append(out, map[string]string{
+			"member": truncateString(values[index], maxBytes),
+			"score":  values[index+1],
+		})
+	}
+	return out
+}
+
+func classifyRedisTestError(err error) connectors.TestStatus {
+	if err == nil {
+		return connectors.TestOK
+	}
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "auth"), strings.Contains(message, "noauth"), strings.Contains(message, "invalid username-password"):
+		return connectors.TestFailedAuth
+	case strings.Contains(message, "connection refused"), strings.Contains(message, "i/o timeout"), strings.Contains(message, "no such host"), strings.Contains(message, "network"):
+		return connectors.TestFailedNetwork
+	default:
+		return connectors.TestUnknownError
+	}
+}
+
+func connectionMode(target connectors.TargetView) string {
+	mode := strings.TrimSpace(stringValue(target.Config, "connection_mode"))
+	if mode == "" {
+		return "direct"
+	}
+	return mode
+}
+
+func redisHost(target connectors.TargetView) string {
+	host := strings.TrimSpace(stringValue(target.Config, "host"))
+	if host == "" {
+		return defaultRedisHost
+	}
+	return host
+}
+
+func redisPort(target connectors.TargetView) int {
+	return normalizeInt(target.Config, "port", defaultRedisPort, 1, 65535)
+}
+
+func redisDatabase(target connectors.TargetView) int {
+	return normalizeInt(target.Config, "database", 0, 0, 1023)
+}
+
+func normalizeStringDefault(input map[string]any, key string, fallback string) string {
+	value := strings.TrimSpace(stringValue(input, key))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func stringValue(values map[string]any, key string) string {
+	if values == nil {
+		return ""
+	}
+	value := values[key]
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func normalizeInt(values map[string]any, key string, fallback int, minValue int, maxValue int) int {
+	if values == nil {
+		return fallback
+	}
+	value, ok := values[key]
+	if !ok || value == nil || value == "" {
+		return fallback
+	}
+	var parsed int
+	switch typed := value.(type) {
+	case int:
+		parsed = typed
+	case int64:
+		parsed = int(typed)
+	case float64:
+		parsed = int(typed)
+	case string:
+		n, err := strconv.Atoi(strings.TrimSpace(typed))
+		if err != nil {
+			return fallback
+		}
+		parsed = n
+	default:
+		return fallback
+	}
+	if parsed < minValue {
+		return minValue
+	}
+	if parsed > maxValue {
+		return maxValue
+	}
+	return parsed
+}
+
+func normalizeKeys(value any) ([]string, error) {
+	raw, ok := value.([]any)
+	if !ok {
+		if stringsValue, ok := value.([]string); ok {
+			raw = make([]any, 0, len(stringsValue))
+			for _, item := range stringsValue {
+				raw = append(raw, item)
+			}
+		}
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("keys must be a non-empty array")
+	}
+	keys := make([]string, 0, len(raw))
+	seen := map[string]bool{}
+	for _, item := range raw {
+		key := strings.TrimSpace(fmt.Sprint(item))
+		if key == "" || seen[key] {
+			continue
+		}
+		keys = append(keys, key)
+		seen[key] = true
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("keys must be a non-empty array")
+	}
+	if len(keys) > maxScanLimit {
+		return nil, fmt.Errorf("too many keys")
+	}
+	return keys, nil
+}
+
+func copyMap(input map[string]any) map[string]any {
+	out := map[string]any{}
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}
+
+func limitStrings(values []string, limit int, maxBytes int) []string {
+	if limit < 1 || len(values) == 0 {
+		return nil
+	}
+	if len(values) > limit {
+		values = values[:limit]
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, truncateString(value, maxBytes))
+	}
+	return out
+}
+
+func limitStringMap(values map[string]string, limit int, maxBytes int) map[string]string {
+	out := map[string]string{}
+	if limit < 1 {
+		return out
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if len(keys) > limit {
+		keys = keys[:limit]
+	}
+	for _, key := range keys {
+		out[key] = truncateString(values[key], maxBytes)
+	}
+	return out
+}
+
+func truncateString(value string, maxBytes int) string {
+	if maxBytes < 1 || len(value) <= maxBytes {
+		return value
+	}
+	return value[:maxBytes] + "...[truncated]"
+}
+
+func min(left int, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}
+
+var _ connectors.Connector = Connector{}
+var _ connectors.TestableConnector = Connector{}

--- a/backend/internal/connectors/redis/redis_test.go
+++ b/backend/internal/connectors/redis/redis_test.go
@@ -1,0 +1,136 @@
+package redisconnector
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+func TestPrepareActionNormalizesRedisScan(t *testing.T) {
+	target := connectors.TargetView{ID: 1, Ref: "redis:1:2", ConnectorKind: Kind, Name: "cache", Config: map[string]any{"connection_mode": "direct"}}
+	profile := connectors.CredentialProfileView{ID: 2, TargetID: 1, ConnectorKind: Kind, Kind: "username_password", Label: "default"}
+
+	prepared, err := Connector{}.PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     target,
+		Profile:    profile,
+		ActionName: ActionScanKeys,
+		Input:      map[string]any{"pattern": "user:*", "limit": 5000},
+	})
+	if err != nil {
+		t.Fatalf("prepare scan: %v", err)
+	}
+	if prepared.Payload["limit"] != maxScanLimit {
+		t.Fatalf("limit = %#v", prepared.Payload["limit"])
+	}
+	if prepared.Risk != connectors.RiskRead {
+		t.Fatalf("risk = %q", prepared.Risk)
+	}
+}
+
+func TestExecuteActionUsesNetworkTransportForPing(t *testing.T) {
+	runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+		if !reflect.DeepEqual(command, []string{"PING"}) {
+			t.Fatalf("command = %#v", command)
+		}
+		return "+PONG\r\n"
+	})
+	result, err := Connector{}.ExecuteAction(context.Background(), runtime, connectors.PreparedAction{ActionName: ActionPing})
+	if err != nil {
+		t.Fatalf("execute ping: %v", err)
+	}
+	if result.Status != connectors.ResultCompleted || result.Output.(map[string]any)["response"] != "PONG" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestExecuteActionScansBoundedKeys(t *testing.T) {
+	commands := 0
+	runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+		commands++
+		if command[0] != "SCAN" {
+			t.Fatalf("command = %#v", command)
+		}
+		return "*2\r\n$1\r\n0\r\n*2\r\n$6\r\nuser:1\r\n$6\r\nuser:2\r\n"
+	})
+	result, err := Connector{}.ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+		ActionName: ActionScanKeys,
+		Payload:    map[string]any{"pattern": "user:*", "cursor": "0", "limit": 10},
+	})
+	if err != nil {
+		t.Fatalf("execute scan: %v", err)
+	}
+	output := result.Output.(map[string]any)
+	if got := output["keys"]; !reflect.DeepEqual(got, []string{"user:1", "user:2"}) {
+		t.Fatalf("keys = %#v", got)
+	}
+	if commands != 1 {
+		t.Fatalf("commands = %d", commands)
+	}
+}
+
+func testRuntimeWithScript(t *testing.T, handler func(*testing.T, []string) string) connectors.RuntimeContext {
+	t.Helper()
+	return connectors.RuntimeContext{
+		Target: connectors.TargetView{
+			ID:            1,
+			Ref:           "redis:1:2",
+			ConnectorKind: Kind,
+			Name:          "cache",
+			Config:        map[string]any{"connection_mode": "direct", "host": "127.0.0.1", "port": 6379, "database": 0},
+		},
+		Profile:      connectors.CredentialProfileView{ID: 2, TargetID: 1, ConnectorKind: Kind, Kind: "username_password", Label: "default"},
+		Secrets:      testSecrets{},
+		Capabilities: testCapabilities{transport: scriptedTransport{t: t, handler: handler}},
+	}
+}
+
+type testSecrets struct{}
+
+func (testSecrets) GetSecret(context.Context, string) (string, error) {
+	return "", fmt.Errorf("missing")
+}
+
+type testCapabilities struct {
+	transport connectors.NetworkTransport
+}
+
+func (capabilities testCapabilities) RuntimeCapability(name string) connectors.RuntimeCapability {
+	if name == connectors.NetworkTransportCapabilityName {
+		return capabilities.transport
+	}
+	return nil
+}
+
+type scriptedTransport struct {
+	t       *testing.T
+	handler func(*testing.T, []string) string
+}
+
+func (scriptedTransport) ConnectorRuntimeCapability() string {
+	return connectors.NetworkTransportCapabilityName
+}
+
+func (transport scriptedTransport) DialConnectorTCP(context.Context, connectors.NetworkDialRequest) (net.Conn, error) {
+	client, server := net.Pipe()
+	go func() {
+		defer server.Close()
+		reader := bufio.NewReader(server)
+		for {
+			value, err := readRESPValue(reader)
+			if err != nil {
+				return
+			}
+			command := respStringSlice(value)
+			response := transport.handler(transport.t, command)
+			if _, err := server.Write([]byte(response)); err != nil {
+				return
+			}
+		}
+	}()
+	return client, nil
+}

--- a/backend/internal/connectors/ssh/apiadapter/adapter.go
+++ b/backend/internal/connectors/ssh/apiadapter/adapter.go
@@ -411,6 +411,71 @@ func (adapter) OpenLiveConsole(ctx context.Context, server connectorapi.GatewayS
 	}, nil
 }
 
+func (adapter) DialConnectorTCP(ctx context.Context, server connectorapi.GatewayServer, runtime connectorapi.GatewayRuntime, targetRef string, network string, address string) (net.Conn, error) {
+	if network == "" {
+		network = "tcp"
+	}
+	if network != "tcp" {
+		return nil, fmt.Errorf("unsupported SSH connector transport network %q", network)
+	}
+	gateway, err := serverFrom(server)
+	if err != nil {
+		return nil, err
+	}
+	runtimeID, err := runtimeIDForTargetRef(ctx, runtime, targetRef)
+	if err != nil {
+		return nil, err
+	}
+	target, privateKey, err := targetMaterial(ctx, runtime, runtimeID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ssh material: %w", err)
+	}
+	client, err := execution.DialSSH(ctx, executionTarget(gateway, target, privateKey))
+	if err != nil {
+		return nil, err
+	}
+	type response struct {
+		conn net.Conn
+		err  error
+	}
+	done := make(chan response, 1)
+	go func() {
+		conn, err := client.Dial(network, address)
+		done <- response{conn: conn, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		_ = client.Close()
+		go func() {
+			value := <-done
+			if value.conn != nil {
+				_ = value.conn.Close()
+			}
+		}()
+		return nil, ctx.Err()
+	case value := <-done:
+		if value.err != nil {
+			_ = client.Close()
+			return nil, fmt.Errorf("ssh tcp dial: %w", value.err)
+		}
+		return sshTCPConn{Conn: value.conn, client: client}, nil
+	}
+}
+
+type sshTCPConn struct {
+	net.Conn
+	client *ssh.Client
+}
+
+func (conn sshTCPConn) Close() error {
+	connErr := conn.Conn.Close()
+	clientErr := conn.client.Close()
+	if connErr != nil {
+		return connErr
+	}
+	return clientErr
+}
+
 func (adapter) SupportsRunning(prepared actions.PreparedRequest) bool {
 	return prepared.Target.ConnectorKind == sshconnector.Kind && prepared.Action.ActionName == sshconnector.ActionExec
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,9 +2,9 @@
 
 AIPermission has published its first public release candidate and is moving
 into the connector-native 0.2 line. The local-only permission gateway is usable
-today with built-in SSH and Postgres connectors; the next releases focus on
+today with built-in SSH, Postgres, and Redis connectors; the next releases focus on
 dogfooding polish, small safety improvements, clearer contributor paths, and
-additional connector kinds such as API, Redis, and queues that share one
+additional connector kinds such as API, queues, and storage that share one
 permission pipeline.
 
 Related notes:
@@ -53,7 +53,7 @@ AIPermission is intentionally:
 - Local-only.
 - Single-user.
 - Developer-focused.
-- Connector-based, with built-in SSH and Postgres.
+- Connector-based, with built-in SSH, Postgres, and Redis.
 - Human-in-the-loop.
 
 These requests conflict with the project principles and should normally be
@@ -182,6 +182,8 @@ Goals:
 
 - Keep SSH working as a built-in connector with its own terminal and file-transfer surface.
 - Add Postgres as the first structured connector.
+- Add Redis as the first cache/key-value connector with direct and SSH-tunneled
+  TCP transport.
 - Store connector permissions by target/profile/action instead of by a
   connector-specific table.
 - Render connector UI through frontend templates so contributors can add a
@@ -190,7 +192,7 @@ Goals:
 - Treat the 0.2 connector line as a clean pre-1.0 schema boundary. Avoid
   permanent compatibility code that keeps SSH outside the shared
   connector path.
-- Make future connectors feel like first-class citizens: adding Redis, API, or
+- Make future connectors feel like first-class citizens: adding API, queue, storage, or
   another integration should mean adding a connector package/template, not
   adding another product-specific pipeline.
 
@@ -206,7 +208,7 @@ Non-goals:
 These may be useful, but they are not required for the RC:
 
 - [ ] API connector definitions from operator-reviewed JSON.
-- [ ] Redis or queue connector exploration after Postgres proves the shared
+- [ ] Queue connector exploration after Redis/Postgres prove the shared
   target/profile/action model.
 - [ ] Optional sensitive/no-persist console sessions.
 - [ ] Export filters for History and Audit data.

--- a/docs/development/add-a-connector.md
+++ b/docs/development/add-a-connector.md
@@ -325,22 +325,26 @@ that can produce/restore backup artifacts implements `BackupRestorer`. Core owns
 HTTP upload/download, confirmation, vault persistence, and audit; the connector
 owns only the external service-specific work.
 
-## Example: Redis
+## Built-In Example: Redis
 
-A Redis connector should add only Redis-specific behavior:
+The built-in Redis connector adds only Redis-specific behavior:
 
-- target fields such as host, port, TLS mode, and database index
+- target fields such as connection mode, host, port, database index, and
+  optional SSH transport target ref
 - credential profile fields such as username/password or token
-- actions such as `get_info`, `scan_keys`, or `get_key`
+- actions such as `ping`, `info`, `scan_keys`, `get_key`, `set_string`,
+  `expire_key`, and `delete_keys`
 - connector help that explains safe key inspection
-- UI templates for Redis target rows, credential profiles, and activity output
+- UI templates for Redis target rows, credential profiles, and key-browser
+  console output
 
 It should not add a Redis-specific token permission table, approval table,
 history page, audit route, MCP tool family, or global UI page.
 
-Minimal Redis skeleton checklist:
+Redis checklist:
 
 - `backend/internal/connectors/redis/redis.go`
+- `backend/internal/connectors/redis/client.go`
 - `backend/internal/connectors/redis/redis_test.go`
 - backend registry entry and registry test
 - backend route tests if the built-in connector list or inventory expectations

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -30,9 +30,10 @@ target + credential profile + action
   -> history + audit
 ```
 
-SSH and Postgres are built-in connectors that share the same target/profile,
-permission, approval, history, and audit model. SSH owns a live terminal and
-file-transfer surface; Postgres owns structured database actions. Future
+SSH, Postgres, and Redis are built-in connectors that share the same
+target/profile, permission, approval, history, and audit model. SSH owns a live
+terminal and file-transfer surface; Postgres owns structured database actions;
+Redis owns bounded key-browser actions. Future
 connectors should add their own execution surface without adding a new
 permission or audit pipeline.
 

--- a/docs/mvp/scope.md
+++ b/docs/mvp/scope.md
@@ -11,7 +11,7 @@ Main target:
 The MVP is not a DevOps platform. It does not own production operations. It gives a developer a controlled, token-scoped, auditable execution channel for debugging, maintenance, incident triage, and temporary AI-assisted automation.
 
 The MVP does not introduce first-class management modules for every external
-system. It introduces one connector pipeline. SSH, Postgres, and future
+system. It introduces one connector pipeline. SSH, Postgres, Redis, and future
 integrations are connector kinds that provide their own actions while sharing
 the same target/profile/action permission model. If an allowed SSH target has
 the needed CLI tools and access, the AI can operate at command level through

--- a/docs/project-principles.md
+++ b/docs/project-principles.md
@@ -8,7 +8,7 @@ part of the security model, not marketing copy.
 - Local-only
 - Single-user
 - Developer-focused
-- Connector-based, with built-in SSH and Postgres
+- Connector-based, with built-in SSH, Postgres, and Redis
 - Human-in-the-loop
 
 ## AIPermission Intentionally Rejects

--- a/docs/whatis-aipermission.md
+++ b/docs/whatis-aipermission.md
@@ -248,7 +248,7 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-SSH, Postgres, and future integrations are exposed as connector actions instead
+SSH, Postgres, Redis, and future integrations are exposed as connector actions instead
 of separate product-specific MCP tools.
 
 ## Connector Action Flow

--- a/frontend/src/connectors/templates/redis/console.jsx
+++ b/frontend/src/connectors/templates/redis/console.jsx
@@ -1,0 +1,469 @@
+import { Database, Plus, RefreshCcw, Save, Search, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "../../../components/ui/badge";
+import { Button } from "../../../components/ui/button";
+import { CopyButton } from "../../../components/ui/copy-button";
+import { Dialog } from "../../../components/ui/dialog";
+import { Checkbox, Input, Textarea } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+import { TerminalBlock } from "../../../components/ui/terminal-block";
+import { apiPost } from "../../../lib/api";
+
+const defaultPattern = "*";
+const defaultLimit = 100;
+
+export function RedisConnectorConsoleTemplate({ target, approvals, theme, session, onNewStructuredSession, onRefreshActivity }) {
+  const activeSession = session || { active: false, startedAt: "" };
+  const [pattern, setPattern] = useState(defaultPattern);
+  const [cursor, setCursor] = useState("0");
+  const [keys, setKeys] = useState([]);
+  const [selectedKeys, setSelectedKeys] = useState([]);
+  const [activeKey, setActiveKey] = useState("");
+  const [keyResult, setKeyResult] = useState(null);
+  const [valueDraft, setValueDraft] = useState("");
+  const [newKey, setNewKey] = useState("");
+  const [newValue, setNewValue] = useState("");
+  const [ttlDraft, setTTLDraft] = useState("");
+  const [state, setState] = useState({ state: "idle", error: "", message: "" });
+  const [resultMode, setResultMode] = useState("value");
+  const [confirmDialog, setConfirmDialog] = useState({ open: false, type: "", title: "", description: "", details: [], tone: "warn", pending: false, onConfirm: null });
+  const panelClass = theme === "light" ? "bg-white text-stone-900" : "bg-[#1e1e1e] text-stone-100";
+  const mutedClass = theme === "light" ? "text-stone-500" : "text-stone-400";
+  const borderClass = theme === "light" ? "border-stone-200" : "border-stone-700";
+  const subtlePanelClass = theme === "light" ? "bg-stone-50" : "bg-[#252526]";
+  const inputClass = theme === "light" ? "border-stone-300 bg-white text-stone-900 placeholder:text-stone-400" : "border-stone-700 bg-[#1a1a1a] text-stone-100 placeholder:text-stone-500";
+  const rowHoverClass = theme === "light" ? "hover:bg-stone-50" : "hover:bg-stone-800/60";
+  const activeRowClass = theme === "light" ? "border-emerald-200 bg-emerald-50 text-emerald-950" : "border-emerald-700 bg-emerald-950/40 text-emerald-100";
+  const activeItems = useMemo(() => (approvals?.data || []).filter((item) => item.target_ref === target.ref), [approvals?.data, target.ref]);
+  const latestAction = activeItems[0] || null;
+  const selectedCount = selectedKeys.length;
+
+  useEffect(() => {
+    setCursor("0");
+    setKeys([]);
+    setSelectedKeys([]);
+    setActiveKey("");
+    setKeyResult(null);
+    setValueDraft("");
+    setNewKey("");
+    setNewValue("");
+    setTTLDraft("");
+    setResultMode("value");
+  }, [target.ref, activeSession.active, activeSession.startedAt]);
+
+  useEffect(() => {
+    if (!activeSession.active) return;
+    void scanKeys({ reset: true });
+  }, [activeSession.active, activeSession.startedAt, target.ref]);
+
+  async function runRedisAction({ actionName, input, reason, busy = "running" }) {
+    setState({ state: busy, error: "", message: "" });
+    try {
+      const item = await apiPost("/api/connector-actions/local-run", {
+        target_ref: target.ref,
+        action_name: actionName,
+        input,
+        reason,
+      });
+      setState({ state: "idle", error: "", message: item.display_text || "" });
+      await onRefreshActivity?.();
+      return item;
+    } catch (error) {
+      setState({ state: "error", error: error.message || "Redis action failed.", message: "" });
+      throw error;
+    }
+  }
+
+  async function scanKeys({ reset = false } = {}) {
+    if (!activeSession.active) return;
+    const startCursor = reset ? "0" : cursor || "0";
+    const effectivePattern = redisScanPattern(pattern);
+    const item = await runRedisAction({
+      actionName: "scan_keys",
+      input: { pattern: effectivePattern, cursor: startCursor, limit: defaultLimit },
+      reason: "manual Redis browser key scan",
+      busy: "scanning",
+    });
+    const output = item.output || {};
+    const nextKeys = Array.isArray(output.keys) ? output.keys : [];
+    setCursor(String(output.next_cursor || "0"));
+    setKeys((current) => uniqueStrings(reset ? nextKeys : [...current, ...nextKeys]));
+  }
+
+  function startNewKey() {
+    setActiveKey("");
+    setKeyResult(null);
+    setValueDraft("");
+    setNewKey("");
+    setNewValue("");
+    setTTLDraft("");
+    setResultMode("value");
+  }
+
+  async function loadKey(key) {
+    if (!activeSession.active || !key) return;
+    setActiveKey(key);
+    setResultMode("value");
+    const item = await runRedisAction({
+      actionName: "get_key",
+      input: { key, limit: 250, max_bytes: 262144 },
+      reason: "manual Redis browser key read",
+      busy: "reading",
+    });
+    const output = item.output || {};
+    setKeyResult(output);
+    setValueDraft(valueToEditableText(output));
+    setTTLDraft(output.ttl_ms && output.ttl_ms > 0 ? String(Math.ceil(output.ttl_ms / 1000)) : "");
+  }
+
+  async function saveStringValue(event) {
+    event?.preventDefault?.();
+    const key = activeKey || newKey.trim();
+    if (!key) return;
+    const value = activeKey ? valueDraft : newValue;
+    const ttlSeconds = Number(ttlDraft) > 0 ? Number(ttlDraft) : 0;
+    openConfirmDialog({
+      type: "save-string",
+      title: activeKey ? "Save Redis string" : "Create Redis string key",
+      description: activeKey ? "This will overwrite the selected key as a Redis string." : "This will create a Redis string key.",
+      tone: "warn",
+      details: [
+        { label: "Key", value: key },
+        { label: "TTL", value: ttlSeconds > 0 ? `${ttlSeconds}s` : "persistent" },
+      ],
+      onConfirm: async () => {
+        await runRedisAction({
+          actionName: "set_string",
+          input: { key, value, ttl_seconds: ttlSeconds },
+          reason: "manual Redis browser string write",
+          busy: "writing",
+        });
+        setNewKey("");
+        setNewValue("");
+        setKeys((current) => uniqueStrings([...current, key]).sort());
+        await loadKey(key);
+      },
+    });
+  }
+
+  async function updateTTL() {
+    if (!activeKey) return;
+    const ttlSeconds = ttlDraft.trim() === "" ? -1 : Number(ttlDraft);
+    const normalizedTTL = Number.isFinite(ttlSeconds) ? ttlSeconds : -1;
+    openConfirmDialog({
+      type: "ttl",
+      title: normalizedTTL < 0 ? "Persist Redis key" : "Update Redis TTL",
+      description: normalizedTTL < 0 ? "This removes the expiration from the selected key." : "This changes when the selected key expires.",
+      tone: "warn",
+      details: [
+        { label: "Key", value: activeKey },
+        { label: "TTL", value: normalizedTTL < 0 ? "persistent" : `${normalizedTTL}s` },
+      ],
+      onConfirm: async () => {
+        await runRedisAction({
+          actionName: "expire_key",
+          input: { key: activeKey, ttl_seconds: normalizedTTL },
+          reason: "manual Redis browser TTL update",
+          busy: "writing",
+        });
+        await loadKey(activeKey);
+      },
+    });
+  }
+
+  async function deleteSelected() {
+    const keysToDelete = selectedKeys.length > 0 ? selectedKeys : activeKey ? [activeKey] : [];
+    if (keysToDelete.length === 0) return;
+    openConfirmDialog({
+      type: "delete",
+      title: `Delete ${keysToDelete.length} Redis key${keysToDelete.length === 1 ? "" : "s"}`,
+      description: "This permanently deletes the selected Redis key data.",
+      tone: "bad",
+      details: keysToDelete.slice(0, 8).map((key) => ({ label: "Key", value: key })).concat(keysToDelete.length > 8 ? [{ label: "More", value: `${keysToDelete.length - 8} additional key(s)` }] : []),
+      onConfirm: async () => {
+        await runRedisAction({
+          actionName: "delete_keys",
+          input: { keys: keysToDelete },
+          reason: "manual Redis browser key delete",
+          busy: "deleting",
+        });
+        setKeys((current) => current.filter((key) => !keysToDelete.includes(key)));
+        setSelectedKeys([]);
+        if (keysToDelete.includes(activeKey)) {
+          setActiveKey("");
+          setKeyResult(null);
+          setValueDraft("");
+        }
+      },
+    });
+  }
+
+  function openConfirmDialog({ type, title, description, details, tone, onConfirm }) {
+    setConfirmDialog({ open: true, type, title, description, details, tone, pending: false, onConfirm });
+  }
+
+  async function confirmPendingAction() {
+    if (!confirmDialog.onConfirm) return;
+    setConfirmDialog((current) => ({ ...current, pending: true }));
+    try {
+      await confirmDialog.onConfirm();
+      setConfirmDialog({ open: false, type: "", title: "", description: "", details: [], tone: "warn", pending: false, onConfirm: null });
+    } catch {
+      setConfirmDialog((current) => ({ ...current, pending: false }));
+    }
+  }
+
+  function toggleSelection(key) {
+    setSelectedKeys((current) => (current.includes(key) ? current.filter((item) => item !== key) : [...current, key]));
+  }
+
+  if (!activeSession.active) {
+    return (
+      <div className={`grid min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
+        <div className="grid place-items-center p-8 text-center">
+          <div className="grid max-w-lg gap-4">
+            <Database className={`mx-auto h-10 w-10 ${mutedClass}`} />
+            <div>
+              <h3 className="text-lg font-semibold">No active Redis session</h3>
+              <p className={`mt-2 text-sm ${mutedClass}`}>Start a structured session to browse Redis keys through the connector approval, history, and audit pipeline.</p>
+            </div>
+            <Button type="button" className="mx-auto" onClick={onNewStructuredSession}>
+              Start Redis session
+            </Button>
+          </div>
+        </div>
+        <RedisEndpointFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
+      </div>
+    );
+  }
+
+  const creatingKey = !activeKey;
+  const editableString = creatingKey || keyResult?.type === "string";
+  const canSaveString = creatingKey ? Boolean(newKey.trim()) : keyResult?.type === "string";
+  const canUpdateTTL = Boolean(activeKey && keyResult && keyResult.type !== "none") && state.state === "idle";
+
+  return (
+    <div className={`grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
+      <div className="grid min-h-0 gap-4 overflow-hidden p-4 lg:grid-cols-[340px_minmax(0,1fr)]">
+        <section className={`grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+          <div className={`border-b p-3 ${borderClass}`}>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold">Keys</p>
+                <p className={`text-xs ${mutedClass}`}>{keys.length} loaded</p>
+              </div>
+              <div className="flex flex-wrap items-center justify-end gap-2">
+                {latestAction ? <Badge tone={latestAction.status === "failed" ? "bad" : latestAction.status === "completed" ? "good" : "warn"}>{latestAction.action_name}</Badge> : null}
+                <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Refresh keys" onClick={() => scanKeys({ reset: true })} disabled={state.state !== "idle"}>
+                  <RefreshCcw className="h-3.5 w-3.5" />
+                </Button>
+                <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={startNewKey}>
+                  <Plus className="h-3.5 w-3.5" />
+                  New
+                </Button>
+                <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={() => setSelectedKeys(selectedKeys.length === keys.length ? [] : keys)}>
+                  {selectedKeys.length === keys.length && keys.length > 0 ? "None" : "All"}
+                </Button>
+              </div>
+            </div>
+          </div>
+          <form className={`grid gap-2 border-b p-3 ${borderClass}`} onSubmit={(event) => { event.preventDefault(); void scanKeys({ reset: true }); }}>
+            <div className="relative">
+              <Search className={`pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 ${mutedClass}`} />
+              <Input className={`pl-9 ${inputClass}`} value={pattern} onChange={(event) => setPattern(event.target.value)} placeholder="SCAN pattern, e.g. user:*" />
+            </div>
+            <Button type="submit" variant="outline" className="h-9" disabled={state.state !== "idle"}>
+              {state.state === "scanning" ? "Scanning" : "Scan keys"}
+            </Button>
+          </form>
+          <div className="min-h-0 overflow-auto p-2">
+            {keys.map((key) => (
+              <button
+                key={key}
+                type="button"
+                className={`mb-1 grid w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-2 rounded-md border px-2 py-2 text-left text-sm transition ${activeKey === key ? activeRowClass : `${borderClass} ${rowHoverClass}`}`}
+                onClick={() => loadKey(key)}
+              >
+                <Checkbox
+                  checked={selectedKeys.includes(key)}
+                  onClick={(event) => event.stopPropagation()}
+                  onChange={() => toggleSelection(key)}
+                  aria-label={`Select ${key}`}
+                />
+                <span className="truncate font-mono text-xs" title={key}>{key}</span>
+              </button>
+            ))}
+            {keys.length === 0 ? <Notice>{state.state === "scanning" ? "Scanning Redis keys..." : "No keys loaded. Scan to browse this database."}</Notice> : null}
+          </div>
+          <div className={`flex items-center justify-between gap-2 border-t p-3 ${borderClass}`}>
+            <Button type="button" variant="outline" className="h-8 px-3 text-xs" disabled={cursor === "0" || state.state !== "idle"} onClick={() => scanKeys({ reset: false })}>
+              More
+            </Button>
+            <Button type="button" variant="outline" className="h-8 px-3 text-xs text-red-600" disabled={(selectedCount === 0 && !activeKey) || state.state !== "idle"} onClick={deleteSelected}>
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete {selectedCount || (activeKey ? 1 : "")}
+            </Button>
+          </div>
+        </section>
+
+        <section className={`grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden rounded-lg border ${borderClass}`}>
+          <div className={`flex flex-wrap items-center justify-between gap-3 border-b p-3 ${borderClass} ${subtlePanelClass}`}>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold">{activeKey || "New string key"}</p>
+              <p className={`truncate text-xs ${mutedClass}`}>{keyResult ? keyMetaText(keyResult) : creatingKey ? "Create a Redis string value." : "Select a key from the browser."}</p>
+            </div>
+            <div className="flex items-center gap-2">
+              {keyResult?.type ? <Badge tone={keyResult.type === "none" ? "neutral" : "good"}>{keyResult.type}</Badge> : null}
+              {keyResult ? <CopyButton value={JSON.stringify(keyResult, null, 2)} variant="outline" className="h-8 px-2 text-xs" title="Copy key JSON">JSON</CopyButton> : null}
+            </div>
+          </div>
+          <div className={`flex flex-wrap items-center justify-between gap-2 border-b p-3 ${borderClass}`}>
+            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+              <Button type="button" variant={resultMode === "value" ? "default" : "outline"} className="h-8 px-3 text-xs" onClick={() => setResultMode("value")}>Value</Button>
+              <Button type="button" variant={resultMode === "json" ? "default" : "outline"} className="h-8 px-3 text-xs" onClick={() => setResultMode("json")}>Raw JSON</Button>
+              {activeKey ? <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Reload key" onClick={() => loadKey(activeKey)} disabled={state.state !== "idle"}><RefreshCcw className="h-3.5 w-3.5" /></Button> : null}
+              {creatingKey ? (
+                <Input className={`h-8 min-w-56 flex-1 ${inputClass}`} value={newKey} onChange={(event) => setNewKey(event.target.value)} placeholder="New key name" />
+              ) : null}
+            </div>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <div className="flex items-center gap-1">
+                <Input
+                  className={`h-8 w-28 ${inputClass}`}
+                  value={ttlDraft}
+                  onChange={(event) => setTTLDraft(event.target.value)}
+                  placeholder="TTL"
+                  aria-label="TTL seconds"
+                />
+                <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Save TTL" disabled={!canUpdateTTL} onClick={updateTTL}>
+                  <Save className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              <Button type="button" className="h-8 px-3 text-xs" disabled={state.state !== "idle" || !canSaveString} onClick={saveStringValue} title={editableString ? "Save Redis string value" : "This Redis type is read-only in the MVP"}>
+                {activeKey ? <Save className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
+                {activeKey ? (editableString ? "Save string" : "Read only") : "Create key"}
+              </Button>
+            </div>
+          </div>
+          <div className="min-h-0 overflow-hidden p-4">
+            {resultMode === "json" ? (
+              <TerminalBlock surface="log" className="h-full min-h-0 text-xs">{keyResult ? JSON.stringify(keyResult, null, 2) : creatingKey ? "New key is not saved yet." : "No key selected."}</TerminalBlock>
+            ) : creatingKey ? (
+              <Textarea className={`h-full min-h-0 resize-none font-mono text-xs ${inputClass}`} value={newValue} onChange={(event) => setNewValue(event.target.value)} placeholder="String value" />
+            ) : (
+              <ValuePanel keyResult={keyResult} valueDraft={valueDraft} onValueDraft={setValueDraft} inputClass={inputClass} />
+            )}
+          </div>
+          <div className={`grid gap-2 border-t p-3 ${borderClass}`}>
+            {keyResult && keyResult.type !== "string" && resultMode === "value" ? <Notice tone="warn">This Redis type is read-only in the MVP. TTL changes are still available from the toolbar.</Notice> : null}
+            {state.error ? <Notice tone="bad">{state.error}</Notice> : null}
+            {state.message ? <Notice tone="good">{state.message}</Notice> : null}
+          </div>
+        </section>
+      </div>
+
+      <RedisEndpointFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
+      <RedisConfirmDialog value={confirmDialog} theme={theme} onClose={() => setConfirmDialog({ open: false, type: "", title: "", description: "", details: [], tone: "warn", pending: false, onConfirm: null })} onConfirm={confirmPendingAction} />
+    </div>
+  );
+}
+
+function RedisConfirmDialog({ value, theme, onClose, onConfirm }) {
+  const danger = value.tone === "bad";
+  const noticeTone = danger ? "bad" : "warn";
+  const detailClass = theme === "light" ? "bg-stone-50" : "bg-stone-900/70 text-stone-100";
+  return (
+    <Dialog
+      open={value.open}
+      title={value.title}
+      description={value.description}
+      onClose={onClose}
+      closeDisabled={value.pending}
+      size="md"
+      closeOnOverlay={!value.pending}
+      closeOnEscape={!value.pending}
+      className={theme === "light" ? "" : "border-stone-700 bg-[#252526] text-stone-100"}
+      bodyClassName={theme === "light" ? "" : "bg-[#252526]"}
+    >
+      <div className="grid gap-4">
+        <Notice tone={noticeTone}>{danger ? "This operation cannot be undone." : "Review the Redis write before continuing."}</Notice>
+        {value.details?.length ? (
+          <div className={`max-h-56 overflow-auto rounded-md border border-stone-300 p-3 text-sm ${detailClass}`}>
+            {value.details.map((item, index) => (
+              <div key={`${item.label}:${index}`} className="grid gap-1 py-1 sm:grid-cols-[110px_minmax(0,1fr)]">
+                <span className="text-xs font-semibold uppercase text-stone-500">{item.label}</span>
+                <span className="break-all font-mono text-xs">{item.value}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose} disabled={value.pending}>
+            Cancel
+          </Button>
+          <Button type="button" variant={danger ? "danger" : "default"} onClick={onConfirm} disabled={value.pending}>
+            {value.pending ? "Working..." : danger ? "Delete" : "Confirm"}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function ValuePanel({ keyResult, valueDraft, onValueDraft, inputClass }) {
+  if (!keyResult) {
+    return <Notice>Select a key from the left panel to inspect its value.</Notice>;
+  }
+  if (keyResult.type === "string") {
+    return <Textarea className={`min-h-0 h-full resize-none font-mono text-xs ${inputClass}`} value={valueDraft} onChange={(event) => onValueDraft(event.target.value)} />;
+  }
+  return <TerminalBlock surface="log" className="min-h-0 text-xs">{formatRedisValue(keyResult.value)}</TerminalBlock>;
+}
+
+function RedisEndpointFooter({ target, borderClass, mutedClass }) {
+  return (
+    <div className={`flex min-w-0 items-center justify-between gap-3 border-t px-3 py-2 text-xs ${borderClass}`}>
+      <span className={`truncate font-mono ${mutedClass}`}>{target.ref}</span>
+      <span className={`truncate ${mutedClass}`}>{target.config?.host}:{target.config?.port} db {target.config?.database || 0}</span>
+    </div>
+  );
+}
+
+function formatRedisValue(value) {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value ?? null, null, 2);
+}
+
+function valueToEditableText(output) {
+  if (!output) return "";
+  if (output.type === "string") return formatEditableString(output.value);
+  return formatRedisValue(output.value);
+}
+
+function formatEditableString(value) {
+  const text = String(value ?? "");
+  const trimmed = text.trim();
+  if (!trimmed) return text;
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function redisScanPattern(value) {
+  const trimmed = String(value || "").trim();
+  if (!trimmed) return defaultPattern;
+  if (/[*?[\]]/.test(trimmed)) return trimmed;
+  return `*${trimmed}*`;
+}
+
+function keyMetaText(result) {
+  const ttl = Number(result.ttl_ms);
+  const ttlText = ttl > 0 ? `${Math.ceil(ttl / 1000)}s TTL` : ttl === -1 ? "persistent" : ttl === -2 ? "missing" : "ttl unknown";
+  return `${result.type || "unknown"} · ${ttlText}`;
+}
+
+function uniqueStrings(values) {
+  return Array.from(new Set((values || []).filter(Boolean)));
+}

--- a/frontend/src/connectors/templates/redis/credential-form.jsx
+++ b/frontend/src/connectors/templates/redis/credential-form.jsx
@@ -1,0 +1,66 @@
+import { Database, Plus } from "lucide-react";
+import { Button } from "../../../components/ui/button";
+import { Field, Input, Select } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+
+export function RedisCredentialFormTemplate({ targets, form, formMode = "create", state, onChange, onSubmit }) {
+  const redisTargets = targets.filter((target) => target.connector_kind === "redis");
+  const editing = formMode === "edit";
+  return (
+    <form className="grid gap-4" onSubmit={onSubmit}>
+      {redisTargets.length === 0 ? (
+        <Notice tone="warn">Create a Redis connector target before adding a Redis credential profile.</Notice>
+      ) : (
+        <Notice tone="good">
+          {editing ? "Update public Redis profile metadata, or enter a new password to rotate the stored secret." : "Create a Redis profile, then bind tokens to this profile from Console or Tokens."}
+        </Notice>
+      )}
+      <Field>
+        Connector target
+        <Select value={form.target_id} onChange={(event) => onChange({ ...form, target_id: event.target.value })} disabled={editing} required>
+          <option value="" disabled>
+            Select Redis target
+          </option>
+          {redisTargets.map((target) => (
+            <option value={target.id} key={target.id}>
+              {target.name} · {target.config?.host}:{target.config?.port}/{target.config?.database || 0}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange({ ...form, profile_label: event.target.value })} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange({ ...form, risk_label: event.target.value })} />
+        </Field>
+      </div>
+      <Field>
+        Username
+        <Input value={form.username} onChange={(event) => onChange({ ...form, username: event.target.value })} autoComplete="off" placeholder="optional Redis ACL username" />
+      </Field>
+      <Field>
+        {editing ? "New password" : "Password"}
+        <Input
+          type="password"
+          value={form.password}
+          onChange={(event) => onChange({ ...form, password: event.target.value })}
+          autoComplete="new-password"
+          placeholder={editing ? "Leave blank to keep current password" : "optional Redis password"}
+        />
+      </Field>
+      {state.state === "error" ? <Notice tone="bad">{state.error}</Notice> : null}
+      <Button type="submit" disabled={state.state === "saving" || redisTargets.length === 0}>
+        <Plus className="h-4 w-4" />
+        {state.state === "saving" ? "Saving..." : editing ? "Save Redis credential" : "Create Redis credential"}
+      </Button>
+      <Notice>
+        <Database className="mr-2 inline h-4 w-4" />
+        Redis secrets are stored in the encrypted local database and are never returned to MCP or REST list responses.
+      </Notice>
+    </form>
+  );
+}

--- a/frontend/src/connectors/templates/redis/form.jsx
+++ b/frontend/src/connectors/templates/redis/form.jsx
@@ -1,0 +1,95 @@
+import { Field, Input, Select } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+
+export function RedisConnectorFormTemplate({ form, mode = "create", targets = [], onChange }) {
+  const editing = mode === "edit";
+  const sshProfiles = sshProfileOptions(targets);
+  const overSSH = form.connection_mode === "over_ssh";
+  return (
+    <>
+      <Notice tone="good">
+        Redis keys can contain secrets. Start with Prompt permissions for write and delete actions until the workflow is trusted.
+      </Notice>
+      <Field>
+        Connector name
+        <Input value={form.name} onChange={(event) => onChange("name", event.target.value)} required />
+      </Field>
+      <Field>
+        Connection mode
+        <Select value={form.connection_mode} onChange={(event) => onChange("connection_mode", event.target.value)}>
+          <option value="direct">Direct from this gateway</option>
+          <option value="over_ssh">Over an SSH connector profile</option>
+        </Select>
+      </Field>
+      {overSSH ? (
+        <Field>
+          SSH transport profile
+          <Select value={form.transport_target_ref} onChange={(event) => onChange("transport_target_ref", event.target.value)} required>
+            <option value="" disabled>
+              Select SSH profile
+            </option>
+            {sshProfiles.map((profile) => (
+              <option value={profile.ref} key={profile.ref}>
+                {profile.label}
+              </option>
+            ))}
+          </Select>
+        </Field>
+      ) : null}
+      {overSSH ? (
+        <Notice>
+          Host and port are resolved from the SSH server. Use 127.0.0.1:6379 when Redis only listens on the remote machine.
+        </Notice>
+      ) : null}
+      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_120px_120px]">
+        <Field>
+          Redis host
+          <Input value={form.host} onChange={(event) => onChange("host", event.target.value)} required />
+        </Field>
+        <Field>
+          Port
+          <Input type="number" min="1" max="65535" value={form.port} onChange={(event) => onChange("port", event.target.value)} required />
+        </Field>
+        <Field>
+          Database
+          <Input type="number" min="0" max="1023" value={form.database} onChange={(event) => onChange("database", event.target.value)} />
+        </Field>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange("profile_label", event.target.value)} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange("risk_label", event.target.value)} />
+        </Field>
+      </div>
+      <Field>
+        Username
+        <Input value={form.username} onChange={(event) => onChange("username", event.target.value)} autoComplete="off" placeholder="optional Redis ACL username" />
+      </Field>
+      <Field>
+        Password
+        <Input
+          type="password"
+          value={form.password}
+          onChange={(event) => onChange("password", event.target.value)}
+          autoComplete="new-password"
+          placeholder={editing ? "Leave blank to keep the current encrypted password" : "optional Redis password"}
+        />
+      </Field>
+    </>
+  );
+}
+
+function sshProfileOptions(targets) {
+  return (targets || [])
+    .filter((target) => target.connector_kind === "ssh")
+    .flatMap((target) =>
+      (target.profiles || []).map((profile) => ({
+        ref: profile.ref || `${target.connector_kind}:${target.id}:${profile.id}`,
+        label: `${target.name} / ${profile.label} · ${target.config?.host || "host"}:${target.config?.port || 22}`,
+      }))
+    );
+}

--- a/frontend/src/connectors/templates/redis/index.jsx
+++ b/frontend/src/connectors/templates/redis/index.jsx
@@ -1,0 +1,15 @@
+import { RedisConnectorConsoleTemplate } from "./console";
+import { RedisCredentialFormTemplate } from "./credential-form";
+import { RedisConnectorFormTemplate } from "./form";
+import { RedisConnectorRowActionsTemplate } from "./list-item";
+import { RedisConnectorOperationsTemplate } from "./operations";
+import * as model from "./model";
+
+export default Object.freeze({
+  Console: RedisConnectorConsoleTemplate,
+  CredentialForm: RedisCredentialFormTemplate,
+  Form: RedisConnectorFormTemplate,
+  model,
+  Operations: RedisConnectorOperationsTemplate,
+  RowActions: RedisConnectorRowActionsTemplate,
+});

--- a/frontend/src/connectors/templates/redis/list-item.jsx
+++ b/frontend/src/connectors/templates/redis/list-item.jsx
@@ -1,0 +1,3 @@
+export function RedisConnectorRowActionsTemplate() {
+  return null;
+}

--- a/frontend/src/connectors/templates/redis/metadata.json
+++ b/frontend/src/connectors/templates/redis/metadata.json
@@ -1,0 +1,8 @@
+{
+  "kind": "redis",
+  "label": "Redis",
+  "summary": "Key browsing, bounded reads, string writes, TTL updates, and destructive deletes through Redis credential profiles.",
+  "version": "0.2",
+  "icon": "database",
+  "badge_tone": "warn"
+}

--- a/frontend/src/connectors/templates/redis/model.js
+++ b/frontend/src/connectors/templates/redis/model.js
@@ -1,0 +1,283 @@
+import { apiDelete, apiPost, apiPut } from "../../../lib/api";
+import { createTargetWithProfile, updateTargetWithProfile } from "../target-profile-save";
+
+const emptyRedisCredentialForm = { target_id: "", profile_label: "default", username: "", password: "", risk_label: "cache access" };
+
+export function emptyForm() {
+  return {
+    connector_kind: "redis",
+    name: "redis-cache",
+    connection_mode: "direct",
+    host: "127.0.0.1",
+    port: 6379,
+    database: 0,
+    transport_target_ref: "",
+    profile_label: "default",
+    username: "",
+    password: "",
+    risk_label: "cache access",
+  };
+}
+
+export function formFromTarget({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : {});
+  return {
+    connector_kind: "redis",
+    profile_id: selectedProfile.id ? String(selectedProfile.id) : "",
+    name: target.name || "",
+    connection_mode: target.config?.connection_mode || "direct",
+    host: target.config?.host || "127.0.0.1",
+    port: target.config?.port || 6379,
+    database: target.config?.database || 0,
+    transport_target_ref: target.config?.transport_target_ref || "",
+    profile_label: selectedProfile.label || "default",
+    username: selectedProfile.public?.username || "",
+    password: "",
+    risk_label: selectedProfile.risk_label || "cache access",
+  };
+}
+
+export function activeCredential() {
+  return null;
+}
+
+export function syncForm({ form }) {
+  if (form.connector_kind !== "redis") return form;
+  const next = { ...form };
+  if (next.connection_mode === "direct") {
+    next.transport_target_ref = "";
+  }
+  return next;
+}
+
+export function submitDisabled({ state }) {
+  return state.state === "saving";
+}
+
+export function submitLabel({ state, mode }) {
+  if (state.state === "saving") return "Saving...";
+  return mode === "edit" ? "Save changes" : "Create connector";
+}
+
+export async function save({ mode, form, target }) {
+  if (mode === "edit") {
+    await updateTarget({ form, target });
+    return;
+  }
+  await createTarget({ form });
+}
+
+export async function deleteTarget({ target }) {
+  await apiDelete(`/api/connector-targets/${target.id}`);
+}
+
+export function emptyCredentialState({ targets = [] } = {}) {
+  const firstTarget = targets.find((target) => target.connector_kind === "redis");
+  return {
+    form: {
+      ...emptyRedisCredentialForm,
+      target_id: String(firstTarget?.id || ""),
+    },
+  };
+}
+
+export function credentialStateFromRow({ row }) {
+  return {
+    form: {
+      target_id: String(row.target_id || ""),
+      profile_label: row.name,
+      username: row.profile?.public?.username || "",
+      password: "",
+      risk_label: row.profile?.risk_label || "",
+    },
+  };
+}
+
+export function credentialFormProps({ targets, formState, setFormState, formMode, state, onSubmit }) {
+  return {
+    form: formState.form,
+    formMode,
+    targets,
+    state,
+    onChange: (form) => setFormState({ form }),
+    onSubmit: (event) => onSubmit(event, formMode === "edit" ? "update" : "create"),
+  };
+}
+
+export async function saveCredential({ operation, row, formState }) {
+  const form = formState.form;
+  if (operation === "create") {
+    await apiPost(`/api/connector-targets/${form.target_id}/profiles`, {
+      kind: "username_password",
+      label: form.profile_label,
+      public: { username: form.username },
+      secret: form.password ? { password: form.password } : {},
+      risk_label: form.risk_label,
+    });
+    return { message: "Redis credential created." };
+  }
+  if (operation === "update") {
+    if (!row) throw new Error("Redis credential is not loaded.");
+    const payload = {
+      kind: row.profile?.kind || "username_password",
+      label: form.profile_label,
+      public: { username: form.username },
+      risk_label: form.risk_label,
+    };
+    if (form.password) {
+      payload.secret = { password: form.password };
+    }
+    await apiPut(`/api/connector-targets/${form.target_id}/profiles/${row.id}`, payload);
+    return { message: "Redis credential updated." };
+  }
+  throw new Error("Unsupported Redis credential operation.");
+}
+
+export async function deleteCredential({ row }) {
+  await apiDelete(`/api/connector-targets/${row.target_id}/profiles/${row.id}`);
+}
+
+export function credentialRows({ targets }) {
+  return targets.flatMap((target) =>
+    (target.profiles || [])
+      .filter((profile) => target.connector_kind === "redis")
+      .map((profile) => ({
+        row_id: `${target.connector_kind}:${target.id}:${profile.id}`,
+        connector_kind: target.connector_kind,
+        resource_kind: "credential_profile",
+        connector_label: "Redis",
+        id: profile.id,
+        target_id: target.id,
+        name: profile.label,
+        kind: profile.kind,
+        profile,
+        target_label: target.name,
+        target_detail: targetEndpoint({ target }),
+        metadata: credentialMetadata(profile),
+        delete_disabled: "",
+      }))
+  );
+}
+
+export async function test({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!selectedProfile) throw new Error("Connector profile is not loaded.");
+  const data = await apiPost(`/api/connector-targets/${target.id}/profiles/${selectedProfile.id}/test`, {});
+  return { ok: data.ok, error: data.message || null, data };
+}
+
+export function canEdit() {
+  return true;
+}
+
+export function canDelete() {
+  return true;
+}
+
+export function credentialHint() {
+  return null;
+}
+
+export function targetEndpoint({ target }) {
+  const host = target.config?.host || "127.0.0.1";
+  const port = target.config?.port || 6379;
+  const database = target.config?.database || 0;
+  const mode = target.config?.connection_mode === "over_ssh" ? "over ssh" : "direct";
+  return `${host}:${port}/${database} · ${mode}`;
+}
+
+export function targetDisplayName({ target }) {
+  if (!target) return "Redis target";
+  return target.target_name || target.name || "Redis target";
+}
+
+export function targetSubtitle({ target }) {
+  return targetEndpoint({ target });
+}
+
+export function targetProfileLabel({ target }) {
+  return target?.profile_label || "default";
+}
+
+export function usesLiveConsole() {
+  return false;
+}
+
+export function deleteDialog({ target }) {
+  return {
+    title: target ? `Delete ${target.name}` : "Delete connector",
+    description: "Remove this Redis connector target, credential profiles, and token action permissions from aipermission.",
+    details: [
+      { label: "Connector", value: target?.name },
+      { label: "Reference", value: target ? `${target.connector_kind}:${target.id}` : "" },
+    ],
+    notice: "This removes the connector target and its credential profiles. It does not change the Redis server.",
+    actions: [
+      { label: "Cancel", action: "close", variant: "outline" },
+      { label: "Delete connector", pendingLabel: "Deleting...", removeKey: false },
+    ],
+  };
+}
+
+export function operationFromError() {
+  return null;
+}
+
+async function createTarget({ form }) {
+  await createTargetWithProfile({
+    targetPayload: {
+      connector_kind: "redis",
+      name: form.name,
+      config: redisTargetConfigFromForm(form),
+    },
+    profilePayload: {
+      kind: "username_password",
+      label: form.profile_label,
+      public: { username: form.username },
+      secret: form.password ? { password: form.password } : {},
+      risk_label: form.risk_label || "cache access",
+    },
+  });
+}
+
+async function updateTarget({ form, target }) {
+  const profile = target?.profiles?.find((item) => Number(item.id) === Number(form.profile_id)) || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!target || !profile) throw new Error("Redis connector profile is not loaded.");
+  const profilePayload = {
+    kind: profile.kind || "username_password",
+    label: form.profile_label,
+    public: { username: form.username },
+    risk_label: form.risk_label || "cache access",
+  };
+  if (form.password) {
+    profilePayload.secret = { password: form.password };
+  }
+  await updateTargetWithProfile({
+    targetID: target.id,
+    previousTarget: target,
+    profileID: profile.id,
+    targetPayload: {
+      name: form.name,
+      config: redisTargetConfigFromForm(form),
+    },
+    profilePayload,
+  });
+}
+
+function redisTargetConfigFromForm(form) {
+  return {
+    connection_mode: form.connection_mode || "direct",
+    host: form.host || "127.0.0.1",
+    port: Number(form.port) || 6379,
+    database: Number(form.database) || 0,
+    transport_target_ref: form.connection_mode === "over_ssh" ? form.transport_target_ref || "" : "",
+  };
+}
+
+function credentialMetadata(profile) {
+  const items = [];
+  if (profile.public?.username) items.push(`username: ${profile.public.username}`);
+  if (profile.risk_label) items.push(`risk: ${profile.risk_label}`);
+  if (items.length === 0) items.push("No public metadata");
+  return items;
+}

--- a/frontend/src/connectors/templates/redis/operations.jsx
+++ b/frontend/src/connectors/templates/redis/operations.jsx
@@ -1,0 +1,3 @@
+export function RedisConnectorOperationsTemplate() {
+  return null;
+}

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -227,7 +227,7 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.3"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.4"/);
   assert.match(releaseSource, /Console profile polish/);
   assert.match(releaseSource, /Postgres management/);
   assert.match(releaseSource, /Maintenance hardening/);

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,26 @@
-export const appVersion = "0.2.3";
+export const appVersion = "0.2.4";
 
 export const changelogEntries = [
+  {
+    version: "0.2.4",
+    label: "Redis connector",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Redis is now a built-in connector with Direct and Over SSH connection modes.",
+          "Redis actions cover ping, info, bounded key scanning, key inspection, string writes, TTL updates, and explicit deletes.",
+          "Redis Console adds a key browser with search, value inspection, string editing, TTL updates, and multi-key delete.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Protocol connectors can use a generic network transport capability without importing SSH-specific code.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.3",
     label: "Console profile polish",

--- a/frontend/src/pages/connectors.jsx
+++ b/frontend/src/pages/connectors.jsx
@@ -323,6 +323,7 @@ export function ConnectorsPage() {
               form={form}
               mode={drawer.mode}
               credentials={credentials.data}
+              targets={targets.data}
               activeCredential={activeCredential}
               onChange={updateForm}
             />

--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,7 +2564,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -8,9 +8,9 @@ credentials, or other connector secrets.
 
 The gateway is intentionally local-only. Run it on the developer machine and
 keep the URL on `localhost`; remote systems are connector targets, not places
-to host the gateway for LAN or internet users. SSH and Postgres are built-in
-connectors that use the same target/profile/action permission model as future
-connectors.
+to host the gateway for LAN or internet users. SSH, Postgres, and Redis are
+built-in connectors that use the same target/profile/action permission model
+as future connectors.
 
 ![AIPermission demo: AI installs Uptime Kuma through approval-based SSH access](https://raw.githubusercontent.com/aipermission/aipermission/main/docs/assets/demo/aipermission-demo.gif)
 
@@ -61,7 +61,7 @@ The generated MCP config contains a bearer token. Keep it private. For project-l
 - `call_connector_action`
 - `get_connector_action_request`
 
-All integration work goes through connector targets. SSH, Postgres, and future
+All integration work goes through connector targets. SSH, Postgres, Redis, and future
 connectors share the same model: target, credential profile, connector action,
 token action permission, approval, history, and audit.
 
@@ -69,6 +69,10 @@ For SSH, call `get_connector_actions(target_ref)` to discover actions such as
 `exec`, `read_console`, `restart_console_session`, `browse_remote_files`, and
 `start_file_download`. SSH `exec` is intended for non-interactive commands. Use
 the web console for truly interactive work.
+
+For Redis, call `get_connector_actions(target_ref)` to discover bounded key
+browser actions such as `scan_keys`, `get_key`, `set_string`, `expire_key`, and
+`delete_keys`.
 
 Connector responses can include `approval_pending` or `running`. Poll
 `get_connector_action_request(request_id)` until the request reaches a terminal

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Highlights

- Adds Redis as a built-in connector with Direct and Over SSH connection modes.
- Adds Redis MCP/UI actions for ping, info, bounded key scan, key read, string writes, TTL updates, and explicit deletes.
- Adds a generic connector TCP transport capability so protocol connectors can use reviewed Over SSH paths without importing SSH-specific code.

## Validation

- node scripts/secret-scan.js
- make test
- make build
- make audit
- cd backend && go test -race ./...
- cd backend && go vet ./...
- cd backend && govulncheck ./...
- docker compose config --quiet
- docker compose up -d --build --force-recreate
- curl -fsS http://127.0.0.1:3210/api/status
- cd packages/mcp && npm pack --dry-run --json
- cd packages/npm-placeholder && npm pack --dry-run

## Notes

Postgres Over SSH is intentionally left for a follow-up release so query, managed-role provisioning, backup, and restore paths can share the transport cleanly.