### PR TITLE
docs: refresh connector positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
   <p><strong>Local permission gateway for AI agents.</strong></p>
   <p>
     Give AI assistants temporary, scoped action access to your local connector
-    targets without sharing SSH keys or database credentials.
+    targets without sharing SSH keys, database passwords, Redis credentials, or
+    future connector secrets.
   </p>
   <p>
     <a href="#quick-start">Quick Start</a>
@@ -96,7 +97,7 @@ With `aipermission`, the AI can inspect approved connector targets directly thro
 
 The UI is built around the live control loop: approve connector actions, inspect structured activity, watch the persistent SSH console when relevant, send notes while the AI works, and audit what happened afterwards.
 
-![AIPermission demo: AI installs Uptime Kuma through approval-based SSH access](docs/assets/demo/aipermission-demo.gif)
+![AIPermission demo: AI operates through approval-based connector access](docs/assets/demo/aipermission-demo.gif)
 
 [Watch the accelerated demo video](https://github.com/aipermission/aipermission/releases/download/v0.1.0-rc.1/aipermission-demo.mp4)
 

--- a/docs/skills/aipermission-docs/SKILL.md
+++ b/docs/skills/aipermission-docs/SKILL.md
@@ -133,7 +133,7 @@ Use the established aipermission naming:
 - `gateway` is the local backend that owns credentials, policy, execution, approvals, and audit.
 - `MCP client` means Cursor, Windsurf, or another AI tool integration.
 - `API token` means the gateway access token used by MCP/API clients.
-- `connector target` means a saved SSH, Postgres, or future integration target.
+- `connector target` means a saved SSH, Postgres, Redis, or future integration target.
 - `server` is acceptable only when specifically describing an SSH connector target.
 - `database` means a configured Postgres connector target/profile.
 - `execution rule` means `always_run`, `approval_required`, or `blocked`.

--- a/docs/whatis-aipermission.md
+++ b/docs/whatis-aipermission.md
@@ -13,9 +13,10 @@ Related central notes:
 operate on connector targets without receiving SSH private keys, SSH passwords,
 database credentials, API credentials, or other connector secrets.
 
-The current model ships with SSH and Postgres connectors. SSH provides live
-terminal/file-transfer actions; Postgres provides structured metadata and
-bounded read-only query actions. Both use the same target, credential profile,
+The current model ships with SSH, Postgres, and Redis connectors. SSH provides
+live terminal/file-transfer actions, Postgres provides structured metadata and
+bounded read-only query actions, and Redis provides bounded key browsing plus
+explicit write/delete actions. They use the same target, credential profile,
 token permission, approval, history, and audit pipeline.
 
 The product is intentionally not positioned as a full DevOps platform.
@@ -88,9 +89,9 @@ for a database.
 This model also works well with AI client instructions or skills. For example,
 a developer can define a workflow like "check a new VPS before adding it to the
 cluster", "inspect container health across allowed SSH targets", "describe a
-readonly Postgres schema", or later "call this internal API operation through a
-stored credential profile." aipermission provides the execution layer without
-exposing credentials.
+readonly Postgres schema", "inspect Redis cache keys", or later "call this
+internal API operation through a stored credential profile." aipermission
+provides the execution layer without exposing credentials.
 
 ## Typical Flow
 
@@ -228,11 +229,13 @@ allowed connector targets:
 - ssh:core-1/admin -> exec approval_required
 - ssh:core-1/admin -> read_console always_run
 - postgres:main-db/readonly -> query_readonly approval_required
+- redis:cache/ops -> get_key approval_required
 ```
 
 The AI assistant can see and use only the connector targets and actions allowed
-by that token. For example, if the token can access five SSH targets and one
-Postgres target, `list_connector_targets` returns only those target/profile refs.
+by that token. For example, if the token can access five SSH targets, one
+Postgres target, and one Redis target, `list_connector_targets` returns only
+those target/profile refs.
 
 If the same token exists in more than one unlocked database, MCP authentication returns a conflict. The gateway does not guess which workspace should receive the command.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -12,7 +12,7 @@ to host the gateway for LAN or internet users. SSH, Postgres, and Redis are
 built-in connectors that use the same target/profile/action permission model
 as future connectors.
 
-![AIPermission demo: AI installs Uptime Kuma through approval-based SSH access](https://raw.githubusercontent.com/aipermission/aipermission/main/docs/assets/demo/aipermission-demo.gif)
+![AIPermission demo: AI operates through approval-based connector access](https://raw.githubusercontent.com/aipermission/aipermission/main/docs/assets/demo/aipermission-demo.gif)
 
 [Watch the demo video](https://github.com/aipermission/aipermission/releases/download/v0.1.0-rc.1/aipermission-demo.mp4) to see an AI assistant install Uptime Kuma on a VPS while the user approves commands and changes the plan mid-run.
 


### PR DESCRIPTION
## Summary

- update visible README/MCP copy away from SSH-only wording
- mention Redis alongside SSH and Postgres in central docs
- keep connector-first wording aligned with the current 0.2 model

## Verification

- git diff --check

No release tag needed for this documentation-only positioning update.