### PR TITLE
Add Postgres Over SSH transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-06-18
+
+### Added
+
+- Added Over SSH connection mode for Postgres connector targets, using the same
+  generic connector network transport introduced for Redis.
+- Added Postgres target form controls for selecting an SSH transport profile
+  when the database is reachable only from a remote server.
+
+### Changed
+
+- Postgres actions, connection tests, managed role provisioning, backup, and
+  restore now use the connector transport abstraction instead of a direct-only
+  code path.
+
 ## [0.2.4] - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ Implemented:
   console/activity surfaces, and connector-owned operations
 - built-in SSH connector with persistent shell, file transfer, remote browsing,
   host-key approval, and command actions
-- built-in Postgres connector with schema/table inspection, bounded read-only
-  SQL actions, managed scoped database-user provisioning, and SQL backup/restore
+- built-in Postgres connector with Direct and Over SSH connection modes,
+  schema/table inspection, bounded read-only SQL actions, managed scoped
+  database-user provisioning, and SQL backup/restore
 - built-in Redis connector with Direct and Over SSH connection modes, bounded
   key scanning, key inspection, string writes, TTL updates, and explicit deletes
 - gateway-generated SSH keys (`ed25519` and `rsa`)

--- a/backend/internal/connectors/postgres/postgres.go
+++ b/backend/internal/connectors/postgres/postgres.go
@@ -49,7 +49,7 @@ const truncatedSuffix = "...[truncated]"
 
 var (
 	ErrUnsupportedAction = errors.New("unsupported postgres connector action")
-	ErrUnsupportedMode   = errors.New("postgres connector connection mode is not supported yet")
+	ErrMissingTransport  = errors.New("postgres connector network transport is unavailable")
 	ErrMissingSecret     = errors.New("postgres connector credential is missing required secret")
 	ErrInvalidConfig     = errors.New("postgres connector target config is invalid")
 
@@ -87,14 +87,21 @@ func (Connector) TargetSchema() connectors.Schema {
 			Description: "Direct connection from the local gateway to a reachable Postgres host.",
 			Options: []connectors.FieldOption{
 				{Value: "direct", Label: "Direct"},
+				{Value: "over_ssh", Label: "Over SSH"},
 			},
+		},
+		{
+			Name:        "transport_target_ref",
+			Label:       "SSH transport profile",
+			Type:        connectors.FieldString,
+			Description: "Connector target profile ref used when connection_mode is over_ssh.",
 		},
 		{
 			Name:        "host",
 			Label:       "Host",
 			Type:        connectors.FieldString,
 			Required:    true,
-			Description: "Postgres host or service address as seen by the gateway.",
+			Description: "Postgres host or service address as seen by the selected connection mode.",
 		},
 		{
 			Name:        "port",
@@ -116,7 +123,7 @@ func (Connector) TargetSchema() connectors.Schema {
 			Label:       "SSL mode",
 			Type:        connectors.FieldSelect,
 			Default:     "require",
-			Description: "Postgres SSL mode for direct connections. Use prefer or disable only when you intentionally accept weaker transport protection.",
+			Description: "Postgres SSL mode. Use prefer or disable only when you intentionally accept weaker transport protection or connect through a trusted SSH tunnel.",
 			Options: []connectors.FieldOption{
 				{Value: "require", Label: "Require"},
 				{Value: "verify_full", Label: "Verify full"},
@@ -304,10 +311,12 @@ func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) 
 		ProfileID:     req.Profile.ID,
 		ActionName:    req.ActionName,
 		ContextMaterial: map[string]any{
-			"connector_kind": Kind,
-			"target_ref":     req.Target.Ref,
-			"profile_id":     req.Profile.ID,
-			"action_name":    req.ActionName,
+			"connector_kind":       Kind,
+			"target_ref":           req.Target.Ref,
+			"profile_id":           req.Profile.ID,
+			"action_name":          req.ActionName,
+			"connection_mode":      connectionMode(req.Target),
+			"transport_target_ref": targetString(req.Target.Config, "transport_target_ref"),
 		},
 	}
 
@@ -382,9 +391,6 @@ func (Connector) ExecuteAction(ctx context.Context, runtime connectors.RuntimeCo
 	if runtime.Target.ConnectorKind != Kind {
 		return connectors.ActionResult{}, fmt.Errorf("target connector kind must be %s", Kind)
 	}
-	if connectionMode(runtime.Target) != "direct" {
-		return connectors.ActionResult{}, ErrUnsupportedMode
-	}
 
 	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
 	defer cancel()
@@ -452,9 +458,6 @@ func (Connector) ExecuteAction(ctx context.Context, runtime connectors.RuntimeCo
 }
 
 func (Connector) TestConnection(ctx context.Context, runtime connectors.RuntimeContext) (connectors.TestResult, error) {
-	if connectionMode(runtime.Target) != "direct" {
-		return connectors.TestResult{Status: connectors.TestUnknownError, Message: "unsupported postgres connection mode"}, ErrUnsupportedMode
-	}
 	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
 	defer cancel()
 	conn, err := connect(ctx, runtime)
@@ -519,9 +522,6 @@ type provisionTableScope struct {
 func (Connector) ProvisionCredentialProfile(ctx context.Context, runtime connectors.RuntimeContext, input map[string]any) (connectors.ProvisionedCredentialProfile, error) {
 	if runtime.Target.ConnectorKind != Kind {
 		return connectors.ProvisionedCredentialProfile{}, fmt.Errorf("target connector kind must be %s", Kind)
-	}
-	if connectionMode(runtime.Target) != "direct" {
-		return connectors.ProvisionedCredentialProfile{}, ErrUnsupportedMode
 	}
 	roleName := cleanSimpleIdentifierInput(input, "role_name")
 	if roleName == "" {
@@ -657,15 +657,14 @@ func (Connector) CleanupProvisionedCredentialProfile(ctx context.Context, runtim
 }
 
 func (Connector) Backup(ctx context.Context, runtime connectors.RuntimeContext, _ connectors.BackupRequest) (connectors.BackupArtifact, error) {
-	if connectionMode(runtime.Target) != "direct" {
-		return connectors.BackupArtifact{}, ErrUnsupportedMode
-	}
 	ctx, cancel := context.WithTimeout(ctx, backupTimeout)
 	defer cancel()
-	env, args, err := postgresCLIConnection(ctx, runtime)
+	invocation, err := postgresCLIConnection(ctx, runtime)
 	if err != nil {
 		return connectors.BackupArtifact{}, err
 	}
+	defer invocation.Cleanup()
+	args := invocation.Args
 	args = append(args,
 		"--format=plain",
 		"--clean",
@@ -678,7 +677,7 @@ func (Connector) Backup(ctx context.Context, runtime connectors.RuntimeContext, 
 	var stderr limitedBuffer
 	stderr.Limit = maxRestoreLog
 	cmd := exec.CommandContext(ctx, "pg_dump", args...)
-	cmd.Env = env
+	cmd.Env = invocation.Env
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -700,9 +699,6 @@ func (Connector) Backup(ctx context.Context, runtime connectors.RuntimeContext, 
 }
 
 func (Connector) Restore(ctx context.Context, runtime connectors.RuntimeContext, request connectors.RestoreRequest) (connectors.ActionResult, error) {
-	if connectionMode(runtime.Target) != "direct" {
-		return connectors.ActionResult{}, ErrUnsupportedMode
-	}
 	if len(request.Data) == 0 {
 		return connectors.ActionResult{}, fmt.Errorf("restore SQL file is empty")
 	}
@@ -711,10 +707,12 @@ func (Connector) Restore(ctx context.Context, runtime connectors.RuntimeContext,
 	}
 	ctx, cancel := context.WithTimeout(ctx, restoreTimeout)
 	defer cancel()
-	env, args, err := postgresCLIConnection(ctx, runtime)
+	invocation, err := postgresCLIConnection(ctx, runtime)
 	if err != nil {
 		return connectors.ActionResult{}, err
 	}
+	defer invocation.Cleanup()
+	args := invocation.Args
 	args = append(args,
 		"--single-transaction",
 		"--set", "ON_ERROR_STOP=on",
@@ -724,7 +722,7 @@ func (Connector) Restore(ctx context.Context, runtime connectors.RuntimeContext,
 	var stderr limitedBuffer
 	stderr.Limit = maxRestoreLog
 	cmd := exec.CommandContext(ctx, "psql", args...)
-	cmd.Env = env
+	cmd.Env = invocation.Env
 	cmd.Stdin = bytes.NewReader(request.Data)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -752,25 +750,42 @@ func connect(ctx context.Context, runtime connectors.RuntimeContext) (*pgx.Conn,
 	return connectPostgres(ctx, runtime, true)
 }
 
-func postgresCLIConnection(ctx context.Context, runtime connectors.RuntimeContext) ([]string, []string, error) {
+type postgresCLIInvocation struct {
+	Env     []string
+	Args    []string
+	Cleanup func()
+}
+
+func postgresCLIConnection(ctx context.Context, runtime connectors.RuntimeContext) (postgresCLIInvocation, error) {
 	username := strings.TrimSpace(publicString(runtime.Profile.Public, "username"))
 	if username == "" {
-		return nil, nil, fmt.Errorf("%w: username", ErrMissingSecret)
+		return postgresCLIInvocation{}, fmt.Errorf("%w: username", ErrMissingSecret)
 	}
 	if runtime.Secrets == nil {
-		return nil, nil, fmt.Errorf("%w: password", ErrMissingSecret)
+		return postgresCLIInvocation{}, fmt.Errorf("%w: password", ErrMissingSecret)
 	}
 	password, err := runtime.Secrets.GetSecret(ctx, "password")
 	if err != nil || strings.TrimSpace(password) == "" {
-		return nil, nil, fmt.Errorf("%w: password", ErrMissingSecret)
+		return postgresCLIInvocation{}, fmt.Errorf("%w: password", ErrMissingSecret)
 	}
 	host := targetString(runtime.Target.Config, "host")
 	database := targetString(runtime.Target.Config, "database")
 	if host == "" {
-		return nil, nil, fmt.Errorf("%w: host is required", ErrInvalidConfig)
+		return postgresCLIInvocation{}, fmt.Errorf("%w: host is required", ErrInvalidConfig)
 	}
 	if database == "" {
-		return nil, nil, fmt.Errorf("%w: database is required", ErrInvalidConfig)
+		return postgresCLIInvocation{}, fmt.Errorf("%w: database is required", ErrInvalidConfig)
+	}
+	port := targetPort(runtime.Target.Config)
+	cleanup := func() {}
+	if connectionMode(runtime.Target) == "over_ssh" {
+		localHost, localPort, stop, err := startPostgresTunnel(ctx, runtime)
+		if err != nil {
+			return postgresCLIInvocation{}, err
+		}
+		host = localHost
+		port = localPort
+		cleanup = stop
 	}
 	env := append(os.Environ(),
 		"PGPASSWORD="+password,
@@ -780,12 +795,12 @@ func postgresCLIConnection(ctx context.Context, runtime connectors.RuntimeContex
 	)
 	args := []string{
 		"--host", host,
-		"--port", strconv.Itoa(targetPort(runtime.Target.Config)),
+		"--port", strconv.Itoa(port),
 		"--username", username,
 		"--dbname", database,
 		"--no-password",
 	}
-	return env, args, nil
+	return postgresCLIInvocation{Env: env, Args: args, Cleanup: cleanup}, nil
 }
 
 func connectPostgres(ctx context.Context, runtime connectors.RuntimeContext, readOnly bool) (*pgx.Conn, error) {
@@ -825,6 +840,14 @@ func connectPostgres(ctx context.Context, runtime connectors.RuntimeContext, rea
 	if err != nil {
 		return nil, fmt.Errorf("parse postgres connection config: %w", err)
 	}
+	transport, err := postgresNetworkTransport(runtime)
+	if err != nil {
+		return nil, err
+	}
+	dialRequest := postgresNetworkDialRequest(runtime.Target)
+	config.Config.DialFunc = func(ctx context.Context, network string, address string) (net.Conn, error) {
+		return transport.DialConnectorTCP(ctx, dialRequest)
+	}
 	if config.RuntimeParams == nil {
 		config.RuntimeParams = map[string]string{}
 	}
@@ -839,6 +862,82 @@ func connectPostgres(ctx context.Context, runtime connectors.RuntimeContext, rea
 		return nil, fmt.Errorf("connect postgres: %w", err)
 	}
 	return conn, nil
+}
+
+func postgresNetworkTransport(runtime connectors.RuntimeContext) (connectors.NetworkTransport, error) {
+	transport, _ := runtime.Capability(connectors.NetworkTransportCapabilityName).(connectors.NetworkTransport)
+	if transport == nil {
+		return nil, ErrMissingTransport
+	}
+	return transport, nil
+}
+
+func postgresNetworkDialRequest(target connectors.TargetView) connectors.NetworkDialRequest {
+	return connectors.NetworkDialRequest{
+		Mode:               connectionMode(target),
+		Host:               targetString(target.Config, "host"),
+		Port:               targetPort(target.Config),
+		TransportTargetRef: strings.TrimSpace(targetString(target.Config, "transport_target_ref")),
+	}
+}
+
+func startPostgresTunnel(ctx context.Context, runtime connectors.RuntimeContext) (string, int, func(), error) {
+	transport, err := postgresNetworkTransport(runtime)
+	if err != nil {
+		return "", 0, nil, err
+	}
+	request := postgresNetworkDialRequest(runtime.Target)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", 0, nil, fmt.Errorf("start postgres local tunnel: %w", err)
+	}
+	tunnelCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			localConn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go pipePostgresTunnelConn(tunnelCtx, transport, request, localConn)
+		}
+	}()
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		cancel()
+		_ = listener.Close()
+		<-done
+		return "", 0, nil, fmt.Errorf("postgres local tunnel address is not TCP")
+	}
+	cleanup := func() {
+		cancel()
+		_ = listener.Close()
+		<-done
+	}
+	return "127.0.0.1", addr.Port, cleanup, nil
+}
+
+func pipePostgresTunnelConn(ctx context.Context, transport connectors.NetworkTransport, request connectors.NetworkDialRequest, localConn net.Conn) {
+	remoteConn, err := transport.DialConnectorTCP(ctx, request)
+	if err != nil {
+		_ = localConn.Close()
+		return
+	}
+	copyDone := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(remoteConn, localConn)
+		_ = remoteConn.Close()
+		_ = localConn.Close()
+		copyDone <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(localConn, remoteConn)
+		_ = localConn.Close()
+		_ = remoteConn.Close()
+		copyDone <- struct{}{}
+	}()
+	<-copyDone
 }
 
 func provisionScopeInput(input map[string]any) (provisionScope, error) {

--- a/backend/internal/connectors/postgres/postgres_test.go
+++ b/backend/internal/connectors/postgres/postgres_test.go
@@ -21,8 +21,11 @@ func TestConnectorMetadataAndSchemas(t *testing.T) {
 	if !hasField(targetSchema, "connection_mode") || !hasField(targetSchema, "host") || !hasField(targetSchema, "database") {
 		t.Fatalf("expected connection_mode, host, and database target fields, got %#v", targetSchema.Fields)
 	}
-	if fieldOptionsContain(targetSchema, "connection_mode", "over_ssh") {
-		t.Fatalf("target schema must not advertise unsupported over_ssh mode: %#v", targetSchema.Fields)
+	if !hasField(targetSchema, "transport_target_ref") {
+		t.Fatalf("expected transport_target_ref field for tunneled connections, got %#v", targetSchema.Fields)
+	}
+	if !fieldOptionsContain(targetSchema, "connection_mode", "over_ssh") {
+		t.Fatalf("target schema should advertise supported over_ssh mode: %#v", targetSchema.Fields)
 	}
 	if defaultFieldValue(targetSchema, "ssl_mode") != "require" {
 		t.Fatalf("postgres ssl_mode should default to require, got %#v", defaultFieldValue(targetSchema, "ssl_mode"))
@@ -123,7 +126,7 @@ func TestPrepareDescribeTableRequiresTable(t *testing.T) {
 func TestPrepareReadonlyQuery(t *testing.T) {
 	connector := New()
 	request := connectors.ActionRequest{
-		Target:     connectors.TargetView{Ref: "postgres:7:11", Name: "main-db", ConnectorKind: Kind},
+		Target:     connectors.TargetView{Ref: "postgres:7:11", Name: "main-db", ConnectorKind: Kind, Config: map[string]any{"connection_mode": "over_ssh", "transport_target_ref": "ssh:3:5"}},
 		Profile:    connectors.CredentialProfileView{ID: 11, ConnectorKind: Kind},
 		ActionName: ActionQueryReadonly,
 		Input: map[string]any{
@@ -142,6 +145,9 @@ func TestPrepareReadonlyQuery(t *testing.T) {
 	}
 	if prepared.ContextMaterial["reason"] != "inspect active users" {
 		t.Fatalf("reason missing from context material: %#v", prepared.ContextMaterial)
+	}
+	if prepared.ContextMaterial["connection_mode"] != "over_ssh" || prepared.ContextMaterial["transport_target_ref"] != "ssh:3:5" {
+		t.Fatalf("transport context missing from context material: %#v", prepared.ContextMaterial)
 	}
 }
 
@@ -288,15 +294,23 @@ func TestPrepareUnsupportedAction(t *testing.T) {
 	}
 }
 
-func TestExecuteActionRejectsUnsupportedConnectionMode(t *testing.T) {
+func TestExecuteActionRequiresNetworkTransport(t *testing.T) {
 	_, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
 		Target: connectors.TargetView{
 			ConnectorKind: Kind,
-			Config:        map[string]any{"connection_mode": "over_ssh"},
+			Config: map[string]any{
+				"connection_mode":      "over_ssh",
+				"transport_target_ref": "ssh:3:5",
+				"host":                 "127.0.0.1",
+				"port":                 5432,
+				"database":             "app",
+			},
 		},
+		Profile: connectors.CredentialProfileView{Public: map[string]any{"username": "app"}},
+		Secrets: fakeSecrets{"password": "secret"},
 	}, connectors.PreparedAction{ActionName: ActionQueryReadonly})
-	if !errors.Is(err, ErrUnsupportedMode) {
-		t.Fatalf("expected ErrUnsupportedMode, got %v", err)
+	if !errors.Is(err, ErrMissingTransport) {
+		t.Fatalf("expected ErrMissingTransport, got %v", err)
 	}
 }
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -130,14 +130,18 @@ Generic target create shape:
     "host": "127.0.0.1",
     "port": 5432,
     "database": "app",
-    "ssl_mode": "require"
+    "ssl_mode": "require",
+    "transport_target_ref": ""
   }
 }
 ```
 
-Postgres defaults to `ssl_mode=require`. `prefer` and `disable` are available
-for local lab databases, but they weaken transport security and should be a
-deliberate operator choice.
+Postgres supports `connection_mode=direct` and `connection_mode=over_ssh`.
+When `over_ssh` is used, `host` and `port` are resolved from the selected SSH
+server and `transport_target_ref` must point at an SSH connector profile such as
+`ssh:3:5`. Postgres defaults to `ssl_mode=require`. `prefer` and `disable` are
+available for local lab databases or trusted SSH-tunneled databases, but they
+weaken transport security and should be a deliberate operator choice.
 
 `POST /api/connector-targets/with-profile` creates a connector target and its
 initial credential profile in one database transaction:

--- a/frontend/src/connectors/templates/postgres/form.jsx
+++ b/frontend/src/connectors/templates/postgres/form.jsx
@@ -1,8 +1,10 @@
 import { Field, Input, Select } from "../../../components/ui/form";
 import { Notice } from "../../../components/ui/notice";
 
-export function PostgresConnectorFormTemplate({ form, mode = "create", onChange }) {
+export function PostgresConnectorFormTemplate({ form, mode = "create", targets = [], onChange }) {
   const editing = mode === "edit";
+  const sshProfiles = sshProfileOptions(targets);
+  const overSSH = form.connection_mode === "over_ssh";
   return (
     <>
       <Notice tone="good">
@@ -12,6 +14,33 @@ export function PostgresConnectorFormTemplate({ form, mode = "create", onChange 
         Connector name
         <Input value={form.name} onChange={(event) => onChange("name", event.target.value)} required />
       </Field>
+      <Field>
+        Connection mode
+        <Select value={form.connection_mode} onChange={(event) => onChange("connection_mode", event.target.value)}>
+          <option value="direct">Direct from this gateway</option>
+          <option value="over_ssh">Over an SSH connector profile</option>
+        </Select>
+      </Field>
+      {overSSH ? (
+        <Field>
+          SSH transport profile
+          <Select value={form.transport_target_ref} onChange={(event) => onChange("transport_target_ref", event.target.value)} required>
+            <option value="" disabled>
+              Select SSH profile
+            </option>
+            {sshProfiles.map((profile) => (
+              <option value={profile.ref} key={profile.ref}>
+                {profile.label}
+              </option>
+            ))}
+          </Select>
+        </Field>
+      ) : null}
+      {overSSH ? (
+        <Notice>
+          Host and port are resolved from the SSH server. Use 127.0.0.1:5432 when Postgres only listens on the remote machine.
+        </Notice>
+      ) : null}
       <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_120px]">
         <Field>
           Host
@@ -64,4 +93,15 @@ export function PostgresConnectorFormTemplate({ form, mode = "create", onChange 
       </Field>
     </>
   );
+}
+
+function sshProfileOptions(targets) {
+  return (targets || [])
+    .filter((target) => target.connector_kind === "ssh")
+    .flatMap((target) =>
+      (target.profiles || []).map((profile) => ({
+        ref: profile.ref || `${target.connector_kind}:${target.id}:${profile.id}`,
+        label: `${target.name} / ${profile.label} · ${target.config?.host || "host"}:${target.config?.port || 22}`,
+      }))
+    );
 }

--- a/frontend/src/connectors/templates/postgres/model.js
+++ b/frontend/src/connectors/templates/postgres/model.js
@@ -7,10 +7,12 @@ export function emptyForm() {
   return {
     connector_kind: "postgres",
     name: "main-db",
+    connection_mode: "direct",
     host: "127.0.0.1",
     port: 5432,
     database: "postgres",
     ssl_mode: "require",
+    transport_target_ref: "",
     profile_label: "readonly",
     username: "",
     password: "",
@@ -24,10 +26,12 @@ export function formFromTarget({ target, profile }) {
     connector_kind: "postgres",
     profile_id: selectedProfile.id ? String(selectedProfile.id) : "",
     name: target.name || "",
+    connection_mode: target.config?.connection_mode || "direct",
     host: target.config?.host || "",
     port: target.config?.port || 5432,
     database: target.config?.database || "",
     ssl_mode: target.config?.ssl_mode || "require",
+    transport_target_ref: target.config?.transport_target_ref || "",
     profile_label: selectedProfile.label || "readonly",
     username: selectedProfile.public?.username || "",
     password: "",
@@ -40,7 +44,15 @@ export function activeCredential() {
 }
 
 export function syncForm({ form }) {
-  return form;
+  if (form.connector_kind !== "postgres") return form;
+  const next = { ...form };
+  if (next.connection_mode === "direct") {
+    next.transport_target_ref = "";
+  }
+  if (next.connection_mode === "over_ssh" && !next.host) {
+    next.host = "127.0.0.1";
+  }
+  return next;
 }
 
 export function submitDisabled({ state }) {
@@ -182,7 +194,8 @@ export function targetEndpoint({ target }) {
   const host = target.config?.host || "host";
   const port = target.config?.port || 5432;
   const database = target.config?.database || "database";
-  return `${host}:${port}/${database}`;
+  const mode = target.config?.connection_mode === "over_ssh" ? "over ssh" : "direct";
+  return `${host}:${port}/${database} · ${mode}`;
 }
 
 export function targetDisplayName({ target }) {
@@ -271,11 +284,12 @@ async function updateTarget({ form, target }) {
 
 function postgresTargetConfigFromForm(form) {
   return {
-    connection_mode: "direct",
-    host: form.host,
+    connection_mode: form.connection_mode || "direct",
+    host: form.host || "127.0.0.1",
     port: Number(form.port) || 5432,
-    database: form.database,
-    ssl_mode: form.ssl_mode,
+    database: form.database || "postgres",
+    ssl_mode: form.ssl_mode || "require",
+    transport_target_ref: form.connection_mode === "over_ssh" ? form.transport_target_ref || "" : "",
   };
 }
 

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -227,7 +227,9 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.4"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.5"/);
+  assert.match(releaseSource, /Postgres over SSH/);
+  assert.match(releaseSource, /Postgres connector targets can now connect directly from the gateway or over an SSH connector profile/);
   assert.match(releaseSource, /Console profile polish/);
   assert.match(releaseSource, /Postgres management/);
   assert.match(releaseSource, /Maintenance hardening/);

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,25 @@
-export const appVersion = "0.2.4";
+export const appVersion = "0.2.5";
 
 export const changelogEntries = [
+  {
+    version: "0.2.5",
+    label: "Postgres over SSH",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Postgres connector targets can now connect directly from the gateway or over an SSH connector profile.",
+          "The Postgres target form exposes an SSH transport profile selector for databases reachable only from a remote server.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Postgres actions, connection tests, managed role provisioning, backup, and restore now use the shared connector network transport path.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.4",
     label: "Redis connector",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,7 +2564,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -70,6 +70,11 @@ For SSH, call `get_connector_actions(target_ref)` to discover actions such as
 `start_file_download`. SSH `exec` is intended for non-interactive commands. Use
 the web console for truly interactive work.
 
+For Postgres, call `get_connector_actions(target_ref)` to discover schema,
+table, and bounded read-only query actions. Postgres targets can connect
+directly from the gateway or over an SSH connector profile when the database is
+reachable only from a remote server.
+
 For Redis, call `get_connector_actions(target_ref)` to discover bounded key
 browser actions such as `scan_keys`, `get_key`, `set_string`, `expire_key`, and
 `delete_keys`.

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- add Over SSH connection mode for Postgres connector targets
- route Postgres actions, connection tests, managed roles, backup, and restore through the shared connector network transport
- update Postgres target form, docs, changelog, and MCP package metadata for v0.2.5

## Validation

- go test ./...
- frontend npm test
- frontend npm run build
- packages/mcp npm test
- packages/mcp npm run build
- make audit
- npm audit --omit=dev --audit-level=moderate in packages/mcp
- npm pack --dry-run in packages/mcp and packages/npm-placeholder
- docker compose config --quiet
- docker compose up -d --build --force-recreate
- manual Postgres Over SSH smoke test by operator
