### PR TITLE
Release 0.2.6 RabbitMQ connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
       - name: Install
         working-directory: frontend
         run: npm ci --workspaces=false
-      - name: Install Playwright browsers
+      - name: Install Playwright browser
         working-directory: frontend
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
       - name: Test
         working-directory: frontend
         run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-06-18
+
+### Added
+
+- Added RabbitMQ as a built-in connector with Direct and Over SSH connection
+  modes through the shared connector permission, approval, history, and audit
+  pipeline.
+- Added RabbitMQ actions for overview metadata, visible vhosts, bounded queue
+  lists, queue details, bindings, bounded message peeking with
+  `ack_requeue_true`, and explicit message publishing.
+- Added a RabbitMQ Console queue browser with vhost filtering, queue counters,
+  binding inspection, and bounded message payload previews.
+- Added connector form host reachability checks that run four TCP dials directly
+  or through the selected SSH transport profile.
+
+### Changed
+
+- Direct connector targets can use `host.docker.internal` to reach services
+  running on the same Linux host as AIPermission Docker.
+
+### Security
+
+- RabbitMQ message preview actions are bounded by count and payload truncation
+  limits. `publish_message` is a separate write action; purge, ack, nack,
+  delete, or other destructive queue operations are intentionally not part of
+  the 0.2.6 MVP.
+
 ## [0.2.5] - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ AIPermission is intentionally designed as a local developer gateway.
 
 - The gateway runs on the developer's own machine.
 - Remote systems are connector targets reached from that local gateway.
-- SSH, Postgres, and Redis are built-in connector types, not separate product modes.
+- SSH, Postgres, Redis, and RabbitMQ are built-in connector types, not separate product modes.
 - The web UI, REST API, and MCP API are not designed to be shared on a LAN.
 - The project does not support running the gateway as a remote hosted service.
 - The project provides a local browser session after database unlock, not multi-user web auth, team RBAC, or public network hardening.
@@ -116,7 +116,7 @@ Implemented:
 - Docker Compose local runtime
 - Go backend with SQLite storage
 - React web UI
-- connector target/profile/action pipeline for SSH, Postgres, Redis, and future local
+- connector target/profile/action pipeline for SSH, Postgres, Redis, RabbitMQ, and future local
   integrations
 - generic connector network transport so protocol connectors can use Direct or
   reviewed Over SSH TCP paths without importing SSH-specific code
@@ -129,6 +129,9 @@ Implemented:
   database-user provisioning, and SQL backup/restore
 - built-in Redis connector with Direct and Over SSH connection modes, bounded
   key scanning, key inspection, string writes, TTL updates, and explicit deletes
+- built-in RabbitMQ connector with Direct and Over SSH connection modes, queue
+  browsing, vhost metadata, binding inspection, bounded message peeking, and
+  explicit message publishing
 - gateway-generated SSH keys (`ed25519` and `rsa`)
 - explicit existing SSH private key import into the encrypted local vault
 - SSH host import from OpenSSH config files for prefilling connector targets
@@ -142,7 +145,7 @@ Implemented:
 - global MCP Started/Stopped switch that preserves permissions while blocking live execution
 - persistent web console with live PTY streaming
 - UI bulk SSH command execution across selected connector targets with per-target history rows
-- MCP bridge with connector action tools for SSH, Postgres, Redis, and future local integrations
+- MCP bridge with connector action tools for SSH, Postgres, Redis, RabbitMQ, and future local integrations
 - approval dialog with Run / Decline / note
 - approval-context snapshots that stale old pending connector actions after
   permission, connector target, credential profile, connector metadata, or
@@ -207,6 +210,14 @@ http://localhost:3210
 ```
 
 The Docker Compose UI port binds to `127.0.0.1` by default. The backend is not published as a separate host port in Docker Compose; the frontend proxies `/api` to the backend inside the shared local container namespace. The backend itself refuses to start when `AIPERMISSION_BACKEND_HOST` is set to `0.0.0.0` or any non-loopback address. AIPermission is local-only: do not publish Compose ports on `0.0.0.0` or a LAN interface. Remote/LAN mode is intentionally not supported.
+
+If AIPermission runs in Docker on a Linux host and a connector target points at
+a service running on that same host, use `host.docker.internal` as the connector
+host instead of `localhost`. The connector network transport resolves that name
+to the Docker host gateway when Docker does not provide it automatically.
+For example, a Postgres service listening on the Linux host can be configured as
+`host.docker.internal:5432` in Direct mode. Use Over SSH only when the service is
+reachable from another SSH target rather than from the Docker host.
 
 ## Basic Flow
 
@@ -300,7 +311,7 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-The MCP surface is connector-first. SSH, Postgres, Redis, and future integrations use
+The MCP surface is connector-first. SSH, Postgres, Redis, RabbitMQ, and future integrations use
 the same target/profile/action permission pipeline. `list_connector_targets` is
 permission-scoped, not a live health check. Current reachability is learned when
 the connector action actually runs and returns a dial, timeout, authentication,
@@ -312,6 +323,12 @@ For SSH, call `get_connector_actions(target_ref)` to discover actions such as
 
 For Redis, call `get_connector_actions(target_ref)` to discover actions such as
 `scan_keys`, `get_key`, `set_string`, `expire_key`, and `delete_keys`.
+
+For RabbitMQ, call `get_connector_actions(target_ref)` to discover actions such
+as `overview`, `list_vhosts`, `list_queues`, `get_queue`, `list_bindings`, and
+`peek_messages`, and `publish_message`. Treat message payload previews and
+message publishing as sensitive queue access; previews use bounded
+count/truncation limits and `ack_requeue_true`.
 
 If an action returns `approval_pending` or `running`, the response includes an
 `assistant_hint` telling the AI to poll `get_connector_action_request` until the

--- a/backend/internal/api/connector_network_transport.go
+++ b/backend/internal/api/connector_network_transport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 )
 
 const connectorNetworkDialTimeout = 12 * time.Second
+const dockerHostInternalName = "host.docker.internal"
 
 type connectorNetworkTransport struct {
 	server  *Server
@@ -69,5 +71,47 @@ func networkDialAddress(host string, port int) (string, error) {
 	if port < 1 || port > 65535 {
 		return "", fmt.Errorf("port must be between 1 and 65535")
 	}
-	return net.JoinHostPort(host, strconv.Itoa(port)), nil
+	return net.JoinHostPort(resolveConnectorDialHost(host), strconv.Itoa(port)), nil
+}
+
+func resolveConnectorDialHost(host string) string {
+	if !strings.EqualFold(strings.TrimSpace(host), dockerHostInternalName) {
+		return host
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if addresses, err := net.DefaultResolver.LookupHost(ctx, host); err == nil && len(addresses) > 0 {
+		return host
+	}
+	if gateway, ok := linuxDefaultGatewayHost(); ok {
+		return gateway
+	}
+	return host
+}
+
+func linuxDefaultGatewayHost() (string, bool) {
+	data, err := os.ReadFile("/proc/net/route")
+	if err != nil {
+		return "", false
+	}
+	return parseLinuxDefaultGatewayRoute(string(data))
+}
+
+func parseLinuxDefaultGatewayRoute(data string) (string, bool) {
+	for _, line := range strings.Split(data, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 || fields[1] != "00000000" {
+			continue
+		}
+		value, err := strconv.ParseUint(fields[2], 16, 32)
+		if err != nil {
+			continue
+		}
+		ip := net.IPv4(byte(value), byte(value>>8), byte(value>>16), byte(value>>24))
+		if ip == nil || ip.Equal(net.IPv4zero) {
+			continue
+		}
+		return ip.String(), true
+	}
+	return "", false
 }

--- a/backend/internal/api/connector_network_transport_test.go
+++ b/backend/internal/api/connector_network_transport_test.go
@@ -1,0 +1,23 @@
+package api
+
+import "testing"
+
+func TestParseLinuxDefaultGatewayRoute(t *testing.T) {
+	gateway, ok := parseLinuxDefaultGatewayRoute(`Iface	Destination	Gateway	Flags	RefCnt	Use	Metric	Mask
+eth0	00000000	010011AC	0003	0	0	0	00000000
+`)
+	if !ok {
+		t.Fatalf("expected default gateway")
+	}
+	if gateway != "172.17.0.1" {
+		t.Fatalf("gateway = %q", gateway)
+	}
+}
+
+func TestParseLinuxDefaultGatewayRouteRejectsMissingDefault(t *testing.T) {
+	if gateway, ok := parseLinuxDefaultGatewayRoute(`Iface	Destination	Gateway	Flags	RefCnt	Use	Metric	Mask
+eth0	0008A8C0	00000000	0001	0	0	0	00FFFFFF
+`); ok || gateway != "" {
+		t.Fatalf("unexpected gateway %q ok=%v", gateway, ok)
+	}
+}

--- a/backend/internal/api/connector_target_ping_handlers.go
+++ b/backend/internal/api/connector_target_ping_handlers.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+const (
+	connectorHostPingDefaultAttempts = 4
+	connectorHostPingTimeout         = 3 * time.Second
+	connectorHostPingPause           = 150 * time.Millisecond
+)
+
+type connectorTargetHostPingRequest struct {
+	Host               string `json:"host"`
+	Port               int    `json:"port"`
+	Mode               string `json:"mode,omitempty"`
+	TransportTargetRef string `json:"transport_target_ref,omitempty"`
+	Attempts           int    `json:"attempts,omitempty"`
+}
+
+type connectorTargetHostPingAttempt struct {
+	Attempt    int    `json:"attempt"`
+	OK         bool   `json:"ok"`
+	DurationMS int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+type connectorTargetHostPingResponse struct {
+	OK                 bool                             `json:"ok"`
+	Host               string                           `json:"host"`
+	Port               int                              `json:"port"`
+	Mode               string                           `json:"mode"`
+	TransportTargetRef string                           `json:"transport_target_ref,omitempty"`
+	Attempts           []connectorTargetHostPingAttempt `json:"attempts"`
+	Sent               int                              `json:"sent"`
+	Received           int                              `json:"received"`
+	DurationMS         int64                            `json:"duration_ms"`
+	Message            string                           `json:"message"`
+}
+
+func (s connectorTargetHandlers) pingConnectorTargetHost(w http.ResponseWriter, r *http.Request) {
+	runtime, ok := s.activeRuntimeOrLocked(w)
+	if !ok {
+		return
+	}
+	var request connectorTargetHostPingRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	request.Host = strings.TrimSpace(request.Host)
+	request.Mode = strings.TrimSpace(request.Mode)
+	if request.Mode == "" {
+		request.Mode = "direct"
+	}
+	request.TransportTargetRef = strings.TrimSpace(request.TransportTargetRef)
+	if _, err := networkDialAddress(request.Host, request.Port); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	switch request.Mode {
+	case "direct":
+	case "over_ssh":
+		if request.TransportTargetRef == "" {
+			writeError(w, http.StatusBadRequest, "transport target ref is required for over_ssh")
+			return
+		}
+	default:
+		writeError(w, http.StatusBadRequest, "unsupported connection mode")
+		return
+	}
+	attemptCount := request.Attempts
+	if attemptCount <= 0 || attemptCount > connectorHostPingDefaultAttempts {
+		attemptCount = connectorHostPingDefaultAttempts
+	}
+
+	transport := connectorNetworkTransport{server: s.Server, runtime: runtime}
+	attempts := make([]connectorTargetHostPingAttempt, 0, connectorHostPingDefaultAttempts)
+	started := time.Now()
+	received := 0
+	for i := 1; i <= attemptCount; i++ {
+		attempt := connectorTargetHostPingAttempt{Attempt: i}
+		attemptStarted := time.Now()
+		ctx, cancel := context.WithTimeout(r.Context(), connectorHostPingTimeout)
+		conn, err := transport.DialConnectorTCP(ctx, connectors.NetworkDialRequest{
+			Mode:               request.Mode,
+			Host:               request.Host,
+			Port:               request.Port,
+			TransportTargetRef: request.TransportTargetRef,
+		})
+		attempt.DurationMS = time.Since(attemptStarted).Milliseconds()
+		cancel()
+		if conn != nil {
+			_ = conn.Close()
+		}
+		if err != nil {
+			attempt.Error = s.redactForPersistence(r.Context(), runtime, normalizeNetworkPingError(err))
+		} else {
+			attempt.OK = true
+			received++
+		}
+		attempts = append(attempts, attempt)
+		if i < attemptCount {
+			select {
+			case <-r.Context().Done():
+				writeError(w, http.StatusRequestTimeout, "ping canceled")
+				return
+			case <-time.After(connectorHostPingPause):
+			}
+		}
+	}
+
+	response := connectorTargetHostPingResponse{
+		OK:                 received == attemptCount,
+		Host:               request.Host,
+		Port:               request.Port,
+		Mode:               request.Mode,
+		TransportTargetRef: request.TransportTargetRef,
+		Attempts:           attempts,
+		Sent:               attemptCount,
+		Received:           received,
+		DurationMS:         time.Since(started).Milliseconds(),
+		Message:            connectorHostPingMessage(received, attemptCount),
+	}
+	s.writeAudit(r.Context(), runtime, "user", nil, 0, "connector.host.ping", map[string]any{
+		"host":                 request.Host,
+		"port":                 request.Port,
+		"mode":                 request.Mode,
+		"transport_target_ref": request.TransportTargetRef,
+		"attempts":             attemptCount,
+		"received":             received,
+		"ok":                   response.OK,
+	})
+	writeJSON(w, http.StatusOK, response)
+}
+
+func normalizeNetworkPingError(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	var dnsErr *net.DNSError
+	if ok := errors.As(err, &dnsErr); ok && dnsErr.Name != "" {
+		return "host lookup failed: " + dnsErr.Name
+	}
+	return message
+}
+
+func connectorHostPingMessage(received, sent int) string {
+	if received == sent {
+		return "Host and port are reachable."
+	}
+	if received == 0 {
+		return "Host and port are not reachable from the selected connection mode."
+	}
+	return "Host and port are intermittently reachable."
+}

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -128,6 +128,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/connector-targets/inventory", connectorTargets.listConnectorTargetInventory)
 	s.mux.HandleFunc("POST /api/connector-targets/with-profile", connectorTargets.createConnectorTargetWithProfile)
 	s.mux.HandleFunc("POST /api/connector-targets", connectorTargets.createConnectorTarget)
+	s.mux.HandleFunc("POST /api/connector-targets/ping", connectorTargets.pingConnectorTargetHost)
 	s.mux.HandleFunc("POST /api/connector-targets/test", connectorTargets.testConnectorTargetDraft)
 	s.mux.HandleFunc("GET /api/connector-targets/{id}", connectorTargets.getConnectorTarget)
 	s.mux.HandleFunc("PUT /api/connector-targets/{id}/with-profile/{profile_id}", connectorTargets.updateConnectorTargetWithProfile)

--- a/backend/internal/api/routes_test.go
+++ b/backend/internal/api/routes_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -213,6 +214,64 @@ func TestConnectorCatalogRoutes(t *testing.T) {
 	}
 	if response := performJSON(handler, http.MethodGet, "/api/connectors/example", "", nil); response.Code != http.StatusNotFound {
 		t.Fatalf("unknown connector should be not found, got %d", response.Code)
+	}
+}
+
+func TestConnectorTargetHostPingRouteChecksTCPReachability(t *testing.T) {
+	fixture := newAPITestFixture(t)
+	handler := fixture.server.Handler()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+	accepted := make(chan net.Conn, 4)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			accepted <- conn
+		}
+	}()
+	_, rawPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener addr: %v", err)
+	}
+	port, err := strconv.Atoi(rawPort)
+	if err != nil {
+		t.Fatalf("parse listener port: %v", err)
+	}
+
+	response := performJSON(handler, http.MethodPost, "/api/connector-targets/ping", "", connectorTargetHostPingRequest{
+		Host:     "127.0.0.1",
+		Port:     port,
+		Mode:     "direct",
+		Attempts: 2,
+	})
+	if response.Code != http.StatusOK {
+		t.Fatalf("ping route failed: %d %s", response.Code, response.Body.String())
+	}
+	page := decodeRouteResponse[connectorTargetHostPingResponse](t, response.Body.Bytes())
+	if !page.OK || page.Sent != 2 || page.Received != 2 || len(page.Attempts) != 2 {
+		t.Fatalf("unexpected ping response: %#v", page)
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case conn := <-accepted:
+			conn.Close()
+		case <-time.After(time.Second):
+			t.Fatalf("listener did not receive attempt %d", i+1)
+		}
+	}
+
+	bad := performJSON(handler, http.MethodPost, "/api/connector-targets/ping", "", connectorTargetHostPingRequest{
+		Host: "",
+		Port: port,
+	})
+	if bad.Code != http.StatusBadRequest {
+		t.Fatalf("missing host should be rejected, got %d %s", bad.Code, bad.Body.String())
 	}
 }
 

--- a/backend/internal/connectors/builtin/registry.go
+++ b/backend/internal/connectors/builtin/registry.go
@@ -5,6 +5,7 @@ package builtin
 import (
 	"github.com/aipermission/aipermission/backend/internal/connectors"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
+	rabbitmqconnector "github.com/aipermission/aipermission/backend/internal/connectors/rabbitmq"
 	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"
 	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
 	_ "github.com/aipermission/aipermission/backend/internal/connectors/ssh/apiadapter"
@@ -14,6 +15,7 @@ import (
 func RegisterAll(registry *connectors.Registry) error {
 	for _, connector := range []connectors.Connector{
 		postgresconnector.New(),
+		rabbitmqconnector.New(),
 		redisconnector.New(),
 		sshconnector.New(),
 	} {

--- a/backend/internal/connectors/builtin/registry_test.go
+++ b/backend/internal/connectors/builtin/registry_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aipermission/aipermission/backend/internal/connectors"
 	"github.com/aipermission/aipermission/backend/internal/connectors/connectortest"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
+	rabbitmqconnector "github.com/aipermission/aipermission/backend/internal/connectors/rabbitmq"
 	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"
 	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
 )
@@ -23,6 +24,13 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	}
 	if postgres.Label() != postgresconnector.Label {
 		t.Fatalf("postgres label = %q", postgres.Label())
+	}
+	rabbitmq, ok := registry.Get(rabbitmqconnector.Kind)
+	if !ok {
+		t.Fatal("expected rabbitmq connector")
+	}
+	if rabbitmq.Label() != rabbitmqconnector.Label {
+		t.Fatalf("rabbitmq label = %q", rabbitmq.Label())
 	}
 	redis, ok := registry.Get(redisconnector.Kind)
 	if !ok {
@@ -41,7 +49,7 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	}
 
 	infos := registry.List()
-	if len(infos) != 3 || infos[0].Kind != postgresconnector.Kind || infos[1].Kind != redisconnector.Kind || infos[2].Kind != sshconnector.Kind {
+	if len(infos) != 4 || infos[0].Kind != postgresconnector.Kind || infos[1].Kind != rabbitmqconnector.Kind || infos[2].Kind != redisconnector.Kind || infos[3].Kind != sshconnector.Kind {
 		t.Fatalf("unexpected connector list: %#v", infos)
 	}
 }
@@ -136,6 +144,29 @@ func builtInDeterminismSamples(t *testing.T, kind string) (connectors.TargetView
 				redisconnector.ActionSetString:  {"key": "app:test", "value": "hello", "ttl_seconds": 60},
 				redisconnector.ActionExpireKey:  {"key": "app:test", "ttl_seconds": 60},
 				redisconnector.ActionDeleteKeys: {"keys": []any{"app:test"}},
+			}
+	case rabbitmqconnector.Kind:
+		return connectors.TargetView{
+				ID:            4,
+				Ref:           "rabbitmq:4:40",
+				ConnectorKind: rabbitmqconnector.Kind,
+				Name:          "queue",
+				Config:        map[string]any{"connection_mode": "direct", "scheme": "http", "host": "127.0.0.1", "port": 15672, "vhost": "/"},
+			}, connectors.CredentialProfileView{
+				ID:            40,
+				TargetID:      4,
+				ConnectorKind: rabbitmqconnector.Kind,
+				Kind:          "username_password",
+				Label:         "monitor",
+				Public:        map[string]any{"username": "guest"},
+			}, map[string]map[string]any{
+				rabbitmqconnector.ActionOverview:     {},
+				rabbitmqconnector.ActionListVhosts:   {},
+				rabbitmqconnector.ActionListQueues:   {"vhost": "/", "pattern": "", "limit": 10},
+				rabbitmqconnector.ActionGetQueue:     {"vhost": "/", "queue": "jobs"},
+				rabbitmqconnector.ActionListBindings: {"vhost": "/", "queue": "jobs", "limit": 10},
+				rabbitmqconnector.ActionPeekMessages: {"vhost": "/", "queue": "jobs", "count": 2, "max_payload_bytes": 4096},
+				rabbitmqconnector.ActionPublish:      {"vhost": "/", "exchange": "amq.default", "routing_key": "jobs", "payload": `{"ok":true}`, "payload_encoding": "string", "properties": map[string]any{"content_type": "application/json"}},
 			}
 	case sshconnector.Kind:
 		return connectors.TargetView{

--- a/backend/internal/connectors/rabbitmq/rabbitmq.go
+++ b/backend/internal/connectors/rabbitmq/rabbitmq.go
@@ -1,0 +1,974 @@
+// Package rabbitmqconnector defines the RabbitMQ connector contract.
+package rabbitmqconnector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+const (
+	Kind    = "rabbitmq"
+	Label   = "RabbitMQ"
+	Version = "0.2"
+
+	ActionOverview     = "overview"
+	ActionListVhosts   = "list_vhosts"
+	ActionListQueues   = "list_queues"
+	ActionGetQueue     = "get_queue"
+	ActionListBindings = "list_bindings"
+	ActionPeekMessages = "peek_messages"
+	ActionPublish      = "publish_message"
+
+	defaultRabbitMQScheme = "http"
+	defaultRabbitMQHost   = "127.0.0.1"
+	defaultRabbitMQPort   = 15672
+	defaultRabbitMQVHost  = "/"
+
+	defaultQueueLimit      = 250
+	maxQueueLimit          = 1000
+	defaultPeekCount       = 5
+	maxPeekCount           = 50
+	defaultPayloadMaxBytes = 64 << 10
+	maxPayloadBytes        = 256 << 10
+	maxPublishPayloadBytes = 256 << 10
+	maxRabbitHTTPBodyBytes = 1 << 20
+	maxRabbitReasonBytes   = 2000
+	rabbitHTTPTimeout      = 15 * time.Second
+)
+
+var (
+	ErrUnsupportedAction = errors.New("unsupported rabbitmq connector action")
+	ErrMissingTransport  = errors.New("rabbitmq connector network transport is unavailable")
+	ErrMissingSecret     = errors.New("rabbitmq connector credential is missing required secret")
+	ErrInvalidConfig     = errors.New("rabbitmq connector target config is invalid")
+)
+
+// Connector describes RabbitMQ as a connector-shaped target for bounded queue
+// inspection through the RabbitMQ Management API.
+type Connector struct{}
+
+func New() Connector {
+	return Connector{}
+}
+
+func (Connector) Kind() string {
+	return Kind
+}
+
+func (Connector) Label() string {
+	return Label
+}
+
+func (Connector) Version() string {
+	return Version
+}
+
+func (Connector) TargetSchema() connectors.Schema {
+	return connectors.Schema{Fields: []connectors.Field{
+		{
+			Name:        "connection_mode",
+			Label:       "Connection mode",
+			Type:        connectors.FieldSelect,
+			Required:    true,
+			Default:     "direct",
+			Description: "Connect directly from the local gateway, or tunnel to the RabbitMQ Management API through an SSH connector profile.",
+			Options: []connectors.FieldOption{
+				{Value: "direct", Label: "Direct"},
+				{Value: "over_ssh", Label: "Over SSH"},
+			},
+		},
+		{
+			Name:        "scheme",
+			Label:       "Scheme",
+			Type:        connectors.FieldSelect,
+			Required:    true,
+			Default:     defaultRabbitMQScheme,
+			Description: "RabbitMQ Management API HTTP scheme.",
+			Options: []connectors.FieldOption{
+				{Value: "http", Label: "HTTP"},
+				{Value: "https", Label: "HTTPS"},
+			},
+		},
+		{
+			Name:        "host",
+			Label:       "Host",
+			Type:        connectors.FieldString,
+			Required:    true,
+			Default:     defaultRabbitMQHost,
+			Description: "RabbitMQ Management API host as seen by the selected connection mode. For Over SSH this is usually 127.0.0.1 on the remote server.",
+		},
+		{
+			Name:        "port",
+			Label:       "Management API port",
+			Type:        connectors.FieldNumber,
+			Required:    true,
+			Default:     defaultRabbitMQPort,
+			Description: "RabbitMQ Management API TCP port, usually 15672 or the port shown in the management URL. Do not use the AMQP listener port.",
+		},
+		{
+			Name:        "vhost",
+			Label:       "Default vhost",
+			Type:        connectors.FieldString,
+			Default:     defaultRabbitMQVHost,
+			Description: "Default RabbitMQ virtual host for queue actions.",
+		},
+		{
+			Name:        "transport_target_ref",
+			Label:       "SSH transport target",
+			Type:        connectors.FieldString,
+			Description: "Connector target ref used when connection_mode is over_ssh.",
+		},
+	}}
+}
+
+func (Connector) CredentialSchemas() []connectors.CredentialSchema {
+	return []connectors.CredentialSchema{
+		{
+			Kind:        "username_password",
+			Label:       "Username and password",
+			Description: "RabbitMQ Management API username and password stored through the encrypted vault layer.",
+			Schema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "username",
+					Label:       "Username",
+					Type:        connectors.FieldString,
+					Required:    true,
+					Description: "RabbitMQ Management API username.",
+				},
+				{
+					Name:        "password",
+					Label:       "Password",
+					Type:        connectors.FieldSecret,
+					Required:    true,
+					Secret:      true,
+					Description: "RabbitMQ Management API password.",
+				},
+			}},
+		},
+	}
+}
+
+func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (connectors.ConnectorHelp, error) {
+	title := "RabbitMQ target"
+	if strings.TrimSpace(target.Name) != "" {
+		title = "RabbitMQ target: " + target.Name
+	}
+	return connectors.ConnectorHelp{
+		Title:       title,
+		Summary:     "Inspect RabbitMQ vhosts, queues, bindings, and bounded message previews through AIPermission approval rules.",
+		Connector:   Label,
+		ConnectorID: Kind,
+		Usage: []string{
+			"Use list_queues before reading queue details when the queue name is unknown.",
+			"Use get_queue to inspect one queue's metadata and counters.",
+			"Use peek_messages only when the operator approved payload inspection; messages are requested with ack_requeue_true.",
+			"Use publish_message only for intentional message creation; it is a write action and should normally start in Prompt mode.",
+			"RabbitMQ destructive actions such as purge, ack, and delete are intentionally not part of the 0.2.6 MVP.",
+		},
+		Warnings: []string{
+			"RabbitMQ message payloads may contain secrets or customer data. Redaction is best-effort; avoid reading payloads unless explicitly approved.",
+			"peek_messages uses the Management API get endpoint with ack_requeue_true and bounded count/truncate limits.",
+			"publish_message creates a new message in RabbitMQ. Use a dedicated credential with RabbitMQ-level write scope.",
+			"RabbitMQ credential profiles decide what the RabbitMQ server itself allows.",
+		},
+	}, nil
+}
+
+func (Connector) GetActionList(context.Context, connectors.TargetView, connectors.CredentialProfileView) ([]connectors.ActionDefinition, error) {
+	return []connectors.ActionDefinition{
+		{
+			Name:        ActionOverview,
+			Label:       "Overview",
+			Description: "Read bounded RabbitMQ overview metadata.",
+			Category:    "metadata",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{},
+			OutputHint:  connectors.OutputHint{Format: "json", MaxBytes: 128 << 10},
+		},
+		{
+			Name:        ActionListVhosts,
+			Label:       "List vhosts",
+			Description: "List RabbitMQ virtual hosts visible to this credential.",
+			Category:    "metadata",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{},
+			OutputHint:  connectors.OutputHint{Format: "json", MaxRows: 500},
+		},
+		{
+			Name:        ActionListQueues,
+			Label:       "List queues",
+			Description: "List queues in one virtual host with bounded rows.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "vhost", Label: "Vhost", Type: connectors.FieldString, Description: "Optional vhost; defaults to target vhost."},
+				{Name: "pattern", Label: "Pattern", Type: connectors.FieldString, Description: "Optional case-insensitive queue name filter."},
+				{Name: "limit", Label: "Limit", Type: connectors.FieldNumber, Default: defaultQueueLimit},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxRows: maxQueueLimit},
+		},
+		{
+			Name:        ActionGetQueue,
+			Label:       "Read queue",
+			Description: "Read metadata and counters for one RabbitMQ queue.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "vhost", Label: "Vhost", Type: connectors.FieldString, Description: "Optional vhost; defaults to target vhost."},
+				{Name: "queue", Label: "Queue", Type: connectors.FieldString, Required: true},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 128 << 10},
+		},
+		{
+			Name:        ActionListBindings,
+			Label:       "List bindings",
+			Description: "List bindings for one vhost or one queue.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "vhost", Label: "Vhost", Type: connectors.FieldString, Description: "Optional vhost; defaults to target vhost."},
+				{Name: "queue", Label: "Queue", Type: connectors.FieldString, Description: "Optional queue name."},
+				{Name: "limit", Label: "Limit", Type: connectors.FieldNumber, Default: defaultQueueLimit},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxRows: maxQueueLimit},
+		},
+		{
+			Name:        ActionPeekMessages,
+			Label:       "Peek messages",
+			Description: "Read a bounded preview of queue messages with ack_requeue_true.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "vhost", Label: "Vhost", Type: connectors.FieldString, Description: "Optional vhost; defaults to target vhost."},
+				{Name: "queue", Label: "Queue", Type: connectors.FieldString, Required: true},
+				{Name: "count", Label: "Count", Type: connectors.FieldNumber, Default: defaultPeekCount},
+				{Name: "max_payload_bytes", Label: "Max payload bytes", Type: connectors.FieldNumber, Default: defaultPayloadMaxBytes},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: maxPayloadBytes},
+		},
+		{
+			Name:        ActionPublish,
+			Label:       "Publish message",
+			Description: "Publish one bounded message through the RabbitMQ Management API.",
+			Category:    "write",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "vhost", Label: "Vhost", Type: connectors.FieldString, Description: "Optional vhost; defaults to target vhost."},
+				{Name: "exchange", Label: "Exchange", Type: connectors.FieldString, Default: "amq.default", Description: "Exchange name. Use amq.default to route directly to a queue by routing key."},
+				{Name: "routing_key", Label: "Routing key", Type: connectors.FieldString, Required: true},
+				{Name: "payload", Label: "Payload", Type: connectors.FieldMultiline, Required: true},
+				{Name: "payload_encoding", Label: "Payload encoding", Type: connectors.FieldSelect, Default: "string", Options: []connectors.FieldOption{
+					{Value: "string", Label: "String"},
+					{Value: "base64", Label: "Base64"},
+				}},
+				{Name: "properties", Label: "Properties", Type: connectors.FieldJSON, Description: "Optional AMQP properties JSON object."},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+	}, nil
+}
+
+func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) (connectors.PreparedAction, error) {
+	input := copyMap(req.Input)
+	risk := connectors.RiskRead
+	title := ""
+	summary := ""
+	vhost := rabbitVHost(req.Target)
+	switch req.ActionName {
+	case ActionOverview:
+		title = "Read RabbitMQ overview"
+		summary = "Read bounded RabbitMQ overview metadata."
+	case ActionListVhosts:
+		title = "List RabbitMQ vhosts"
+		summary = "List visible RabbitMQ virtual hosts."
+	case ActionListQueues:
+		vhost = normalizeVHost(input, "vhost", vhost)
+		pattern := strings.TrimSpace(stringValue(input, "pattern"))
+		limit := normalizeInt(input, "limit", defaultQueueLimit, 1, maxQueueLimit)
+		input["vhost"] = vhost
+		input["pattern"] = pattern
+		input["limit"] = limit
+		title = "List RabbitMQ queues"
+		summary = fmt.Sprintf("List queues in vhost %q.", vhost)
+	case ActionGetQueue:
+		vhost = normalizeVHost(input, "vhost", vhost)
+		queue := strings.TrimSpace(stringValue(input, "queue"))
+		if queue == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("queue is required")
+		}
+		input["vhost"] = vhost
+		input["queue"] = queue
+		title = "Read RabbitMQ queue"
+		summary = fmt.Sprintf("%s/%s", vhost, queue)
+	case ActionListBindings:
+		vhost = normalizeVHost(input, "vhost", vhost)
+		queue := strings.TrimSpace(stringValue(input, "queue"))
+		limit := normalizeInt(input, "limit", defaultQueueLimit, 1, maxQueueLimit)
+		input["vhost"] = vhost
+		input["queue"] = queue
+		input["limit"] = limit
+		title = "List RabbitMQ bindings"
+		if queue != "" {
+			summary = fmt.Sprintf("List bindings for %s/%s.", vhost, queue)
+		} else {
+			summary = fmt.Sprintf("List bindings in vhost %q.", vhost)
+		}
+	case ActionPeekMessages:
+		vhost = normalizeVHost(input, "vhost", vhost)
+		queue := strings.TrimSpace(stringValue(input, "queue"))
+		if queue == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("queue is required")
+		}
+		count := normalizeInt(input, "count", defaultPeekCount, 1, maxPeekCount)
+		maxBytes := normalizeInt(input, "max_payload_bytes", defaultPayloadMaxBytes, 1, maxPayloadBytes)
+		input["vhost"] = vhost
+		input["queue"] = queue
+		input["count"] = count
+		input["max_payload_bytes"] = maxBytes
+		title = "Peek RabbitMQ messages"
+		summary = fmt.Sprintf("Peek %d message(s) from %s/%s with requeue.", count, vhost, queue)
+	case ActionPublish:
+		risk = connectors.RiskWrite
+		vhost = normalizeVHost(input, "vhost", vhost)
+		exchange := strings.TrimSpace(stringValue(input, "exchange"))
+		if exchange == "" {
+			exchange = "amq.default"
+		}
+		routingKey := strings.TrimSpace(stringValue(input, "routing_key"))
+		if routingKey == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("routing_key is required")
+		}
+		payload := stringValue(input, "payload")
+		if payload == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("payload is required")
+		}
+		if len(payload) > maxPublishPayloadBytes {
+			return connectors.PreparedAction{}, fmt.Errorf("payload is larger than %d bytes", maxPublishPayloadBytes)
+		}
+		encoding := strings.ToLower(strings.TrimSpace(stringValue(input, "payload_encoding")))
+		if encoding == "" {
+			encoding = "string"
+		}
+		if encoding != "string" && encoding != "base64" {
+			return connectors.PreparedAction{}, fmt.Errorf("payload_encoding must be string or base64")
+		}
+		properties, err := normalizeJSONMap(input, "properties")
+		if err != nil {
+			return connectors.PreparedAction{}, err
+		}
+		input["vhost"] = vhost
+		input["exchange"] = exchange
+		input["routing_key"] = routingKey
+		input["payload"] = payload
+		input["payload_encoding"] = encoding
+		input["properties"] = properties
+		title = "Publish RabbitMQ message"
+		summary = fmt.Sprintf("Publish one message to %s/%s using routing key %q.", vhost, exchange, routingKey)
+	default:
+		return connectors.PreparedAction{}, ErrUnsupportedAction
+	}
+	if len(req.Reason) > maxRabbitReasonBytes {
+		return connectors.PreparedAction{}, fmt.Errorf("reason is too large")
+	}
+	return connectors.PreparedAction{
+		ConnectorKind: Kind,
+		TargetRef:     req.Target.Ref,
+		ProfileID:     req.Profile.ID,
+		ActionName:    req.ActionName,
+		Risk:          risk,
+		Title:         title,
+		Summary:       summary,
+		Preview:       input,
+		Payload:       input,
+		ContextMaterial: map[string]any{
+			"target":          req.Target.Name,
+			"profile":         req.Profile.Label,
+			"connection_mode": connectionMode(req.Target),
+			"vhost":           vhost,
+		},
+	}, nil
+}
+
+func (Connector) ExecuteAction(ctx context.Context, runtime connectors.RuntimeContext, action connectors.PreparedAction) (connectors.ActionResult, error) {
+	client, err := newRabbitClient(ctx, runtime)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	switch action.ActionName {
+	case ActionOverview:
+		return executeOverview(ctx, client)
+	case ActionListVhosts:
+		return executeListVhosts(ctx, client)
+	case ActionListQueues:
+		return executeListQueues(ctx, client, action.Payload, rabbitVHost(runtime.Target))
+	case ActionGetQueue:
+		return executeGetQueue(ctx, client, action.Payload, rabbitVHost(runtime.Target))
+	case ActionListBindings:
+		return executeListBindings(ctx, client, action.Payload, rabbitVHost(runtime.Target))
+	case ActionPeekMessages:
+		return executePeekMessages(ctx, client, action.Payload, rabbitVHost(runtime.Target))
+	case ActionPublish:
+		return executePublishMessage(ctx, client, action.Payload, rabbitVHost(runtime.Target))
+	default:
+		return connectors.ActionResult{}, ErrUnsupportedAction
+	}
+}
+
+func (Connector) TestConnection(ctx context.Context, runtime connectors.RuntimeContext) (connectors.TestResult, error) {
+	client, err := newRabbitClient(ctx, runtime)
+	if err != nil {
+		return connectors.TestResult{Status: classifyRabbitTestError(err), Message: err.Error()}, nil
+	}
+	var output map[string]any
+	if err := client.Get(ctx, "/api/overview", &output); err != nil {
+		return connectors.TestResult{Status: classifyRabbitTestError(err), Message: err.Error()}, nil
+	}
+	return connectors.TestResult{
+		Status:  connectors.TestOK,
+		Message: "RabbitMQ Management API connection ok.",
+		Details: map[string]any{
+			"product": output["product_name"],
+			"version": output["rabbitmq_version"],
+			"vhost":   rabbitVHost(runtime.Target),
+		},
+	}, nil
+}
+
+func executeOverview(ctx context.Context, client *rabbitClient) (connectors.ActionResult, error) {
+	var output map[string]any
+	if err := client.Get(ctx, "/api/overview", &output); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      output,
+		DisplayText: rabbitSummary(output),
+	}, nil
+}
+
+func executeListVhosts(ctx context.Context, client *rabbitClient) (connectors.ActionResult, error) {
+	var rows []map[string]any
+	if err := client.Get(ctx, "/api/vhosts", &rows); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if name := strings.TrimSpace(fmt.Sprint(row["name"])); name != "" {
+			names = append(names, name)
+		}
+	}
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      map[string]any{"vhosts": rows, "names": names, "count": len(rows)},
+		DisplayText: strings.Join(names, "\n"),
+	}, nil
+}
+
+func executeListQueues(ctx context.Context, client *rabbitClient, input map[string]any, fallbackVHost string) (connectors.ActionResult, error) {
+	vhost := normalizeVHost(input, "vhost", fallbackVHost)
+	pattern := strings.ToLower(strings.TrimSpace(stringValue(input, "pattern")))
+	limit := normalizeInt(input, "limit", defaultQueueLimit, 1, maxQueueLimit)
+	var rows []map[string]any
+	if err := client.Get(ctx, "/api/queues/"+pathPart(vhost), &rows); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	filtered := make([]map[string]any, 0, min(len(rows), limit))
+	truncated := false
+	for _, row := range rows {
+		name := strings.TrimSpace(fmt.Sprint(row["name"]))
+		if pattern != "" && !strings.Contains(strings.ToLower(name), pattern) {
+			continue
+		}
+		if len(filtered) >= limit {
+			truncated = true
+			break
+		}
+		filtered = append(filtered, slimQueue(row))
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"vhost":     vhost,
+			"pattern":   pattern,
+			"queues":    filtered,
+			"count":     len(filtered),
+			"truncated": truncated,
+		},
+		DisplayText: queueListDisplay(filtered),
+	}, nil
+}
+
+func executeGetQueue(ctx context.Context, client *rabbitClient, input map[string]any, fallbackVHost string) (connectors.ActionResult, error) {
+	vhost := normalizeVHost(input, "vhost", fallbackVHost)
+	queue := strings.TrimSpace(stringValue(input, "queue"))
+	if queue == "" {
+		return connectors.ActionResult{}, fmt.Errorf("queue is required")
+	}
+	var output map[string]any
+	if err := client.Get(ctx, "/api/queues/"+pathPart(vhost)+"/"+pathPart(queue), &output); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      output,
+		DisplayText: queueDetailDisplay(output),
+	}, nil
+}
+
+func executeListBindings(ctx context.Context, client *rabbitClient, input map[string]any, fallbackVHost string) (connectors.ActionResult, error) {
+	vhost := normalizeVHost(input, "vhost", fallbackVHost)
+	queue := strings.TrimSpace(stringValue(input, "queue"))
+	limit := normalizeInt(input, "limit", defaultQueueLimit, 1, maxQueueLimit)
+	path := "/api/bindings/" + pathPart(vhost)
+	if queue != "" {
+		path = "/api/queues/" + pathPart(vhost) + "/" + pathPart(queue) + "/bindings"
+	}
+	var rows []map[string]any
+	if err := client.Get(ctx, path, &rows); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"vhost":    vhost,
+			"queue":    queue,
+			"bindings": rows,
+			"count":    len(rows),
+		},
+		DisplayText: fmt.Sprintf("%d binding(s)", len(rows)),
+	}, nil
+}
+
+func executePeekMessages(ctx context.Context, client *rabbitClient, input map[string]any, fallbackVHost string) (connectors.ActionResult, error) {
+	vhost := normalizeVHost(input, "vhost", fallbackVHost)
+	queue := strings.TrimSpace(stringValue(input, "queue"))
+	if queue == "" {
+		return connectors.ActionResult{}, fmt.Errorf("queue is required")
+	}
+	count := normalizeInt(input, "count", defaultPeekCount, 1, maxPeekCount)
+	maxBytes := normalizeInt(input, "max_payload_bytes", defaultPayloadMaxBytes, 1, maxPayloadBytes)
+	body := map[string]any{
+		"count":    count,
+		"ackmode":  "ack_requeue_true",
+		"encoding": "auto",
+		"truncate": maxBytes,
+	}
+	var rows []map[string]any
+	if err := client.Post(ctx, "/api/queues/"+pathPart(vhost)+"/"+pathPart(queue)+"/get", body, &rows); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	for _, row := range rows {
+		if payload, ok := row["payload"].(string); ok && len(payload) > maxBytes {
+			row["payload"] = truncateString(payload, maxBytes)
+			row["payload_truncated_by_gateway"] = true
+		}
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"vhost":              vhost,
+			"queue":              queue,
+			"ackmode":            "ack_requeue_true",
+			"messages":           rows,
+			"count":              len(rows),
+			"max_payload_bytes":  maxBytes,
+			"management_api_get": true,
+		},
+		DisplayText: fmt.Sprintf("Peeked %d message(s) from %s/%s with requeue.", len(rows), vhost, queue),
+	}, nil
+}
+
+func executePublishMessage(ctx context.Context, client *rabbitClient, input map[string]any, fallbackVHost string) (connectors.ActionResult, error) {
+	vhost := normalizeVHost(input, "vhost", fallbackVHost)
+	exchange := strings.TrimSpace(stringValue(input, "exchange"))
+	if exchange == "" {
+		exchange = "amq.default"
+	}
+	routingKey := strings.TrimSpace(stringValue(input, "routing_key"))
+	if routingKey == "" {
+		return connectors.ActionResult{}, fmt.Errorf("routing_key is required")
+	}
+	payload := stringValue(input, "payload")
+	if payload == "" {
+		return connectors.ActionResult{}, fmt.Errorf("payload is required")
+	}
+	if len(payload) > maxPublishPayloadBytes {
+		return connectors.ActionResult{}, fmt.Errorf("payload is larger than %d bytes", maxPublishPayloadBytes)
+	}
+	encoding := strings.ToLower(strings.TrimSpace(stringValue(input, "payload_encoding")))
+	if encoding == "" {
+		encoding = "string"
+	}
+	properties, err := normalizeJSONMap(input, "properties")
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	body := map[string]any{
+		"properties":       properties,
+		"routing_key":      routingKey,
+		"payload":          payload,
+		"payload_encoding": encoding,
+	}
+	var output map[string]any
+	if err := client.Post(ctx, "/api/exchanges/"+pathPart(vhost)+"/"+pathPart(exchange)+"/publish", body, &output); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	routed, _ := output["routed"].(bool)
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"vhost":            vhost,
+			"exchange":         exchange,
+			"routing_key":      routingKey,
+			"payload_bytes":    len(payload),
+			"payload_encoding": encoding,
+			"routed":           routed,
+		},
+		DisplayText: fmt.Sprintf("Published %d byte(s) to %s/%s routing_key=%q routed=%t.", len(payload), vhost, exchange, routingKey, routed),
+	}, nil
+}
+
+type rabbitClient struct {
+	baseURL    string
+	username   string
+	password   string
+	httpClient *http.Client
+}
+
+func newRabbitClient(ctx context.Context, runtime connectors.RuntimeContext) (*rabbitClient, error) {
+	transport, _ := runtime.Capability(connectors.NetworkTransportCapabilityName).(connectors.NetworkTransport)
+	if transport == nil {
+		return nil, ErrMissingTransport
+	}
+	username := strings.TrimSpace(stringValue(runtime.Profile.Public, "username"))
+	if username == "" {
+		return nil, fmt.Errorf("%w: username is required", ErrMissingSecret)
+	}
+	password, err := runtime.Secrets.GetSecret(ctx, "password")
+	if err != nil || strings.TrimSpace(password) == "" {
+		return nil, fmt.Errorf("%w: password is required", ErrMissingSecret)
+	}
+	scheme := rabbitScheme(runtime.Target)
+	host := rabbitHost(runtime.Target)
+	port := rabbitPort(runtime.Target)
+	request := connectors.NetworkDialRequest{
+		Mode:               connectionMode(runtime.Target),
+		Host:               host,
+		Port:               port,
+		TransportTargetRef: strings.TrimSpace(stringValue(runtime.Target.Config, "transport_target_ref")),
+	}
+	httpTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
+			return transport.DialConnectorTCP(ctx, request)
+		},
+		ForceAttemptHTTP2:     false,
+		MaxIdleConns:          2,
+		IdleConnTimeout:       30 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	return &rabbitClient{
+		baseURL:  fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(host, strconv.Itoa(port))),
+		username: username,
+		password: password,
+		httpClient: &http.Client{
+			Timeout:   rabbitHTTPTimeout,
+			Transport: httpTransport,
+		},
+	}, nil
+}
+
+func (client *rabbitClient) Get(ctx context.Context, path string, out any) error {
+	return client.Do(ctx, http.MethodGet, path, nil, out)
+}
+
+func (client *rabbitClient) Post(ctx context.Context, path string, payload any, out any) error {
+	return client.Do(ctx, http.MethodPost, path, payload, out)
+}
+
+func (client *rabbitClient) Do(ctx context.Context, method string, path string, payload any, out any) error {
+	var body io.Reader
+	if payload != nil {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(encoded)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, client.baseURL+path, body)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(client.username, client.password)
+	req.Header.Set("Accept", "application/json")
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxRabbitHTTPBodyBytes+1))
+	if err != nil {
+		return err
+	}
+	if len(data) > maxRabbitHTTPBodyBytes {
+		return fmt.Errorf("rabbitmq response is larger than %d bytes", maxRabbitHTTPBodyBytes)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return rabbitHTTPError(resp.StatusCode, data)
+	}
+	if out == nil {
+		return nil
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("decode rabbitmq response: %w", err)
+	}
+	return nil
+}
+
+func rabbitHTTPError(status int, data []byte) error {
+	message := strings.TrimSpace(string(data))
+	if len(message) > 800 {
+		message = message[:800] + "...[truncated]"
+	}
+	if message == "" {
+		message = http.StatusText(status)
+	}
+	switch status {
+	case http.StatusUnauthorized:
+		return fmt.Errorf("rabbitmq authentication failed: %s", message)
+	case http.StatusForbidden:
+		return fmt.Errorf("rabbitmq permission denied: %s", message)
+	case http.StatusNotFound:
+		return fmt.Errorf("rabbitmq resource not found: %s", message)
+	default:
+		return fmt.Errorf("rabbitmq management API returned %d: %s", status, message)
+	}
+}
+
+func classifyRabbitTestError(err error) connectors.TestStatus {
+	if err == nil {
+		return connectors.TestOK
+	}
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "authentication"), strings.Contains(message, "unauthorized"), strings.Contains(message, "password"):
+		return connectors.TestFailedAuth
+	case strings.Contains(message, "permission denied"), strings.Contains(message, "forbidden"):
+		return connectors.TestFailedPermission
+	case strings.Contains(message, "tls"), strings.Contains(message, "certificate"):
+		return connectors.TestFailedTLS
+	case strings.Contains(message, "connection refused"), strings.Contains(message, "i/o timeout"), strings.Contains(message, "no such host"), strings.Contains(message, "network"), strings.Contains(message, "http/0.9"), strings.Contains(message, "malformed http"), strings.Contains(message, "server gave http response"):
+		return connectors.TestFailedNetwork
+	default:
+		return connectors.TestUnknownError
+	}
+}
+
+func rabbitSummary(output map[string]any) string {
+	product := strings.TrimSpace(fmt.Sprint(output["product_name"]))
+	version := strings.TrimSpace(fmt.Sprint(output["rabbitmq_version"]))
+	if product == "" && version == "" {
+		return "RabbitMQ overview read."
+	}
+	return strings.TrimSpace(product + " " + version)
+}
+
+func slimQueue(row map[string]any) map[string]any {
+	out := map[string]any{}
+	for _, key := range []string{
+		"name", "vhost", "durable", "auto_delete", "exclusive", "state", "messages", "messages_ready", "messages_unacknowledged", "consumers", "memory", "idle_since",
+	} {
+		if value, ok := row[key]; ok {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func queueListDisplay(rows []map[string]any) string {
+	lines := make([]string, 0, len(rows))
+	for _, row := range rows {
+		lines = append(lines, fmt.Sprintf("%s ready=%v unacked=%v consumers=%v", row["name"], row["messages_ready"], row["messages_unacknowledged"], row["consumers"]))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func queueDetailDisplay(row map[string]any) string {
+	return fmt.Sprintf("%s ready=%v unacked=%v consumers=%v state=%v", row["name"], row["messages_ready"], row["messages_unacknowledged"], row["consumers"], row["state"])
+}
+
+func connectionMode(target connectors.TargetView) string {
+	mode := strings.TrimSpace(stringValue(target.Config, "connection_mode"))
+	if mode == "" {
+		return "direct"
+	}
+	return mode
+}
+
+func rabbitScheme(target connectors.TargetView) string {
+	scheme := strings.ToLower(strings.TrimSpace(stringValue(target.Config, "scheme")))
+	if scheme != "https" {
+		return defaultRabbitMQScheme
+	}
+	return scheme
+}
+
+func rabbitHost(target connectors.TargetView) string {
+	host := strings.TrimSpace(stringValue(target.Config, "host"))
+	if host == "" {
+		return defaultRabbitMQHost
+	}
+	return host
+}
+
+func rabbitPort(target connectors.TargetView) int {
+	return normalizeInt(target.Config, "port", defaultRabbitMQPort, 1, 65535)
+}
+
+func rabbitVHost(target connectors.TargetView) string {
+	return normalizeVHost(target.Config, "vhost", defaultRabbitMQVHost)
+}
+
+func normalizeVHost(input map[string]any, key string, fallback string) string {
+	value := strings.TrimSpace(stringValue(input, key))
+	if value == "" {
+		value = fallback
+	}
+	if value == "" {
+		return defaultRabbitMQVHost
+	}
+	return value
+}
+
+func pathPart(value string) string {
+	return url.PathEscape(value)
+}
+
+func stringValue(values map[string]any, key string) string {
+	if values == nil {
+		return ""
+	}
+	value := values[key]
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func normalizeInt(values map[string]any, key string, fallback int, minValue int, maxValue int) int {
+	if values == nil {
+		return fallback
+	}
+	value, ok := values[key]
+	if !ok || value == nil || value == "" {
+		return fallback
+	}
+	var parsed int
+	switch typed := value.(type) {
+	case int:
+		parsed = typed
+	case int64:
+		parsed = int(typed)
+	case float64:
+		parsed = int(typed)
+	case json.Number:
+		n, err := typed.Int64()
+		if err != nil {
+			return fallback
+		}
+		parsed = int(n)
+	case string:
+		n, err := strconv.Atoi(strings.TrimSpace(typed))
+		if err != nil {
+			return fallback
+		}
+		parsed = n
+	default:
+		return fallback
+	}
+	if parsed < minValue {
+		return minValue
+	}
+	if parsed > maxValue {
+		return maxValue
+	}
+	return parsed
+}
+
+func normalizeJSONMap(values map[string]any, key string) (map[string]any, error) {
+	if values == nil {
+		return map[string]any{}, nil
+	}
+	value, ok := values[key]
+	if !ok || value == nil || value == "" {
+		return map[string]any{}, nil
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, nil
+	case string:
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(typed), &decoded); err != nil {
+			return nil, fmt.Errorf("%s must be a JSON object", key)
+		}
+		if decoded == nil {
+			return map[string]any{}, nil
+		}
+		return decoded, nil
+	default:
+		return nil, fmt.Errorf("%s must be a JSON object", key)
+	}
+}
+
+func copyMap(input map[string]any) map[string]any {
+	out := map[string]any{}
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}
+
+func truncateString(value string, maxBytes int) string {
+	if maxBytes < 1 || len(value) <= maxBytes {
+		return value
+	}
+	return value[:maxBytes] + "...[truncated]"
+}
+
+func min(left int, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}
+
+var _ connectors.Connector = Connector{}
+var _ connectors.TestableConnector = Connector{}

--- a/backend/internal/connectors/rabbitmq/rabbitmq_test.go
+++ b/backend/internal/connectors/rabbitmq/rabbitmq_test.go
@@ -1,0 +1,300 @@
+package rabbitmqconnector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+func TestPrepareActionNormalizesPeekMessages(t *testing.T) {
+	target := connectors.TargetView{
+		ID:            1,
+		Ref:           "rabbitmq:1:2",
+		ConnectorKind: Kind,
+		Name:          "queue",
+		Config:        map[string]any{"connection_mode": "direct", "scheme": "http", "host": "127.0.0.1", "port": 15672, "vhost": "/"},
+	}
+	profile := connectors.CredentialProfileView{ID: 2, TargetID: 1, ConnectorKind: Kind, Kind: "username_password", Label: "monitor"}
+
+	prepared, err := Connector{}.PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     target,
+		Profile:    profile,
+		ActionName: ActionPeekMessages,
+		Input:      map[string]any{"queue": "jobs", "count": 500, "max_payload_bytes": 1 << 30},
+	})
+	if err != nil {
+		t.Fatalf("prepare peek: %v", err)
+	}
+	if prepared.Payload["count"] != maxPeekCount {
+		t.Fatalf("count = %#v", prepared.Payload["count"])
+	}
+	if prepared.Payload["max_payload_bytes"] != maxPayloadBytes {
+		t.Fatalf("max_payload_bytes = %#v", prepared.Payload["max_payload_bytes"])
+	}
+	if prepared.Payload["vhost"] != "/" {
+		t.Fatalf("vhost = %#v", prepared.Payload["vhost"])
+	}
+	if prepared.Risk != connectors.RiskRead {
+		t.Fatalf("risk = %q", prepared.Risk)
+	}
+}
+
+func TestExecuteActionListsQueuesThroughNetworkTransport(t *testing.T) {
+	var seenAuth bool
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "guest" || password != "secret" {
+			http.Error(w, "bad auth", http.StatusUnauthorized)
+			return
+		}
+		seenAuth = true
+		if r.URL.EscapedPath() != "/api/queues/%2F" {
+			t.Fatalf("path = %q escaped=%q", r.URL.Path, r.URL.EscapedPath())
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"name": "jobs", "vhost": "/", "messages_ready": 3, "messages_unacknowledged": 1, "messages": 4, "consumers": 2, "state": "running"},
+			{"name": "events", "vhost": "/", "messages_ready": 0, "messages_unacknowledged": 0, "messages": 0, "consumers": 1, "state": "running"},
+		})
+	}))
+	server.Start()
+	defer server.Close()
+
+	result, err := Connector{}.ExecuteAction(context.Background(), testRuntimeForServer(t, server), connectors.PreparedAction{
+		ActionName: ActionListQueues,
+		Payload:    map[string]any{"vhost": "/", "pattern": "job", "limit": 10},
+	})
+	if err != nil {
+		t.Fatalf("execute list queues: %v", err)
+	}
+	if !seenAuth {
+		t.Fatal("expected basic auth")
+	}
+	output := result.Output.(map[string]any)
+	queues := output["queues"].([]map[string]any)
+	if len(queues) != 1 || queues[0]["name"] != "jobs" {
+		t.Fatalf("queues = %#v", queues)
+	}
+	if result.DisplayText == "" || !strings.Contains(result.DisplayText, "jobs") {
+		t.Fatalf("display = %q", result.DisplayText)
+	}
+}
+
+func TestExecuteActionPeeksMessagesWithRequeue(t *testing.T) {
+	var body map[string]any
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != "/api/queues/%2F/jobs/get" {
+			t.Fatalf("path = %q escaped=%q", r.URL.Path, r.URL.EscapedPath())
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"payload": `{"ok":true}`, "payload_encoding": "string", "redelivered": false},
+		})
+	}))
+	server.Start()
+	defer server.Close()
+
+	result, err := Connector{}.ExecuteAction(context.Background(), testRuntimeForServer(t, server), connectors.PreparedAction{
+		ActionName: ActionPeekMessages,
+		Payload:    map[string]any{"vhost": "/", "queue": "jobs", "count": 2, "max_payload_bytes": 4096},
+	})
+	if err != nil {
+		t.Fatalf("execute peek: %v", err)
+	}
+	if body["ackmode"] != "ack_requeue_true" || body["count"].(float64) != 2 {
+		t.Fatalf("body = %#v", body)
+	}
+	output := result.Output.(map[string]any)
+	if output["ackmode"] != "ack_requeue_true" || output["count"] != 1 {
+		t.Fatalf("output = %#v", output)
+	}
+}
+
+func TestPrepareActionNormalizesPublishMessage(t *testing.T) {
+	target := connectors.TargetView{
+		ID:            1,
+		Ref:           "rabbitmq:1:2",
+		ConnectorKind: Kind,
+		Name:          "queue",
+		Config:        map[string]any{"connection_mode": "direct", "scheme": "http", "host": "127.0.0.1", "port": 15672, "vhost": "/"},
+	}
+	profile := connectors.CredentialProfileView{ID: 2, TargetID: 1, ConnectorKind: Kind, Kind: "username_password", Label: "writer"}
+
+	prepared, err := Connector{}.PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     target,
+		Profile:    profile,
+		ActionName: ActionPublish,
+		Input: map[string]any{
+			"routing_key": "jobs",
+			"payload":     `{"hello":"world"}`,
+			"properties":  `{"content_type":"application/json"}`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare publish: %v", err)
+	}
+	if prepared.Risk != connectors.RiskWrite {
+		t.Fatalf("risk = %q", prepared.Risk)
+	}
+	if prepared.Payload["exchange"] != "amq.default" || prepared.Payload["payload_encoding"] != "string" {
+		t.Fatalf("payload = %#v", prepared.Payload)
+	}
+	properties := prepared.Payload["properties"].(map[string]any)
+	if properties["content_type"] != "application/json" {
+		t.Fatalf("properties = %#v", properties)
+	}
+}
+
+func TestExecuteActionPublishesMessage(t *testing.T) {
+	var body map[string]any
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != "/api/exchanges/%2F/amq.default/publish" {
+			t.Fatalf("path = %q escaped=%q", r.URL.Path, r.URL.EscapedPath())
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"routed": true})
+	}))
+	server.Start()
+	defer server.Close()
+
+	result, err := Connector{}.ExecuteAction(context.Background(), testRuntimeForServer(t, server), connectors.PreparedAction{
+		ActionName: ActionPublish,
+		Payload: map[string]any{
+			"vhost":            "/",
+			"exchange":         "amq.default",
+			"routing_key":      "jobs",
+			"payload":          `{"ok":true}`,
+			"payload_encoding": "string",
+			"properties":       map[string]any{"content_type": "application/json"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute publish: %v", err)
+	}
+	if body["routing_key"] != "jobs" || body["payload_encoding"] != "string" {
+		t.Fatalf("body = %#v", body)
+	}
+	output := result.Output.(map[string]any)
+	if output["routed"] != true || output["payload_bytes"] != len(`{"ok":true}`) {
+		t.Fatalf("output = %#v", output)
+	}
+}
+
+func TestConnectionReportsAuthFailure(t *testing.T) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	server.Start()
+	defer server.Close()
+
+	result, err := Connector{}.TestConnection(context.Background(), testRuntimeForServer(t, server))
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if result.Status != connectors.TestFailedAuth {
+		t.Fatalf("status = %#v message=%q", result.Status, result.Message)
+	}
+}
+
+func testRuntimeForServer(t *testing.T, server *httptest.Server) connectors.RuntimeContext {
+	t.Helper()
+	host, port := splitServerAddr(t, server.Listener.Addr().String())
+	return connectors.RuntimeContext{
+		Target: connectors.TargetView{
+			ID:            1,
+			Ref:           "rabbitmq:1:2",
+			ConnectorKind: Kind,
+			Name:          "queue",
+			Config:        map[string]any{"connection_mode": "direct", "scheme": "http", "host": host, "port": port, "vhost": "/"},
+		},
+		Profile: connectors.CredentialProfileView{
+			ID:            2,
+			TargetID:      1,
+			ConnectorKind: Kind,
+			Kind:          "username_password",
+			Label:         "monitor",
+			Public:        map[string]any{"username": "guest"},
+		},
+		Secrets:      rabbitTestSecrets{"password": "secret"},
+		Capabilities: rabbitTestCapabilities{transport: rabbitHTTPTransport{targetAddr: server.Listener.Addr().String()}},
+	}
+}
+
+func splitServerAddr(t *testing.T, addr string) (string, int) {
+	t.Helper()
+	host, rawPort, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+	var port int
+	if _, err := fmt.Sscanf(rawPort, "%d", &port); err != nil {
+		t.Fatalf("scan port: %v", err)
+	}
+	return host, port
+}
+
+type rabbitTestSecrets map[string]string
+
+func (secrets rabbitTestSecrets) GetSecret(_ context.Context, name string) (string, error) {
+	value, ok := secrets[name]
+	if !ok {
+		return "", fmt.Errorf("missing secret")
+	}
+	return value, nil
+}
+
+type rabbitTestCapabilities struct {
+	transport connectors.NetworkTransport
+}
+
+func (capabilities rabbitTestCapabilities) RuntimeCapability(name string) connectors.RuntimeCapability {
+	if name == connectors.NetworkTransportCapabilityName {
+		return capabilities.transport
+	}
+	return nil
+}
+
+type rabbitHTTPTransport struct {
+	targetAddr string
+	requests   []connectors.NetworkDialRequest
+}
+
+func (rabbitHTTPTransport) ConnectorRuntimeCapability() string {
+	return connectors.NetworkTransportCapabilityName
+}
+
+func (transport rabbitHTTPTransport) DialConnectorTCP(ctx context.Context, request connectors.NetworkDialRequest) (net.Conn, error) {
+	if request.Mode != "direct" {
+		return nil, fmt.Errorf("mode = %q", request.Mode)
+	}
+	if request.Host == "" || request.Port == 0 {
+		return nil, fmt.Errorf("invalid dial request: %#v", request)
+	}
+	return (&net.Dialer{}).DialContext(ctx, "tcp", transport.targetAddr)
+}
+
+func TestActionListNames(t *testing.T) {
+	actions, err := Connector{}.GetActionList(context.Background(), connectors.TargetView{}, connectors.CredentialProfileView{})
+	if err != nil {
+		t.Fatalf("actions: %v", err)
+	}
+	names := make([]string, 0, len(actions))
+	for _, action := range actions {
+		names = append(names, action.Name)
+	}
+	want := []string{ActionOverview, ActionListVhosts, ActionListQueues, ActionGetQueue, ActionListBindings, ActionPeekMessages, ActionPublish}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("names = %#v", names)
+	}
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 AIPermission has published its first public release candidate and is moving
 into the connector-native 0.2 line. The local-only permission gateway is usable
-today with built-in SSH, Postgres, and Redis connectors; the next releases focus on
+today with built-in SSH, Postgres, Redis, and RabbitMQ connectors; the next releases focus on
 dogfooding polish, small safety improvements, clearer contributor paths, and
 additional connector kinds such as API, queues, and storage that share one
 permission pipeline.
@@ -53,7 +53,7 @@ AIPermission is intentionally:
 - Local-only.
 - Single-user.
 - Developer-focused.
-- Connector-based, with built-in SSH, Postgres, and Redis.
+- Connector-based, with built-in SSH, Postgres, Redis, and RabbitMQ.
 - Human-in-the-loop.
 
 These requests conflict with the project principles and should normally be
@@ -184,6 +184,8 @@ Goals:
 - Add Postgres as the first structured connector.
 - Add Redis as the first cache/key-value connector with direct and SSH-tunneled
   TCP transport.
+- Add RabbitMQ as the first queue connector with direct and SSH-tunneled
+  Management API access.
 - Store connector permissions by target/profile/action instead of by a
   connector-specific table.
 - Render connector UI through frontend templates so contributors can add a
@@ -208,8 +210,8 @@ Non-goals:
 These may be useful, but they are not required for the RC:
 
 - [ ] API connector definitions from operator-reviewed JSON.
-- [ ] Queue connector exploration after Redis/Postgres prove the shared
-  target/profile/action model.
+- [ ] Expand queue connector destructive operations after RabbitMQ
+  `publish_message` is dogfooded.
 - [ ] Optional sensitive/no-persist console sessions.
 - [ ] Export filters for History and Audit data.
 - [ ] FTS5 search only if the SQLCipher driver/build supports it without

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -1,9 +1,9 @@
 # MCP Tools
 
 The MCP surface is connector-first. AIPermission does not expose separate
-product-specific MCP wrappers for SSH or database products. SSH, Postgres, and
-future integrations are reached through the same connector target/action
-pipeline.
+product-specific MCP wrappers for SSH, database, cache, or queue products. SSH,
+Postgres, Redis, RabbitMQ, and future integrations are reached through the same
+connector target/action pipeline.
 
 Recommended package use:
 
@@ -49,15 +49,17 @@ Examples:
 ```txt
 ssh:3:1
 postgres:7:2
+redis:8:3
+rabbitmq:9:4
 ```
 
 The profile chooses which stored credential is used. The connector action still
 runs locally through the gateway; AIPermission does not host a remote connector
 service.
 
-Clients should discover targets and actions at runtime. Do not hardcode SSH or
-Postgres as special MCP modes; future connector kinds use the same tools and
-`target_ref` shape.
+Clients should discover targets and actions at runtime. Do not hardcode SSH,
+Postgres, Redis, or RabbitMQ as special MCP modes; future connector kinds use
+the same tools and `target_ref` shape.
 
 ## list_connector_targets
 
@@ -132,6 +134,15 @@ Postgres managed database users are created from the local UI through credential
 provisioning, which uses an admin profile to create a scoped role with a random
 password and stores the resulting profile in the encrypted local vault.
 Postgres backup/restore is also a local UI operator flow, not an MCP action.
+
+Redis actions include bounded key scanning, key inspection, string writes, TTL
+updates, and explicit key deletes.
+
+RabbitMQ actions include overview metadata, visible vhost listing, bounded
+queue listing, queue detail reads, binding listing, and bounded message peeking
+with `ack_requeue_true`, plus explicit `publish_message` writes. Message
+payload previews and published payloads may contain secrets or customer data;
+prefer approval-required access until the workflow is trusted.
 
 ## call_connector_action
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -59,6 +59,7 @@ GET /api/connector-targets
 GET /api/connector-targets/inventory
 POST /api/connector-targets/with-profile
 POST /api/connector-targets
+POST /api/connector-targets/ping
 POST /api/connector-targets/test
 GET /api/connector-targets/{id}
 PUT /api/connector-targets/{id}/with-profile/{profile_id}
@@ -200,6 +201,25 @@ route is implemented for the SSH adapter because host-key approval and
 gateway-managed key selection happen before the target is saved. Other
 connectors should normally use saved profile tests through
 `POST /api/connector-targets/{id}/profiles/{profile_id}/test`.
+
+`POST /api/connector-targets/ping` runs four bounded TCP reachability checks
+from the selected connection mode. This is a local UI helper for connector forms
+and does not use credential secrets or connector action permissions. It checks
+the service port, not ICMP ping:
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 5432,
+  "mode": "over_ssh",
+  "transport_target_ref": "ssh:3:5",
+  "attempts": 4
+}
+```
+
+When `mode=over_ssh`, the TCP checks are dialed through the referenced SSH
+connector profile so the result matches what Redis, Postgres, RabbitMQ, or a
+future TCP-backed connector would see from that SSH target.
 
 `POST /api/connector-targets/{id}/operations/docker-check` runs a read-only,
 on-demand Docker status command through the SSH connector adapter. It does not

--- a/docs/development/add-a-connector.md
+++ b/docs/development/add-a-connector.md
@@ -359,6 +359,24 @@ Redis checklist:
 - frontend smoke/runtime tests that assert the shipped connector folders
 - README, REST/MCP docs, and connector-specific safety notes
 
+## Built-In Example: RabbitMQ
+
+The built-in RabbitMQ connector follows the same normal structured connector
+path as Redis:
+
+- target fields such as connection mode, scheme, host, port, default vhost, and
+  optional SSH transport target ref
+- credential profile fields for RabbitMQ Management API username/password
+- actions such as `overview`, `list_vhosts`, `list_queues`, `get_queue`,
+  `list_bindings`, `peek_messages`, and `publish_message`
+- connector help that explains payload sensitivity, bounded peeking, and
+  write-scoped publishing
+- UI templates for RabbitMQ target rows, credential profiles, and queue-browser
+  console output
+
+It should not add RabbitMQ-specific permission tables, approval tables, history
+pages, audit routes, MCP tool families, or global UI pages.
+
 ## Postgres Safety Boundary
 
 The built-in Postgres connector is intentionally conservative. `query_readonly`

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -30,12 +30,12 @@ target + credential profile + action
   -> history + audit
 ```
 
-SSH, Postgres, and Redis are built-in connectors that share the same
+SSH, Postgres, Redis, and RabbitMQ are built-in connectors that share the same
 target/profile, permission, approval, history, and audit model. SSH owns a live
 terminal and file-transfer surface; Postgres owns structured database actions;
-Redis owns bounded key-browser actions. Future
-connectors should add their own execution surface without adding a new
-permission or audit pipeline.
+Redis owns bounded key-browser actions; RabbitMQ owns queue browsing and
+bounded message previews. Future connectors should add their own execution
+surface without adding a new permission or audit pipeline.
 
 The 0.2 connector line is treated as a clean connector-schema boundary. It is
 allowed to make breaking local database changes while the project is still

--- a/docs/mvp/scope.md
+++ b/docs/mvp/scope.md
@@ -11,7 +11,7 @@ Main target:
 The MVP is not a DevOps platform. It does not own production operations. It gives a developer a controlled, token-scoped, auditable execution channel for debugging, maintenance, incident triage, and temporary AI-assisted automation.
 
 The MVP does not introduce first-class management modules for every external
-system. It introduces one connector pipeline. SSH, Postgres, Redis, and future
+system. It introduces one connector pipeline. SSH, Postgres, Redis, RabbitMQ, and future
 integrations are connector kinds that provide their own actions while sharing
 the same target/profile/action permission model. If an allowed SSH target has
 the needed CLI tools and access, the AI can operate at command level through

--- a/docs/project-principles.md
+++ b/docs/project-principles.md
@@ -8,7 +8,7 @@ part of the security model, not marketing copy.
 - Local-only
 - Single-user
 - Developer-focused
-- Connector-based, with built-in SSH, Postgres, and Redis
+- Connector-based, with built-in SSH, Postgres, Redis, and RabbitMQ
 - Human-in-the-loop
 
 ## AIPermission Intentionally Rejects

--- a/docs/skills/aipermission-docs/SKILL.md
+++ b/docs/skills/aipermission-docs/SKILL.md
@@ -133,7 +133,7 @@ Use the established aipermission naming:
 - `gateway` is the local backend that owns credentials, policy, execution, approvals, and audit.
 - `MCP client` means Cursor, Windsurf, or another AI tool integration.
 - `API token` means the gateway access token used by MCP/API clients.
-- `connector target` means a saved SSH, Postgres, Redis, or future integration target.
+- `connector target` means a saved SSH, Postgres, Redis, RabbitMQ, or future integration target.
 - `server` is acceptable only when specifically describing an SSH connector target.
 - `database` means a configured Postgres connector target/profile.
 - `execution rule` means `always_run`, `approval_required`, or `blocked`.

--- a/docs/skills/aipermission-operator/SKILL.md
+++ b/docs/skills/aipermission-operator/SKILL.md
@@ -46,6 +46,8 @@ Good reasons:
 Check Docker service state before cleanup.
 Inspect recent kubelet errors on worker node.
 List Postgres schemas before a read-only metadata query.
+Peek a RabbitMQ queue after the operator approved payload inspection. Publish
+RabbitMQ messages only when the operator explicitly asked for a write.
 ```
 
 Avoid vague reasons:

--- a/docs/whatis-aipermission.md
+++ b/docs/whatis-aipermission.md
@@ -13,11 +13,13 @@ Related central notes:
 operate on connector targets without receiving SSH private keys, SSH passwords,
 database credentials, API credentials, or other connector secrets.
 
-The current model ships with SSH, Postgres, and Redis connectors. SSH provides
-live terminal/file-transfer actions, Postgres provides structured metadata and
-bounded read-only query actions, and Redis provides bounded key browsing plus
-explicit write/delete actions. They use the same target, credential profile,
-token permission, approval, history, and audit pipeline.
+The current model ships with SSH, Postgres, Redis, and RabbitMQ connectors. SSH
+provides live terminal/file-transfer actions, Postgres provides structured
+metadata and bounded read-only query actions, Redis provides bounded key
+browsing plus explicit write/delete actions, and RabbitMQ provides queue
+metadata, bindings, bounded message previews, and explicit message publishing.
+They use the same target, credential profile, token permission, approval,
+history, and audit pipeline.
 
 The product is intentionally not positioned as a full DevOps platform.
 
@@ -251,8 +253,8 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-SSH, Postgres, Redis, and future integrations are exposed as connector actions instead
-of separate product-specific MCP tools.
+SSH, Postgres, Redis, RabbitMQ, and future integrations are exposed as
+connector actions instead of separate product-specific MCP tools.
 
 ## Connector Action Flow
 

--- a/frontend/src/connectors/templates/host-ping-button.jsx
+++ b/frontend/src/connectors/templates/host-ping-button.jsx
@@ -1,0 +1,113 @@
+import { Activity, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { useState } from "react";
+import { Badge } from "../../components/ui/badge";
+import { Button } from "../../components/ui/button";
+import { Dialog } from "../../components/ui/dialog";
+import { Notice } from "../../components/ui/notice";
+import { apiPost } from "../../lib/api";
+
+export function HostPingButton({ host, port, mode = "direct", transportTargetRef = "", label = "Ping host" }) {
+  const [dialog, setDialog] = useState({ open: false, state: "idle", result: null, error: "" });
+  const normalizedMode = mode || "direct";
+  const numericPort = Number(port);
+  const disabledReason = pingDisabledReason({ host, port: numericPort, mode: normalizedMode, transportTargetRef });
+
+  async function runPing(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (disabledReason) return;
+    setDialog({ open: true, state: "running", result: null, error: "" });
+    try {
+      const result = await apiPost("/api/connector-targets/ping", {
+        host,
+        port: numericPort,
+        mode: normalizedMode,
+        transport_target_ref: transportTargetRef || "",
+        attempts: 4,
+      });
+      setDialog({ open: true, state: "done", result, error: "" });
+    } catch (error) {
+      setDialog({ open: true, state: "error", result: null, error: error.message || "Ping failed." });
+    }
+  }
+
+  function closeDialog() {
+    setDialog((current) => ({ ...current, open: false }));
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-8 w-8 shrink-0 px-0"
+        title={disabledReason || label}
+        aria-label={label}
+        disabled={Boolean(disabledReason)}
+        onClick={runPing}
+      >
+        <Activity className="h-4 w-4" />
+      </Button>
+      <Dialog
+        open={dialog.open}
+        title="Host reachability"
+        description={`${modeLabel(normalizedMode)} TCP check for ${host || "host"}:${numericPort || "port"}`}
+        onClose={closeDialog}
+        closeOnOverlay={false}
+        size="md"
+      >
+        <div className="grid gap-4">
+          {dialog.state === "running" ? (
+            <Notice>
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Running 4 reachability checks...
+              </span>
+            </Notice>
+          ) : null}
+          {dialog.error ? <Notice tone="bad">{dialog.error}</Notice> : null}
+          {dialog.result ? (
+            <>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge tone={dialog.result.ok ? "good" : dialog.result.received > 0 ? "warn" : "bad"}>{dialog.result.received}/{dialog.result.sent} reachable</Badge>
+                <Badge tone="neutral">{dialog.result.duration_ms} ms total</Badge>
+                <Badge tone="neutral">{modeLabel(dialog.result.mode)}</Badge>
+              </div>
+              <Notice tone={dialog.result.ok ? "good" : "warn"}>{dialog.result.message}</Notice>
+              <div className="overflow-hidden rounded-lg border border-stone-200">
+                {(dialog.result.attempts || []).map((attempt) => (
+                  <div key={attempt.attempt} className="grid gap-2 border-b border-stone-200 px-3 py-2 last:border-b-0 sm:grid-cols-[92px_120px_minmax(0,1fr)]">
+                    <span className="text-sm font-semibold text-stone-900">Attempt {attempt.attempt}</span>
+                    <span className={`inline-flex items-center gap-1.5 text-sm font-semibold ${attempt.ok ? "text-emerald-700" : "text-red-700"}`}>
+                      {attempt.ok ? <CheckCircle2 className="h-4 w-4" /> : <XCircle className="h-4 w-4" />}
+                      {attempt.ok ? "reachable" : "failed"}
+                    </span>
+                    <span className="min-w-0 truncate font-mono text-xs text-stone-500" title={attempt.error || `${attempt.duration_ms} ms`}>
+                      {attempt.error || `${attempt.duration_ms} ms`}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : null}
+          <div className="flex justify-end">
+            <Button type="button" variant="outline" onClick={closeDialog}>
+              Close
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    </>
+  );
+}
+
+function pingDisabledReason({ host, port, mode, transportTargetRef }) {
+  if (!String(host || "").trim()) return "Enter a host first.";
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return "Enter a valid port first.";
+  if (mode === "over_ssh" && !String(transportTargetRef || "").trim()) return "Select an SSH transport profile first.";
+  return "";
+}
+
+function modeLabel(mode) {
+  return mode === "over_ssh" ? "Over SSH" : "Direct";
+}

--- a/frontend/src/connectors/templates/postgres/form.jsx
+++ b/frontend/src/connectors/templates/postgres/form.jsx
@@ -1,5 +1,6 @@
 import { Field, Input, Select } from "../../../components/ui/form";
 import { Notice } from "../../../components/ui/notice";
+import { HostPingButton } from "../host-ping-button";
 
 export function PostgresConnectorFormTemplate({ form, mode = "create", targets = [], onChange }) {
   const editing = mode === "edit";
@@ -40,10 +41,17 @@ export function PostgresConnectorFormTemplate({ form, mode = "create", targets =
         <Notice>
           Host and port are resolved from the SSH server. Use 127.0.0.1:5432 when Postgres only listens on the remote machine.
         </Notice>
-      ) : null}
+      ) : (
+        <Notice>
+          For Postgres running on the same Linux host as AIPermission Docker, use host.docker.internal instead of localhost.
+        </Notice>
+      )}
       <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_120px]">
         <Field>
-          Host
+          <span className="flex items-center justify-between gap-2">
+            <span>Host</span>
+            <HostPingButton host={form.host} port={form.port} mode={form.connection_mode} transportTargetRef={form.transport_target_ref} />
+          </span>
           <Input value={form.host} onChange={(event) => onChange("host", event.target.value)} required />
         </Field>
         <Field>

--- a/frontend/src/connectors/templates/rabbitmq/console.jsx
+++ b/frontend/src/connectors/templates/rabbitmq/console.jsx
@@ -1,0 +1,608 @@
+import { Database, Eye, ListTree, RefreshCcw, Search, Send } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "../../../components/ui/badge";
+import { Button } from "../../../components/ui/button";
+import { CopyButton } from "../../../components/ui/copy-button";
+import { Input, Textarea } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+import { TerminalBlock } from "../../../components/ui/terminal-block";
+import { apiPost } from "../../../lib/api";
+
+const defaultQueueLimit = 250;
+const defaultPeekCount = 5;
+const defaultPayloadBytes = 65536;
+
+export function RabbitMQConnectorConsoleTemplate({ target, approvals, theme, session, onNewStructuredSession, onRefreshActivity }) {
+  const activeSession = session || { active: false, startedAt: "" };
+  const [pattern, setPattern] = useState("");
+  const [vhost, setVhost] = useState(target.config?.vhost || "/");
+  const [queues, setQueues] = useState([]);
+  const [activeQueue, setActiveQueue] = useState("");
+  const [queueDetail, setQueueDetail] = useState(null);
+  const [bindings, setBindings] = useState([]);
+  const [messages, setMessages] = useState([]);
+  const [peekCount, setPeekCount] = useState(defaultPeekCount);
+  const [detailMode, setDetailMode] = useState("inspect");
+  const [publishExchange, setPublishExchange] = useState("amq.default");
+  const [customRoutingKey, setCustomRoutingKey] = useState(false);
+  const [publishRoutingKey, setPublishRoutingKey] = useState("");
+  const [publishPayload, setPublishPayload] = useState("");
+  const [publishProperties, setPublishProperties] = useState('{"content_type":"application/json"}');
+  const [state, setState] = useState({ state: "idle", error: "", message: "" });
+  const panelClass = theme === "light" ? "bg-white text-stone-900" : "bg-[#1e1e1e] text-stone-100";
+  const mutedClass = theme === "light" ? "text-stone-500" : "text-stone-400";
+  const borderClass = theme === "light" ? "border-stone-200" : "border-stone-700";
+  const subtlePanelClass = theme === "light" ? "bg-stone-50" : "bg-[#252526]";
+  const inputClass = theme === "light" ? "border-stone-300 bg-white text-stone-900 placeholder:text-stone-400" : "border-stone-700 bg-[#1a1a1a] text-stone-100 placeholder:text-stone-500";
+  const rowHoverClass = theme === "light" ? "hover:bg-stone-50" : "hover:bg-stone-800/60";
+  const activeRowClass = theme === "light" ? "border-emerald-200 bg-emerald-50 text-emerald-950" : "border-emerald-700 bg-emerald-950/40 text-emerald-100";
+  const activeItems = useMemo(() => (approvals?.data || []).filter((item) => item.target_ref === target.ref), [approvals?.data, target.ref]);
+  const latestAction = activeItems[0] || null;
+  const filteredQueues = useMemo(() => filterQueues(queues, pattern), [queues, pattern]);
+
+  useEffect(() => {
+    setVhost(target.config?.vhost || "/");
+    setQueues([]);
+    setActiveQueue("");
+    setQueueDetail(null);
+    setBindings([]);
+    setMessages([]);
+    setPattern("");
+    setPeekCount(defaultPeekCount);
+    setDetailMode("inspect");
+    setPublishExchange("amq.default");
+    setCustomRoutingKey(false);
+    setPublishRoutingKey("");
+    setPublishPayload("");
+    setPublishProperties('{"content_type":"application/json"}');
+  }, [target.ref, activeSession.active, activeSession.startedAt]);
+
+  useEffect(() => {
+    if (!activeSession.active) return;
+    void refreshQueues();
+  }, [activeSession.active, activeSession.startedAt, target.ref]);
+
+  async function runRabbitAction({ actionName, input, reason, busy = "running", suppressError = false }) {
+    setState({ state: busy, error: "", message: "" });
+    try {
+      const item = await apiPost("/api/connector-actions/local-run", {
+        target_ref: target.ref,
+        action_name: actionName,
+        input,
+        reason,
+      });
+      setState({ state: "idle", error: "", message: item.display_text || "" });
+      await onRefreshActivity?.();
+      return item;
+    } catch (error) {
+      if (suppressError) {
+        setState({ state: "idle", error: "", message: "" });
+      } else {
+        setState({ state: "error", error: error.message || "RabbitMQ action failed.", message: "" });
+      }
+      throw error;
+    }
+  }
+
+  async function refreshQueues() {
+    if (!activeSession.active) return;
+    const queueItem = await runRabbitAction({
+      actionName: "list_queues",
+      input: { vhost, pattern: "", limit: defaultQueueLimit },
+      reason: "manual RabbitMQ browser queue list",
+      busy: "loading",
+    });
+    const nextQueues = Array.isArray(queueItem.output?.queues) ? queueItem.output.queues : [];
+    setQueues(nextQueues);
+    if (activeQueue && !nextQueues.some((queue) => queue.name === activeQueue)) {
+      setActiveQueue("");
+      setQueueDetail(null);
+      setBindings([]);
+      setMessages([]);
+    }
+  }
+
+  async function selectQueue(queueName) {
+    if (!activeSession.active || !queueName) return;
+    setActiveQueue(queueName);
+    setDetailMode("inspect");
+    setCustomRoutingKey(false);
+    setPublishRoutingKey(queueName);
+    setMessages([]);
+    const detailItem = await runRabbitAction({ actionName: "get_queue", input: { vhost, queue: queueName }, reason: "manual RabbitMQ browser queue detail", busy: "reading" });
+    setQueueDetail(detailItem.output || null);
+    try {
+      const bindingItem = await runRabbitAction({ actionName: "list_bindings", input: { vhost, queue: queueName, limit: 250 }, reason: "manual RabbitMQ browser queue bindings", busy: "reading", suppressError: true });
+      setBindings(Array.isArray(bindingItem.output?.bindings) ? bindingItem.output.bindings : []);
+    } catch {
+      setBindings([]);
+    }
+  }
+
+  async function peekMessages() {
+    if (!activeQueue) return;
+    const item = await runRabbitAction({
+      actionName: "peek_messages",
+      input: { vhost, queue: activeQueue, count: Number(peekCount) || defaultPeekCount, max_payload_bytes: defaultPayloadBytes },
+      reason: "manual RabbitMQ browser message peek",
+      busy: "peeking",
+    });
+    setMessages(Array.isArray(item.output?.messages) ? item.output.messages : []);
+  }
+
+  function startPublish() {
+    setDetailMode("publish");
+    setState({ state: "idle", error: "", message: "" });
+    if (!publishRoutingKey.trim() && activeQueue) {
+      setCustomRoutingKey(false);
+      setPublishRoutingKey(activeQueue);
+    }
+  }
+
+  async function publishMessage(event) {
+    event.preventDefault();
+    if (!activeSession.active || state.state !== "idle") return;
+    const routingKey = publishRoutingKey.trim();
+    if (!routingKey || !publishPayload) {
+      setState({ state: "error", error: "Routing key and payload are required.", message: "" });
+      return;
+    }
+    let properties = {};
+    if (publishProperties.trim()) {
+      try {
+        properties = JSON.parse(publishProperties);
+      } catch {
+        setState({ state: "error", error: "Properties must be a JSON object.", message: "" });
+        return;
+      }
+      if (!properties || Array.isArray(properties) || typeof properties !== "object") {
+        setState({ state: "error", error: "Properties must be a JSON object.", message: "" });
+        return;
+      }
+    }
+    await runRabbitAction({
+      actionName: "publish_message",
+      input: {
+        vhost,
+        exchange: publishExchange.trim() || "amq.default",
+        routing_key: routingKey,
+        payload: publishPayload,
+        payload_encoding: "string",
+        properties,
+      },
+      reason: "manual RabbitMQ browser message publish",
+      busy: "publishing",
+    });
+    setPublishPayload("");
+    await refreshQueues();
+  }
+
+  if (!activeSession.active) {
+    return (
+      <div className={`grid min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
+        <div className="grid place-items-center p-8 text-center">
+          <div className="grid max-w-lg gap-4">
+            <Database className={`mx-auto h-10 w-10 ${mutedClass}`} />
+            <div>
+              <h3 className="text-lg font-semibold">No active RabbitMQ session</h3>
+              <p className={`mt-2 text-sm ${mutedClass}`}>Start a structured session to browse queues through the connector approval, history, and audit pipeline.</p>
+            </div>
+            <Button type="button" className="mx-auto" onClick={onNewStructuredSession}>
+              Start RabbitMQ session
+            </Button>
+          </div>
+        </div>
+        <RabbitEndpointFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
+      <div className="grid min-h-0 gap-4 overflow-hidden p-4 xl:grid-cols-[360px_minmax(0,1fr)]">
+        <section className={`grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+          <div className={`border-b p-3 ${borderClass}`}>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold">Queues</p>
+                <p className={`text-xs ${mutedClass}`}>{filteredQueues.length} shown · {queues.length} loaded</p>
+              </div>
+              <div className="flex items-center gap-2">
+                {latestAction ? <Badge tone={latestAction.status === "failed" ? "bad" : latestAction.status === "completed" ? "good" : "warn"}>{latestAction.action_name}</Badge> : null}
+                <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Refresh queues" onClick={refreshQueues} disabled={state.state !== "idle"}>
+                  <RefreshCcw className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          </div>
+          <form
+            className={`grid gap-2 border-b p-3 ${borderClass}`}
+            onSubmit={(event) => {
+              event.preventDefault();
+              void refreshQueues();
+            }}
+          >
+            <div className="relative">
+              <Search className={`pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 ${mutedClass}`} />
+              <Input className={`pl-9 ${inputClass}`} value={pattern} onChange={(event) => setPattern(event.target.value)} placeholder="Filter queues" />
+            </div>
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
+              <Input className={inputClass} value={vhost} onChange={(event) => setVhost(event.target.value)} placeholder="vhost" />
+              <Button type="submit" variant="outline" className="h-9" disabled={state.state !== "idle"}>
+                {state.state === "loading" ? "Loading" : "Refresh"}
+              </Button>
+            </div>
+          </form>
+          <div className="min-h-0 overflow-auto p-2">
+            {filteredQueues.map((queue) => (
+              <button
+                key={`${queue.vhost || vhost}:${queue.name}`}
+                type="button"
+                className={`mb-1 grid w-full gap-1 rounded-md border px-3 py-2 text-left text-sm transition ${activeQueue === queue.name ? activeRowClass : `${borderClass} ${rowHoverClass}`}`}
+                onClick={() => selectQueue(queue.name)}
+              >
+                <span className="truncate font-mono text-xs font-semibold" title={queue.name}>{queue.name}</span>
+                <span className={`text-xs ${activeQueue === queue.name ? "" : mutedClass}`}>
+                  ready {numberText(queue.messages_ready)} · unacked {numberText(queue.messages_unacknowledged)} · consumers {numberText(queue.consumers)}
+                </span>
+              </button>
+            ))}
+            {filteredQueues.length === 0 ? <Notice>{state.state === "loading" ? "Loading RabbitMQ queues..." : "No queues found for this vhost/filter."}</Notice> : null}
+          </div>
+          <div className={`border-t p-3 ${borderClass}`}>
+            <QueueTotalsStrip queues={queues} mutedClass={mutedClass} />
+          </div>
+        </section>
+
+        <section className={`grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden rounded-lg border ${borderClass}`}>
+          <div className={`flex flex-wrap items-center justify-between gap-3 border-b p-3 ${borderClass} ${subtlePanelClass}`}>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold">{detailMode === "publish" ? "Publish message" : activeQueue || "Queue detail"}</p>
+              <p className={`truncate text-xs ${mutedClass}`}>
+                {detailMode === "publish"
+                  ? publishHelpText(activeQueue)
+                  : queueDetail
+                    ? queueMetaText(queueDetail)
+                    : "Select a queue to inspect counters, bindings, and bounded message previews."}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {detailMode === "inspect" && queueDetail?.state ? <Badge tone={queueDetail.state === "running" ? "good" : "warn"}>{queueDetail.state}</Badge> : null}
+              {detailMode === "inspect" && queueDetail ? <CopyButton value={JSON.stringify({ queue: queueDetail, bindings, messages }, null, 2)} variant="outline" className="h-8 px-2 text-xs" title="Copy queue JSON">JSON</CopyButton> : null}
+            </div>
+          </div>
+          <div className={`flex flex-wrap items-center justify-between gap-2 border-b p-3 ${borderClass}`}>
+            <div className="flex min-w-0 items-center gap-2">
+              {detailMode === "publish" ? (
+                <>
+                  <Send className={`h-4 w-4 ${mutedClass}`} />
+                  <span className={`text-xs ${mutedClass}`}>New write action</span>
+                </>
+              ) : (
+                <>
+                  <ListTree className={`h-4 w-4 ${mutedClass}`} />
+                  <span className={`text-xs ${mutedClass}`}>{bindings.length} binding(s)</span>
+                </>
+              )}
+            </div>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              {detailMode === "publish" ? (
+                <Button type="button" variant="outline" className="h-8 px-3 text-xs" onClick={() => setDetailMode("inspect")}>
+                  Back to detail
+                </Button>
+              ) : (
+                <>
+                  <Input
+                    className={`h-8 w-24 ${inputClass}`}
+                    type="number"
+                    min="1"
+                    max="50"
+                    value={peekCount}
+                    onChange={(event) => setPeekCount(event.target.value)}
+                    aria-label="Peek count"
+                  />
+                  <Button type="button" className="h-8 px-3 text-xs" disabled={!activeQueue || state.state !== "idle"} onClick={peekMessages}>
+                    <Eye className="h-3.5 w-3.5" />
+                    Peek
+                  </Button>
+                  <Button type="button" variant="outline" className="h-8 px-3 text-xs" disabled={state.state !== "idle"} onClick={startPublish}>
+                    <Send className="h-3.5 w-3.5" />
+                    Publish
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+          <div className="min-h-0 overflow-hidden p-4">
+            {detailMode === "publish" ? (
+              <form className="grid h-full min-h-0 grid-rows-[auto_auto_auto_minmax(0,1fr)_auto] gap-3" onSubmit={publishMessage}>
+                <Notice tone="warn">
+                  This creates a new RabbitMQ message. With the default exchange, set Routing key to the destination queue name.
+                </Notice>
+                <div className="grid gap-2 md:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+                  <FieldBlock label="Exchange" help="amq.default is RabbitMQ's default exchange. It routes directly to the queue named by the routing key." mutedClass={mutedClass}>
+                    <Input className={inputClass} value={publishExchange} onChange={(event) => setPublishExchange(event.target.value)} placeholder="amq.default" aria-label="Publish exchange" />
+                  </FieldBlock>
+                  <FieldBlock label="Routing key" help={activeQueue ? `Use ${activeQueue} to publish to the selected queue via amq.default.` : "Usually the queue name when using amq.default."} mutedClass={mutedClass}>
+                    <div className={`grid gap-2 ${customRoutingKey ? "md:grid-cols-2" : ""}`}>
+                      <RoutingKeyPicker
+                        queues={queues}
+                        value={publishRoutingKey}
+                        custom={customRoutingKey}
+                        onQueue={(queueName) => {
+                          setCustomRoutingKey(false);
+                          setPublishRoutingKey(queueName);
+                        }}
+                        onCustom={() => {
+                          setCustomRoutingKey(true);
+                          if (!publishRoutingKey.trim()) {
+                            setPublishRoutingKey("");
+                          }
+                        }}
+                        inputClass={inputClass}
+                        borderClass={borderClass}
+                        mutedClass={mutedClass}
+                        subtlePanelClass={subtlePanelClass}
+                        rowHoverClass={rowHoverClass}
+                        activeRowClass={activeRowClass}
+                      />
+                      {customRoutingKey ? (
+                        <Input className={inputClass} value={publishRoutingKey} onChange={(event) => setPublishRoutingKey(event.target.value)} placeholder="Custom routing key" aria-label="Custom routing key" />
+                      ) : null}
+                    </div>
+                  </FieldBlock>
+                </div>
+                <FieldBlock label="Properties JSON" help="Optional AMQP properties. content_type helps consumers parse JSON payloads." mutedClass={mutedClass}>
+                  <Input className={inputClass} value={publishProperties} onChange={(event) => setPublishProperties(event.target.value)} placeholder='{"content_type":"application/json"}' aria-label="Publish properties JSON" />
+                </FieldBlock>
+                <FieldBlock label="Payload" help="Message body to publish. Keep secrets out unless this write was explicitly approved." mutedClass={mutedClass} grow>
+                  <Textarea className={`h-full min-h-0 resize-none font-mono text-xs ${inputClass}`} value={publishPayload} onChange={(event) => setPublishPayload(event.target.value)} placeholder='{"type":"test","ok":true}' aria-label="Publish payload" />
+                </FieldBlock>
+                <div className="flex justify-end">
+                  <Button type="submit" className="h-9 px-4 text-sm" disabled={state.state !== "idle" || !publishRoutingKey.trim() || !publishPayload}>
+                    <Send className="h-4 w-4" />
+                    Publish message
+                  </Button>
+                </div>
+              </form>
+            ) : (
+              <div className="grid h-full min-h-0 gap-4 overflow-hidden lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+                <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-2">
+                  <p className={`text-xs font-semibold uppercase ${mutedClass}`}>Queue and bindings</p>
+                  <TerminalBlock surface="log" className="min-h-0 text-xs">{queueDetail ? JSON.stringify({ queue: queueDetail, bindings }, null, 2) : "No queue selected."}</TerminalBlock>
+                </div>
+                <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-2">
+                  <p className={`text-xs font-semibold uppercase ${mutedClass}`}>Messages</p>
+                  <TerminalBlock surface="log" className="min-h-0 text-xs">{messages.length ? formatMessages(messages) : "No messages peeked in this session."}</TerminalBlock>
+                </div>
+              </div>
+            )}
+          </div>
+          <div className={`grid gap-3 border-t p-3 ${borderClass}`}>
+            <Notice tone="warn">Peek uses ack_requeue_true with bounded count and payload truncation. Avoid reading payloads unless the operator approved that access.</Notice>
+            <Notice tone="warn">Publish creates a new RabbitMQ message and uses the write permission for this connector action.</Notice>
+            {state.error ? <Notice tone="bad">{state.error}</Notice> : null}
+            {state.message ? <Notice tone="good">{state.message}</Notice> : null}
+          </div>
+        </section>
+      </div>
+      <RabbitEndpointFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
+    </div>
+  );
+}
+
+function QueueTotalsStrip({ queues, mutedClass }) {
+  const totals = (queues || []).reduce(
+    (acc, queue) => ({
+      ready: acc.ready + numericValue(queue.messages_ready),
+      unacked: acc.unacked + numericValue(queue.messages_unacknowledged),
+      messages: acc.messages + numericValue(queue.messages),
+      consumers: acc.consumers + numericValue(queue.consumers),
+    }),
+    { ready: 0, unacked: 0, messages: 0, consumers: 0 }
+  );
+  return (
+    <div className="grid gap-1 text-xs">
+      <span>Loaded queue totals</span>
+      <span className={mutedClass}>
+        queues {queues.length} · messages {totals.messages} · ready {totals.ready} · unacked {totals.unacked} · consumers {totals.consumers}
+      </span>
+    </div>
+  );
+}
+
+function RoutingKeyPicker({ queues, value, custom, onQueue, onCustom, inputClass, borderClass, mutedClass, subtlePanelClass, rowHoverClass, activeRowClass }) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const queueNames = useMemo(() => uniqueQueueNames(queues), [queues]);
+  const selectedLabel = custom ? "Custom routing key" : value || "";
+  const visibleQueues = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return queueNames.slice(0, 80);
+    return queueNames.filter((name) => name.toLowerCase().includes(needle)).slice(0, 80);
+  }, [queueNames, query]);
+  const options = useMemo(
+    () => [
+      { kind: "custom", label: "Custom routing key", help: "Type an exchange-specific routing key manually." },
+      ...visibleQueues.map((queueName) => ({ kind: "queue", label: queueName, help: "Queue routing key via amq.default" })),
+    ],
+    [visibleQueues]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setActiveIndex((index) => Math.min(Math.max(index, 0), Math.max(options.length - 1, 0)));
+  }, [open, options.length]);
+
+  function chooseCustom(event) {
+    event.preventDefault();
+    onCustom();
+    setOpen(false);
+    setQuery("");
+  }
+
+  function chooseQueue(event, queueName) {
+    event.preventDefault();
+    onQueue(queueName);
+    setOpen(false);
+    setQuery("");
+  }
+
+  function chooseOption(event, option) {
+    if (!option) return;
+    if (option.kind === "custom") {
+      chooseCustom(event);
+      return;
+    }
+    chooseQueue(event, option.label);
+  }
+
+  function handleKeyDown(event) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setOpen(true);
+      setActiveIndex((index) => (index + 1) % Math.max(options.length, 1));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setOpen(true);
+      setActiveIndex((index) => (index - 1 + Math.max(options.length, 1)) % Math.max(options.length, 1));
+      return;
+    }
+    if ((event.key === "Enter" || event.key === "Tab") && open) {
+      chooseOption(event, options[activeIndex]);
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setOpen(false);
+      setQuery("");
+    }
+  }
+
+  return (
+    <div className="relative">
+      <Input
+        aria-activedescendant={open ? `rabbit-routing-option-${activeIndex}` : undefined}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        role="combobox"
+        className={inputClass}
+        value={open ? query : selectedLabel}
+        onFocus={() => {
+          setOpen(true);
+          setQuery("");
+          setActiveIndex(0);
+        }}
+        onBlur={() => {
+          window.setTimeout(() => setOpen(false), 120);
+        }}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setOpen(true);
+          setActiveIndex(0);
+        }}
+        onKeyDown={handleKeyDown}
+        placeholder="Search queue routing keys"
+        aria-label="Search queue routing keys"
+      />
+      {open ? (
+        <div className={`absolute left-0 right-0 top-[calc(100%+4px)] z-20 max-h-64 overflow-auto rounded-md border p-1 shadow-xl ${borderClass} ${subtlePanelClass}`} role="listbox">
+          {options.map((option, index) => (
+            <button
+              key={`${option.kind}:${option.label}`}
+              id={`rabbit-routing-option-${index}`}
+              type="button"
+              role="option"
+              aria-selected={index === activeIndex}
+              className={`grid w-full gap-0.5 rounded px-2 py-2 text-left text-sm ${index === activeIndex ? activeRowClass : rowHoverClass}`}
+              onMouseEnter={() => setActiveIndex(index)}
+              onMouseDown={(event) => chooseOption(event, option)}
+            >
+              <span className={`${option.kind === "queue" ? "truncate font-mono text-xs" : ""} font-semibold`}>{option.label}</span>
+              <span className={`text-xs ${mutedClass}`}>{option.help}</span>
+            </button>
+          ))}
+          {visibleQueues.length === 0 ? <div className={`px-2 py-3 text-xs ${mutedClass}`}>No queue matches this search.</div> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FieldBlock({ label, help, mutedClass, children, grow = false }) {
+  return (
+    <label className={`grid min-h-0 gap-1 text-sm font-medium ${grow ? "grid-rows-[auto_minmax(0,1fr)_auto]" : ""}`}>
+      <span>{label}</span>
+      {children}
+      {help ? <span className={`text-xs font-normal ${mutedClass}`}>{help}</span> : null}
+    </label>
+  );
+}
+
+function publishHelpText(activeQueue) {
+  if (activeQueue) {
+    return `Publishing to ${activeQueue} through amq.default uses routing_key=${activeQueue}.`;
+  }
+  return "Create one RabbitMQ message through the connector write permission.";
+}
+
+function RabbitEndpointFooter({ target, borderClass, mutedClass }) {
+  return (
+    <div className={`flex min-w-0 items-center justify-between gap-3 border-t px-3 py-2 text-xs ${borderClass}`}>
+      <span className={`truncate font-mono ${mutedClass}`}>{target.ref}</span>
+      <span className={`truncate ${mutedClass}`}>{target.config?.scheme || "http"}://{target.config?.host}:{target.config?.port || 15672} · vhost {target.config?.vhost || "/"}</span>
+    </div>
+  );
+}
+
+function filterQueues(queues, pattern) {
+  const needle = String(pattern || "").trim().toLowerCase();
+  if (!needle) return queues;
+  return queues.filter((queue) => String(queue.name || "").toLowerCase().includes(needle));
+}
+
+function uniqueQueueNames(queues) {
+  return Array.from(new Set((queues || []).map((queue) => String(queue.name || "").trim()).filter(Boolean))).sort((left, right) => left.localeCompare(right));
+}
+
+function queueMetaText(queue) {
+  return `ready ${numberText(queue.messages_ready)} · unacked ${numberText(queue.messages_unacknowledged)} · consumers ${numberText(queue.consumers)} · durable ${queue.durable ? "yes" : "no"}`;
+}
+
+function formatMessages(messages) {
+  return JSON.stringify(
+    messages.map((message, index) => ({
+      index: index + 1,
+      payload: formatPayload(message.payload),
+      payload_encoding: message.payload_encoding,
+      redelivered: message.redelivered,
+      properties: message.properties,
+    })),
+    null,
+    2
+  );
+}
+
+function formatPayload(payload) {
+  if (typeof payload !== "string") return payload;
+  const trimmed = payload.trim();
+  if (!trimmed) return payload;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return payload;
+  }
+}
+
+function numberText(value) {
+  if (value === undefined || value === null || value === "") return "0";
+  return String(value);
+}
+
+function numericValue(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}

--- a/frontend/src/connectors/templates/rabbitmq/credential-form.jsx
+++ b/frontend/src/connectors/templates/rabbitmq/credential-form.jsx
@@ -1,0 +1,67 @@
+import { Database, Plus } from "lucide-react";
+import { Button } from "../../../components/ui/button";
+import { Field, Input, Select } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+
+export function RabbitMQCredentialFormTemplate({ targets, form, formMode = "create", state, onChange, onSubmit }) {
+  const rabbitTargets = targets.filter((target) => target.connector_kind === "rabbitmq");
+  const editing = formMode === "edit";
+  return (
+    <form className="grid gap-4" onSubmit={onSubmit}>
+      {rabbitTargets.length === 0 ? (
+        <Notice tone="warn">Create a RabbitMQ connector target before adding a RabbitMQ credential profile.</Notice>
+      ) : (
+        <Notice tone="good">
+          {editing ? "Update public RabbitMQ profile metadata, or enter a new password to rotate the stored secret." : "Create a RabbitMQ profile, then bind tokens to this profile from Console or Tokens."}
+        </Notice>
+      )}
+      <Field>
+        Connector target
+        <Select value={form.target_id} onChange={(event) => onChange({ ...form, target_id: event.target.value })} disabled={editing} required>
+          <option value="" disabled>
+            Select RabbitMQ target
+          </option>
+          {rabbitTargets.map((target) => (
+            <option value={target.id} key={target.id}>
+          {target.name} · management {target.config?.scheme || "http"}://{target.config?.host}:{target.config?.port || 15672} · {target.config?.vhost || "/"}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange({ ...form, profile_label: event.target.value })} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange({ ...form, risk_label: event.target.value })} />
+        </Field>
+      </div>
+      <Field>
+        Username
+        <Input value={form.username} onChange={(event) => onChange({ ...form, username: event.target.value })} autoComplete="off" placeholder="RabbitMQ Management API username" required />
+      </Field>
+      <Field>
+        {editing ? "New password" : "Password"}
+        <Input
+          type="password"
+          value={form.password}
+          onChange={(event) => onChange({ ...form, password: event.target.value })}
+          autoComplete="new-password"
+          required={!editing}
+          placeholder={editing ? "Leave blank to keep current password" : "RabbitMQ Management API password"}
+        />
+      </Field>
+      {state.state === "error" ? <Notice tone="bad">{state.error}</Notice> : null}
+      <Button type="submit" disabled={state.state === "saving" || rabbitTargets.length === 0}>
+        <Plus className="h-4 w-4" />
+        {state.state === "saving" ? "Saving..." : editing ? "Save RabbitMQ credential" : "Create RabbitMQ credential"}
+      </Button>
+      <Notice>
+        <Database className="mr-2 inline h-4 w-4" />
+        RabbitMQ secrets are stored in the encrypted local database and are never returned to MCP or REST list responses.
+      </Notice>
+    </form>
+  );
+}

--- a/frontend/src/connectors/templates/rabbitmq/form.jsx
+++ b/frontend/src/connectors/templates/rabbitmq/form.jsx
@@ -1,0 +1,111 @@
+import { Field, Input, Select } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+import { HostPingButton } from "../host-ping-button";
+
+export function RabbitMQConnectorFormTemplate({ form, mode = "create", targets = [], onChange }) {
+  const editing = mode === "edit";
+  const sshProfiles = sshProfileOptions(targets);
+  const overSSH = form.connection_mode === "over_ssh";
+  return (
+    <>
+      <Notice tone="good">
+        RabbitMQ uses the Management API, not the AMQP listener. Use the port from the management URL, usually 15672, and start with Prompt permissions for message peeking.
+      </Notice>
+      <Field>
+        Connector name
+        <Input value={form.name} onChange={(event) => onChange("name", event.target.value)} required />
+      </Field>
+      <Field>
+        Connection mode
+        <Select value={form.connection_mode} onChange={(event) => onChange("connection_mode", event.target.value)}>
+          <option value="direct">Direct from this gateway</option>
+          <option value="over_ssh">Over an SSH connector profile</option>
+        </Select>
+      </Field>
+      {overSSH ? (
+        <Field>
+          SSH transport profile
+          <Select value={form.transport_target_ref} onChange={(event) => onChange("transport_target_ref", event.target.value)} required>
+            <option value="" disabled>
+              Select SSH profile
+            </option>
+            {sshProfiles.map((profile) => (
+              <option value={profile.ref} key={profile.ref}>
+                {profile.label}
+              </option>
+            ))}
+          </Select>
+        </Field>
+      ) : null}
+      {overSSH ? (
+        <Notice>
+          Host and port are resolved from the SSH server. Use 127.0.0.1:15672 when RabbitMQ Management only listens on the remote machine; do not use the AMQP port.
+        </Notice>
+      ) : (
+        <Notice>
+          For RabbitMQ Management running on the same Linux host as AIPermission Docker, use host.docker.internal instead of localhost.
+        </Notice>
+      )}
+      <div className="grid gap-3 sm:grid-cols-[120px_minmax(0,1fr)_120px]">
+        <Field>
+          Scheme
+          <Select value={form.scheme || "http"} onChange={(event) => onChange("scheme", event.target.value)}>
+            <option value="http">HTTP</option>
+            <option value="https">HTTPS</option>
+          </Select>
+        </Field>
+        <Field>
+          <span className="flex items-center justify-between gap-2">
+            <span>Management host</span>
+            <HostPingButton host={form.host} port={form.port} mode={form.connection_mode} transportTargetRef={form.transport_target_ref} />
+          </span>
+          <Input value={form.host} onChange={(event) => onChange("host", event.target.value)} required />
+        </Field>
+        <Field>
+          Management API port
+          <Input type="number" min="1" max="65535" value={form.port} onChange={(event) => onChange("port", event.target.value)} placeholder="15672" required />
+        </Field>
+      </div>
+      <Field>
+        Default vhost
+        <Input value={form.vhost} onChange={(event) => onChange("vhost", event.target.value)} placeholder="/" />
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange("profile_label", event.target.value)} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange("risk_label", event.target.value)} />
+        </Field>
+      </div>
+      <Field>
+        Username
+        <Input value={form.username} onChange={(event) => onChange("username", event.target.value)} autoComplete="off" placeholder="RabbitMQ Management API username" required />
+      </Field>
+      <Field>
+        Password
+        <Input
+          type="password"
+          value={form.password}
+          onChange={(event) => onChange("password", event.target.value)}
+          autoComplete="new-password"
+          required={!editing}
+          placeholder={editing ? "Leave blank to keep the current encrypted password" : "RabbitMQ Management API password"}
+        />
+      </Field>
+    </>
+  );
+}
+
+function sshProfileOptions(targets) {
+  return (targets || [])
+    .filter((target) => target.connector_kind === "ssh")
+    .flatMap((target) =>
+      (target.profiles || []).map((profile) => ({
+        ref: profile.ref || `${target.connector_kind}:${target.id}:${profile.id}`,
+        label: `${target.name} / ${profile.label} · ${target.config?.host || "host"}:${target.config?.port || 22}`,
+      }))
+    );
+}

--- a/frontend/src/connectors/templates/rabbitmq/index.jsx
+++ b/frontend/src/connectors/templates/rabbitmq/index.jsx
@@ -1,0 +1,15 @@
+import { RabbitMQConnectorConsoleTemplate } from "./console";
+import { RabbitMQCredentialFormTemplate } from "./credential-form";
+import { RabbitMQConnectorFormTemplate } from "./form";
+import { RabbitMQConnectorRowActionsTemplate } from "./list-item";
+import { RabbitMQConnectorOperationsTemplate } from "./operations";
+import * as model from "./model";
+
+export default Object.freeze({
+  Console: RabbitMQConnectorConsoleTemplate,
+  CredentialForm: RabbitMQCredentialFormTemplate,
+  Form: RabbitMQConnectorFormTemplate,
+  model,
+  Operations: RabbitMQConnectorOperationsTemplate,
+  RowActions: RabbitMQConnectorRowActionsTemplate,
+});

--- a/frontend/src/connectors/templates/rabbitmq/list-item.jsx
+++ b/frontend/src/connectors/templates/rabbitmq/list-item.jsx
@@ -1,0 +1,3 @@
+export function RabbitMQConnectorRowActionsTemplate() {
+  return null;
+}

--- a/frontend/src/connectors/templates/rabbitmq/metadata.json
+++ b/frontend/src/connectors/templates/rabbitmq/metadata.json
@@ -1,0 +1,8 @@
+{
+  "kind": "rabbitmq",
+  "label": "RabbitMQ",
+  "summary": "Queue browsing, bounded message previews, and explicit message publishing through RabbitMQ Management API profiles.",
+  "version": "0.2",
+  "icon": "database",
+  "badge_tone": "warn"
+}

--- a/frontend/src/connectors/templates/rabbitmq/model.js
+++ b/frontend/src/connectors/templates/rabbitmq/model.js
@@ -1,0 +1,293 @@
+import { apiDelete, apiPost, apiPut } from "../../../lib/api";
+import { createTargetWithProfile, updateTargetWithProfile } from "../target-profile-save";
+
+const emptyRabbitCredentialForm = { target_id: "", profile_label: "monitor", username: "", password: "", risk_label: "queue access" };
+
+export function emptyForm() {
+  return {
+    connector_kind: "rabbitmq",
+    name: "rabbitmq",
+    connection_mode: "direct",
+    scheme: "http",
+    host: "127.0.0.1",
+    port: 15672,
+    vhost: "/",
+    transport_target_ref: "",
+    profile_label: "monitor",
+    username: "",
+    password: "",
+    risk_label: "queue access",
+  };
+}
+
+export function formFromTarget({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : {});
+  return {
+    connector_kind: "rabbitmq",
+    profile_id: selectedProfile.id ? String(selectedProfile.id) : "",
+    name: target.name || "",
+    connection_mode: target.config?.connection_mode || "direct",
+    scheme: target.config?.scheme || "http",
+    host: target.config?.host || "127.0.0.1",
+    port: target.config?.port || 15672,
+    vhost: target.config?.vhost || "/",
+    transport_target_ref: target.config?.transport_target_ref || "",
+    profile_label: selectedProfile.label || "monitor",
+    username: selectedProfile.public?.username || "",
+    password: "",
+    risk_label: selectedProfile.risk_label || "queue access",
+  };
+}
+
+export function activeCredential() {
+  return null;
+}
+
+export function syncForm({ form }) {
+  if (form.connector_kind !== "rabbitmq") return form;
+  const next = { ...form };
+  if (next.connection_mode === "direct") {
+    next.transport_target_ref = "";
+  }
+  if (!next.scheme) {
+    next.scheme = "http";
+  }
+  if (!next.vhost) {
+    next.vhost = "/";
+  }
+  return next;
+}
+
+export function submitDisabled({ state }) {
+  return state.state === "saving";
+}
+
+export function submitLabel({ state, mode }) {
+  if (state.state === "saving") return "Saving...";
+  return mode === "edit" ? "Save changes" : "Create connector";
+}
+
+export async function save({ mode, form, target }) {
+  if (mode === "edit") {
+    await updateTarget({ form, target });
+    return;
+  }
+  await createTarget({ form });
+}
+
+export async function deleteTarget({ target }) {
+  await apiDelete(`/api/connector-targets/${target.id}`);
+}
+
+export function emptyCredentialState({ targets = [] } = {}) {
+  const firstTarget = targets.find((target) => target.connector_kind === "rabbitmq");
+  return {
+    form: {
+      ...emptyRabbitCredentialForm,
+      target_id: String(firstTarget?.id || ""),
+    },
+  };
+}
+
+export function credentialStateFromRow({ row }) {
+  return {
+    form: {
+      target_id: String(row.target_id || ""),
+      profile_label: row.name,
+      username: row.profile?.public?.username || "",
+      password: "",
+      risk_label: row.profile?.risk_label || "",
+    },
+  };
+}
+
+export function credentialFormProps({ targets, formState, setFormState, formMode, state, onSubmit }) {
+  return {
+    form: formState.form,
+    formMode,
+    targets,
+    state,
+    onChange: (form) => setFormState({ form }),
+    onSubmit: (event) => onSubmit(event, formMode === "edit" ? "update" : "create"),
+  };
+}
+
+export async function saveCredential({ operation, row, formState }) {
+  const form = formState.form;
+  if (operation === "create") {
+    await apiPost(`/api/connector-targets/${form.target_id}/profiles`, {
+      kind: "username_password",
+      label: form.profile_label,
+      public: { username: form.username },
+      secret: form.password ? { password: form.password } : {},
+      risk_label: form.risk_label,
+    });
+    return { message: "RabbitMQ credential created." };
+  }
+  if (operation === "update") {
+    if (!row) throw new Error("RabbitMQ credential is not loaded.");
+    const payload = {
+      kind: row.profile?.kind || "username_password",
+      label: form.profile_label,
+      public: { username: form.username },
+      risk_label: form.risk_label,
+    };
+    if (form.password) {
+      payload.secret = { password: form.password };
+    }
+    await apiPut(`/api/connector-targets/${form.target_id}/profiles/${row.id}`, payload);
+    return { message: "RabbitMQ credential updated." };
+  }
+  throw new Error("Unsupported RabbitMQ credential operation.");
+}
+
+export async function deleteCredential({ row }) {
+  await apiDelete(`/api/connector-targets/${row.target_id}/profiles/${row.id}`);
+}
+
+export function credentialRows({ targets }) {
+  return targets.flatMap((target) =>
+    (target.profiles || [])
+      .filter((profile) => target.connector_kind === "rabbitmq")
+      .map((profile) => ({
+        row_id: `${target.connector_kind}:${target.id}:${profile.id}`,
+        connector_kind: target.connector_kind,
+        resource_kind: "credential_profile",
+        connector_label: "RabbitMQ",
+        id: profile.id,
+        target_id: target.id,
+        name: profile.label,
+        kind: profile.kind,
+        profile,
+        target_label: target.name,
+        target_detail: targetEndpoint({ target }),
+        metadata: credentialMetadata(profile),
+        delete_disabled: "",
+      }))
+  );
+}
+
+export async function test({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!selectedProfile) throw new Error("Connector profile is not loaded.");
+  const data = await apiPost(`/api/connector-targets/${target.id}/profiles/${selectedProfile.id}/test`, {});
+  return { ok: data.ok, error: data.message || null, data };
+}
+
+export function canEdit() {
+  return true;
+}
+
+export function canDelete() {
+  return true;
+}
+
+export function credentialHint() {
+  return null;
+}
+
+export function targetEndpoint({ target }) {
+  const scheme = target.config?.scheme || "http";
+  const host = target.config?.host || "127.0.0.1";
+  const port = target.config?.port || 15672;
+  const vhost = target.config?.vhost || "/";
+  const mode = target.config?.connection_mode === "over_ssh" ? "over ssh" : "direct";
+  return `${scheme}://${host}:${port} · vhost ${vhost} · ${mode}`;
+}
+
+export function targetDisplayName({ target }) {
+  if (!target) return "RabbitMQ target";
+  return target.target_name || target.name || "RabbitMQ target";
+}
+
+export function targetSubtitle({ target }) {
+  return targetEndpoint({ target });
+}
+
+export function targetProfileLabel({ target }) {
+  return target?.profile_label || "monitor";
+}
+
+export function usesLiveConsole() {
+  return false;
+}
+
+export function deleteDialog({ target }) {
+  return {
+    title: target ? `Delete ${target.name}` : "Delete connector",
+    description: "Remove this RabbitMQ connector target, credential profiles, and token action permissions from aipermission.",
+    details: [
+      { label: "Connector", value: target?.name },
+      { label: "Reference", value: target ? `${target.connector_kind}:${target.id}` : "" },
+    ],
+    notice: "This removes the connector target and its credential profiles. It does not change the RabbitMQ server.",
+    actions: [
+      { label: "Cancel", action: "close", variant: "outline" },
+      { label: "Delete connector", pendingLabel: "Deleting...", removeKey: false },
+    ],
+  };
+}
+
+export function operationFromError() {
+  return null;
+}
+
+async function createTarget({ form }) {
+  await createTargetWithProfile({
+    targetPayload: {
+      connector_kind: "rabbitmq",
+      name: form.name,
+      config: rabbitTargetConfigFromForm(form),
+    },
+    profilePayload: {
+      kind: "username_password",
+      label: form.profile_label,
+      public: { username: form.username },
+      secret: form.password ? { password: form.password } : {},
+      risk_label: form.risk_label || "queue access",
+    },
+  });
+}
+
+async function updateTarget({ form, target }) {
+  const profile = target?.profiles?.find((item) => Number(item.id) === Number(form.profile_id)) || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!target || !profile) throw new Error("RabbitMQ connector profile is not loaded.");
+  const profilePayload = {
+    kind: profile.kind || "username_password",
+    label: form.profile_label,
+    public: { username: form.username },
+    risk_label: form.risk_label || "queue access",
+  };
+  if (form.password) {
+    profilePayload.secret = { password: form.password };
+  }
+  await updateTargetWithProfile({
+    targetID: target.id,
+    previousTarget: target,
+    profileID: profile.id,
+    targetPayload: {
+      name: form.name,
+      config: rabbitTargetConfigFromForm(form),
+    },
+    profilePayload,
+  });
+}
+
+function rabbitTargetConfigFromForm(form) {
+  return {
+    connection_mode: form.connection_mode || "direct",
+    scheme: form.scheme === "https" ? "https" : "http",
+    host: form.host || "127.0.0.1",
+    port: Number(form.port) || 15672,
+    vhost: form.vhost || "/",
+    transport_target_ref: form.connection_mode === "over_ssh" ? form.transport_target_ref || "" : "",
+  };
+}
+
+function credentialMetadata(profile) {
+  const items = [];
+  if (profile.public?.username) items.push(`username: ${profile.public.username}`);
+  if (profile.risk_label) items.push(`risk: ${profile.risk_label}`);
+  if (items.length === 0) items.push("No public metadata");
+  return items;
+}

--- a/frontend/src/connectors/templates/rabbitmq/operations.jsx
+++ b/frontend/src/connectors/templates/rabbitmq/operations.jsx
@@ -1,0 +1,3 @@
+export function RabbitMQConnectorOperationsTemplate() {
+  return null;
+}

--- a/frontend/src/connectors/templates/redis/form.jsx
+++ b/frontend/src/connectors/templates/redis/form.jsx
@@ -1,5 +1,6 @@
 import { Field, Input, Select } from "../../../components/ui/form";
 import { Notice } from "../../../components/ui/notice";
+import { HostPingButton } from "../host-ping-button";
 
 export function RedisConnectorFormTemplate({ form, mode = "create", targets = [], onChange }) {
   const editing = mode === "edit";
@@ -40,10 +41,17 @@ export function RedisConnectorFormTemplate({ form, mode = "create", targets = []
         <Notice>
           Host and port are resolved from the SSH server. Use 127.0.0.1:6379 when Redis only listens on the remote machine.
         </Notice>
-      ) : null}
+      ) : (
+        <Notice>
+          For Redis running on the same Linux host as AIPermission Docker, use host.docker.internal instead of localhost.
+        </Notice>
+      )}
       <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_120px_120px]">
         <Field>
-          Redis host
+          <span className="flex items-center justify-between gap-2">
+            <span>Redis host</span>
+            <HostPingButton host={form.host} port={form.port} mode={form.connection_mode} transportTargetRef={form.transport_target_ref} />
+          </span>
           <Input value={form.host} onChange={(event) => onChange("host", event.target.value)} required />
         </Field>
         <Field>

--- a/frontend/src/connectors/templates/ssh/form.jsx
+++ b/frontend/src/connectors/templates/ssh/form.jsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Checkbox, Field, Input, Select, Textarea } from "../../../components/ui/form";
 import { Notice } from "../../../components/ui/notice";
 import { InstallCommandPanel } from "../common";
+import { HostPingButton } from "../host-ping-button";
 
 export function SSHConnectorFormTemplate({ form, credentials, activeCredential, onChange }) {
   return (
@@ -20,7 +21,10 @@ export function SSHConnectorFormTemplate({ form, credentials, activeCredential, 
       </Field>
       <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_120px]">
         <Field>
-          Host
+          <span className="flex items-center justify-between gap-2">
+            <span>Host</span>
+            <HostPingButton host={form.host} port={form.port} />
+          </span>
           <Input value={form.host} onChange={(event) => onChange("host", event.target.value)} placeholder="203.0.113.10" required />
         </Field>
         <Field>

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -35,6 +35,7 @@ const connectorTemplateCommonSource = readFileSync(join(currentDir, "..", "conne
 const connectorTargetProfileSaveSource = readFileSync(join(currentDir, "..", "connectors", "templates", "target-profile-save.js"), "utf8");
 const connectorTemplateRegistrySource = readFileSync(join(currentDir, "..", "connectors", "templates", "registry.jsx"), "utf8");
 const connectorTemplateCatalogSource = readFileSync(join(currentDir, "..", "connectors", "templates", "catalog.js"), "utf8");
+const connectorHostPingSource = readFileSync(join(currentDir, "..", "connectors", "templates", "host-ping-button.jsx"), "utf8");
 const backendConnectorRegistrySource = readFileSync(join(currentDir, "..", "..", "..", "backend", "internal", "connectors", "builtin", "registry.go"), "utf8");
 const connectorTemplateKinds = readdirSync(connectorTemplatesDir, { withFileTypes: true })
   .filter((entry) => entry.isDirectory())
@@ -57,6 +58,8 @@ const postgresConnectorIndexSource = readFileSync(join(currentDir, "..", "connec
 const postgresConnectorMetadataSource = readFileSync(join(currentDir, "..", "connectors", "templates", "postgres", "metadata.json"), "utf8");
 const postgresConnectorModelSource = readFileSync(join(currentDir, "..", "connectors", "templates", "postgres", "model.js"), "utf8");
 const postgresConnectorOperationsSource = readFileSync(join(currentDir, "..", "connectors", "templates", "postgres", "operations.jsx"), "utf8");
+const redisConnectorFormTemplateSource = readFileSync(join(currentDir, "..", "connectors", "templates", "redis", "form.jsx"), "utf8");
+const rabbitMQConnectorFormTemplateSource = readFileSync(join(currentDir, "..", "connectors", "templates", "rabbitmq", "form.jsx"), "utf8");
 
 function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -115,6 +118,7 @@ test("Connectors page wires generic connector templates", () => {
   assert.match(postgresConnectorMetadataSource, /"icon": "database"/);
   assert.match(connectorTemplateRegistrySource, /ConnectorTemplateNotFound/);
   assert.match(sshConnectorFormTemplateSource, /SSHConnectorFormTemplate/);
+  assert.match(sshConnectorFormTemplateSource, /HostPingButton/);
   assert.match(sshConnectorListItemTemplateSource, /SSHConnectorRowActionsTemplate/);
   assert.match(sshConnectorConsoleTemplateSource, /SSHConnectorConsoleTemplate/);
   assert.match(sshConnectorModelSource, /apiPost\("\/api\/connector-targets\/test"/);
@@ -127,6 +131,11 @@ test("Connectors page wires generic connector templates", () => {
   assert.doesNotMatch(sshConnectorModelSource, /apiDelete\(`\/api\/servers\//);
   assert.match(sshConnectorModelSource, /deleteDialog/);
   assert.match(postgresConnectorFormTemplateSource, /PostgresConnectorFormTemplate/);
+  assert.match(postgresConnectorFormTemplateSource, /HostPingButton/);
+  assert.match(redisConnectorFormTemplateSource, /HostPingButton/);
+  assert.match(rabbitMQConnectorFormTemplateSource, /HostPingButton/);
+  assert.match(connectorHostPingSource, /\/api\/connector-targets\/ping/);
+  assert.match(connectorHostPingSource, /transport_target_ref/);
   assert.match(postgresConnectorListItemTemplateSource, /PostgresConnectorRowActionsTemplate/);
   assert.match(postgresConnectorConsoleTemplateSource, /PostgresConnectorConsoleTemplate/);
   assert.match(postgresConnectorModelSource, /createTargetWithProfile/);
@@ -227,9 +236,10 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.5"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.6"/);
+  assert.match(releaseSource, /RabbitMQ connector/);
+  assert.match(releaseSource, /RabbitMQ is now a built-in connector with Direct and Over SSH connection modes/);
   assert.match(releaseSource, /Postgres over SSH/);
-  assert.match(releaseSource, /Postgres connector targets can now connect directly from the gateway or over an SSH connector profile/);
   assert.match(releaseSource, /Console profile polish/);
   assert.match(releaseSource, /Postgres management/);
   assert.match(releaseSource, /Maintenance hardening/);

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,33 @@
-export const appVersion = "0.2.5";
+export const appVersion = "0.2.6";
 
 export const changelogEntries = [
+  {
+    version: "0.2.6",
+    label: "RabbitMQ connector",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "RabbitMQ is now a built-in connector with Direct and Over SSH connection modes.",
+          "RabbitMQ actions cover overview metadata, vhost listing, bounded queue lists, queue details, bindings, bounded message peeking with requeue, and explicit message publishing.",
+          "RabbitMQ Console adds a queue browser with counters, binding inspection, message preview panels, and a write-scoped publish panel.",
+          "Connector target forms can run four direct or Over SSH host reachability checks before saving.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Direct connector targets can use host.docker.internal to reach services running on the same Linux host as AIPermission Docker.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "RabbitMQ message preview is bounded by count and payload truncation limits. publish_message is a separate write action; destructive queue operations are intentionally not part of this MVP.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.5",
     label: "Postgres over SSH",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,7 +2564,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -8,7 +8,7 @@ credentials, or other connector secrets.
 
 The gateway is intentionally local-only. Run it on the developer machine and
 keep the URL on `localhost`; remote systems are connector targets, not places
-to host the gateway for LAN or internet users. SSH, Postgres, and Redis are
+to host the gateway for LAN or internet users. SSH, Postgres, Redis, and RabbitMQ are
 built-in connectors that use the same target/profile/action permission model
 as future connectors.
 
@@ -61,7 +61,7 @@ The generated MCP config contains a bearer token. Keep it private. For project-l
 - `call_connector_action`
 - `get_connector_action_request`
 
-All integration work goes through connector targets. SSH, Postgres, Redis, and future
+All integration work goes through connector targets. SSH, Postgres, Redis, RabbitMQ, and future
 connectors share the same model: target, credential profile, connector action,
 token action permission, approval, history, and audit.
 
@@ -78,6 +78,12 @@ reachable only from a remote server.
 For Redis, call `get_connector_actions(target_ref)` to discover bounded key
 browser actions such as `scan_keys`, `get_key`, `set_string`, `expire_key`, and
 `delete_keys`.
+
+For RabbitMQ, call `get_connector_actions(target_ref)` to discover queue
+browser actions such as `overview`, `list_vhosts`, `list_queues`, `get_queue`,
+`list_bindings`, `peek_messages`, and `publish_message`. Message payload
+previews and published payloads can contain secrets or customer data; use short
+reasons and prefer approval-required access until the workflow is trusted.
 
 Connector responses can include `approval_pending` or `running`. Poll
 `get_connector_action_request(request_id)` until the request reaches a terminal

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/resources/aipermission-operator/SKILL.md
+++ b/packages/mcp/resources/aipermission-operator/SKILL.md
@@ -46,6 +46,8 @@ Good reasons:
 Check Docker service state before cleanup.
 Inspect recent kubelet errors on worker node.
 List Postgres schemas before a read-only metadata query.
+Peek a RabbitMQ queue after the operator approved payload inspection. Publish
+RabbitMQ messages only when the operator explicitly asked for a write.
 ```
 
 Avoid vague reasons:

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Highlights

- Adds RabbitMQ as a built-in connector with Direct and Over SSH connection modes.
- Adds RabbitMQ queue browsing, bounded message peeking, and explicit write-scoped message publishing.
- Adds connector form host reachability checks for direct and SSH-routed targets.

## Changes

### Added

- RabbitMQ connector actions for overview metadata, vhost listing, bounded queue lists, queue details, bindings, bounded peeking, and `publish_message`.
- RabbitMQ Console template with queue counters, binding inspection, message previews, searchable routing keys, and a publish panel.
- `POST /api/connector-targets/ping` for bounded TCP reachability checks from direct mode or through an SSH transport profile.

### Changed

- Direct connector targets can use `host.docker.internal` to reach services running on the same Linux Docker host.
- README, REST/MCP docs, roadmap, operator skills, in-app release notes, and MCP package metadata are aligned for v0.2.6.

## Security

- RabbitMQ peeking is bounded by count and payload truncation limits.
- `publish_message` is a separate write action. Destructive queue operations such as purge, ack, nack, and delete are intentionally out of scope for this MVP.

## Validation

- `node scripts/secret-scan.js`
- `make test`
- `make build`
- `make audit`
- `cd backend && go test -race ./...`
- `cd backend && go vet ./...`
- `cd backend && govulncheck ./...`
- `cd packages/mcp && npm run build && npm audit --omit=dev --audit-level=moderate && npm pack --dry-run`
- `docker compose config --quiet`
- `git diff --check`
- Local Docker Compose smoke test with RabbitMQ UI polish.

## Notes

- AIPermission remains local-only, single-user, connector-based, and human-in-the-loop.
- The MCP npm package version is bumped to `0.2.6`; npm publish is a separate post-merge step.
