### PR TITLE
feat: add Docker connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-06-23
+
+### Added
+
+- Added Docker as a built-in connector that runs bounded Docker CLI templates
+  through an SSH transport profile.
+- Added Docker actions for version metadata, scoped container listing, redacted
+  inspect metadata, bounded log tails, and explicit start/stop/restart lifecycle
+  operations.
+- Added a Docker Console container browser with profile-scoped container lists,
+  logs, inspect output, and lifecycle confirmation dialogs.
+- Added Docker credential profile scopes so a token can be limited to all
+  containers, selected container names/IDs, or name patterns.
+
+### Changed
+
+- Added a generic connector command transport capability so structured
+  connectors can run reviewed command templates through connector transports
+  without importing SSH-specific code.
+
+### Security
+
+- Docker does not expose arbitrary `docker exec`, container/image removal,
+  prune, shell, or raw Docker command execution in the 0.2.8 MVP.
+- Docker inspect output masks container environment values before returning
+  structured output to UI, MCP, history, or audit.
+- Container-targeted Docker actions resolve the requested container first and
+  enforce the credential profile scope before reading logs, inspecting metadata,
+  or running lifecycle changes.
+
 ## [0.2.7] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   <p><strong>Local permission gateway for AI agents.</strong></p>
   <p>
     Give AI assistants temporary, scoped action access to your local connector
-    targets without sharing SSH keys, database passwords, Redis credentials, or
-    future connector secrets.
+    targets without sharing SSH keys, database passwords, cache credentials,
+    queue credentials, or future connector secrets.
   </p>
   <p>
     <a href="#quick-start">Quick Start</a>
@@ -56,7 +56,7 @@ AIPermission is intentionally designed as a local developer gateway.
 
 - The gateway runs on the developer's own machine.
 - Remote systems are connector targets reached from that local gateway.
-- SSH, Postgres, Redis, and RabbitMQ are built-in connector types, not separate product modes.
+- SSH, Postgres, Redis, RabbitMQ, and Docker are built-in connector types, not separate product modes.
 - The web UI, REST API, and MCP API are not designed to be shared on a LAN.
 - The project does not support running the gateway as a remote hosted service.
 - The project provides a local browser session after database unlock, not multi-user web auth, team RBAC, or public network hardening.
@@ -86,7 +86,7 @@ That loop is slow when you are debugging servers, containers, Kubernetes nodes, 
 
 With `aipermission`, the AI can inspect approved connector targets directly through MCP while you keep control:
 
-- SSH private keys, database credentials, and future connector secrets stay inside the local gateway.
+- SSH private keys, database credentials, cache credentials, queue credentials, and future connector secrets stay inside the local gateway.
 - The AI sees only targets and actions allowed for its token.
 - You can require approval before actions run.
 - You can watch the same persistent SSH console live when the connector has a terminal surface.
@@ -116,10 +116,14 @@ Implemented:
 - Docker Compose local runtime
 - Go backend with SQLite storage
 - React web UI
-- connector target/profile/action pipeline for SSH, Postgres, Redis, RabbitMQ, and future local
+- connector target/profile/action pipeline for SSH, Postgres, Redis, RabbitMQ,
+  Docker, and future local
   integrations
 - generic connector network transport so protocol connectors can use Direct or
   reviewed Over SSH TCP paths without importing SSH-specific code
+- generic connector command transport so structured connectors can run reviewed
+  command templates through connector transports without importing SSH-specific
+  code
 - connector template architecture for target forms, credential forms, list rows,
   console/activity surfaces, and connector-owned operations
 - built-in SSH connector with persistent shell, file transfer, remote browsing,
@@ -132,6 +136,12 @@ Implemented:
 - built-in RabbitMQ connector with Direct and Over SSH connection modes, queue
   browsing, vhost metadata, binding inspection, bounded message peeking, and
   explicit message publishing
+- built-in Docker connector over an SSH transport profile, with scoped
+  container inventory, redacted inspect metadata, bounded logs, and explicit
+  start/stop/restart actions
+- Docker credential profiles can scope MCP access to all containers, selected
+  container names/IDs, or name patterns, so one token can be limited to a
+  single container on a shared Docker host.
 - gateway-generated SSH keys (`ed25519` and `rsa`)
 - explicit existing SSH private key import into the encrypted local vault
 - SSH host import from OpenSSH config files for prefilling connector targets
@@ -145,7 +155,8 @@ Implemented:
 - global MCP Started/Stopped switch that preserves permissions while blocking live execution
 - persistent web console with live PTY streaming
 - UI bulk SSH command execution across selected connector targets with per-target history rows
-- MCP bridge with connector action tools for SSH, Postgres, Redis, RabbitMQ, and future local integrations
+- MCP bridge with connector action tools for SSH, Postgres, Redis, RabbitMQ,
+  Docker, and future local integrations
 - approval dialog with Run / Decline / note
 - approval-context snapshots that stale old pending connector actions after
   permission, connector target, credential profile, connector metadata, or
@@ -316,7 +327,7 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-The MCP surface is connector-first. SSH, Postgres, Redis, RabbitMQ, and future integrations use
+The MCP surface is connector-first. SSH, Postgres, Redis, RabbitMQ, Docker, and future integrations use
 the same target/profile/action permission pipeline. `list_connector_targets` is
 permission-scoped, not a live health check. Current reachability is learned when
 the connector action actually runs and returns a dial, timeout, authentication,

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	github.com/creack/pty v1.1.24
 	github.com/gorilla/websocket v1.5.3
-	github.com/jackc/pgx/v5 v5.7.2
+	github.com/jackc/pgx/v5 v5.10.0
 	github.com/mutecomm/go-sqlcipher/v4 v4.4.2
 	github.com/pkg/sftp v1.13.10
 	golang.org/x/crypto v0.53.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -9,8 +9,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.2 h1:mLoDLV6sonKlvjIEsV56SkWNCnuNv531l94GaIzO+XI=
-github.com/jackc/pgx/v5 v5.7.2/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
+github.com/jackc/pgx/v5 v5.10.0 h1:VhSvgU2jSli8o3AqIEOTJr7rZwAEUVo4E4XhR94Zfr0=
+github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
@@ -24,8 +24,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=

--- a/backend/internal/api/connector_api_adapters.go
+++ b/backend/internal/api/connector_api_adapters.go
@@ -27,8 +27,10 @@ func (c connectorRuntimeCapabilities) RuntimeCapability(name string) connectors.
 func connectorRuntimeCapabilitiesFor(kind string, server *Server, runtime *databaseRuntime) connectors.RuntimeCapabilityResolver {
 	capabilities := connectorRuntimeCapabilities{}
 	if server != nil && runtime != nil {
-		transport := connectorNetworkTransport{server: server, runtime: runtime}
-		capabilities[transport.ConnectorRuntimeCapability()] = transport
+		networkTransport := connectorNetworkTransport{server: server, runtime: runtime}
+		capabilities[networkTransport.ConnectorRuntimeCapability()] = networkTransport
+		commandTransport := connectorCommandTransport{server: server, runtime: runtime}
+		capabilities[commandTransport.ConnectorRuntimeCapability()] = commandTransport
 	}
 	adapter := connectorRuntimeAdapterFor(kind)
 	if adapter != nil {

--- a/backend/internal/api/connector_command_transport.go
+++ b/backend/internal/api/connector_command_transport.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/connectorapi"
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
+)
+
+const (
+	defaultConnectorCommandTimeout = 30 * time.Second
+	maxConnectorCommandTimeout     = 60 * time.Second
+)
+
+type connectorCommandTransport struct {
+	server  *Server
+	runtime *databaseRuntime
+}
+
+func (connectorCommandTransport) ConnectorRuntimeCapability() string {
+	return connectors.CommandTransportCapabilityName
+}
+
+func (transport connectorCommandTransport) RunConnectorCommand(ctx context.Context, request connectors.CommandRunRequest) (connectors.CommandRunResult, error) {
+	mode := strings.TrimSpace(request.Mode)
+	if mode == "" {
+		mode = "over_ssh"
+	}
+	if strings.TrimSpace(request.Command) == "" {
+		return connectors.CommandRunResult{}, fmt.Errorf("command is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timeout := defaultConnectorCommandTimeout
+	if request.TimeoutSeconds > 0 {
+		timeout = time.Duration(request.TimeoutSeconds) * time.Second
+		if timeout > maxConnectorCommandTimeout {
+			timeout = maxConnectorCommandTimeout
+		}
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	switch mode {
+	case "over_ssh":
+		targetRef := strings.TrimSpace(request.TransportTargetRef)
+		if targetRef == "" {
+			return connectors.CommandRunResult{}, fmt.Errorf("transport target ref is required for over_ssh")
+		}
+		kind, _, _, ok := connectortargets.ParseConnectorTargetRef(targetRef)
+		if !ok {
+			return connectors.CommandRunResult{}, connectortargets.ErrInvalidTargetRef
+		}
+		adapter, _ := connectorAPIAdapterFor(kind).(connectorapi.CommandTransportAdapter)
+		if adapter == nil {
+			return connectors.CommandRunResult{}, fmt.Errorf("%s connector does not expose command transport", kind)
+		}
+		return adapter.RunConnectorCommand(ctx, transport.server, transport.runtime, targetRef, request.Command)
+	default:
+		return connectors.CommandRunResult{}, fmt.Errorf("unsupported command transport mode %q", mode)
+	}
+}

--- a/backend/internal/connectorapi/registry.go
+++ b/backend/internal/connectorapi/registry.go
@@ -180,6 +180,13 @@ type TCPTransportAdapter interface {
 	DialConnectorTCP(ctx context.Context, server GatewayServer, runtime GatewayRuntime, targetRef string, network string, address string) (net.Conn, error)
 }
 
+// CommandTransportAdapter lets one connector run a bounded command template
+// through another connector-owned transport without exposing connector-specific
+// material to core or to the caller.
+type CommandTransportAdapter interface {
+	RunConnectorCommand(ctx context.Context, server GatewayServer, runtime GatewayRuntime, targetRef string, command string) (connectors.CommandRunResult, error)
+}
+
 type TransferProgress func(transferred int64, total int64)
 
 type TransferOptions struct {

--- a/backend/internal/connectors/builtin/registry.go
+++ b/backend/internal/connectors/builtin/registry.go
@@ -4,6 +4,7 @@ package builtin
 
 import (
 	"github.com/aipermission/aipermission/backend/internal/connectors"
+	dockerconnector "github.com/aipermission/aipermission/backend/internal/connectors/docker"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
 	rabbitmqconnector "github.com/aipermission/aipermission/backend/internal/connectors/rabbitmq"
 	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"
@@ -14,6 +15,7 @@ import (
 // RegisterAll adds all built-in connectors to the provided registry.
 func RegisterAll(registry *connectors.Registry) error {
 	for _, connector := range []connectors.Connector{
+		dockerconnector.New(),
 		postgresconnector.New(),
 		rabbitmqconnector.New(),
 		redisconnector.New(),

--- a/backend/internal/connectors/builtin/registry_test.go
+++ b/backend/internal/connectors/builtin/registry_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aipermission/aipermission/backend/internal/connectors"
 	"github.com/aipermission/aipermission/backend/internal/connectors/connectortest"
+	dockerconnector "github.com/aipermission/aipermission/backend/internal/connectors/docker"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
 	rabbitmqconnector "github.com/aipermission/aipermission/backend/internal/connectors/rabbitmq"
 	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"
@@ -16,6 +17,14 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	registry, err := NewRegistry()
 	if err != nil {
 		t.Fatalf("new registry: %v", err)
+	}
+
+	docker, ok := registry.Get(dockerconnector.Kind)
+	if !ok {
+		t.Fatal("expected docker connector")
+	}
+	if docker.Label() != dockerconnector.Label {
+		t.Fatalf("docker label = %q", docker.Label())
 	}
 
 	postgres, ok := registry.Get(postgresconnector.Kind)
@@ -49,7 +58,7 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	}
 
 	infos := registry.List()
-	if len(infos) != 4 || infos[0].Kind != postgresconnector.Kind || infos[1].Kind != rabbitmqconnector.Kind || infos[2].Kind != redisconnector.Kind || infos[3].Kind != sshconnector.Kind {
+	if len(infos) != 5 || infos[0].Kind != dockerconnector.Kind || infos[1].Kind != postgresconnector.Kind || infos[2].Kind != rabbitmqconnector.Kind || infos[3].Kind != redisconnector.Kind || infos[4].Kind != sshconnector.Kind {
 		t.Fatalf("unexpected connector list: %#v", infos)
 	}
 }
@@ -104,6 +113,29 @@ func builtInDeterminismSamples(t *testing.T, kind string) (connectors.TargetView
 	t.Helper()
 
 	switch kind {
+	case dockerconnector.Kind:
+		return connectors.TargetView{
+				ID:            5,
+				Ref:           "docker:5:50",
+				ConnectorKind: dockerconnector.Kind,
+				Name:          "docker-host",
+				Config:        map[string]any{"connection_mode": "over_ssh", "transport_target_ref": "ssh:2:20", "docker_command": "docker"},
+			}, connectors.CredentialProfileView{
+				ID:            50,
+				TargetID:      5,
+				ConnectorKind: dockerconnector.Kind,
+				Kind:          "container_scope",
+				Label:         "api-only",
+				Public:        map[string]any{"scope_mode": "selected", "allowed_containers": "api"},
+			}, map[string]map[string]any{
+				dockerconnector.ActionVersion:          {},
+				dockerconnector.ActionListContainers:   {"all": true},
+				dockerconnector.ActionInspectContainer: {"container": "api"},
+				dockerconnector.ActionContainerLogs:    {"container": "api", "tail": 100},
+				dockerconnector.ActionStartContainer:   {"container": "api"},
+				dockerconnector.ActionStopContainer:    {"container": "api", "timeout_seconds": 10},
+				dockerconnector.ActionRestartContainer: {"container": "api", "timeout_seconds": 10},
+			}
 	case postgresconnector.Kind:
 		return connectors.TargetView{
 				ID:            1,

--- a/backend/internal/connectors/connector.go
+++ b/backend/internal/connectors/connector.go
@@ -107,7 +107,10 @@ type RuntimeCapability interface {
 	ConnectorRuntimeCapability() string
 }
 
-const NetworkTransportCapabilityName = "network_transport"
+const (
+	NetworkTransportCapabilityName = "network_transport"
+	CommandTransportCapabilityName = "command_transport"
+)
 
 // NetworkDialRequest describes a connector-owned network connection request.
 //
@@ -128,6 +131,35 @@ type NetworkDialRequest struct {
 type NetworkTransport interface {
 	RuntimeCapability
 	DialConnectorTCP(ctx context.Context, request NetworkDialRequest) (net.Conn, error)
+}
+
+// CommandRunRequest describes a connector-owned command execution request.
+//
+// Connectors use this capability when a bounded, connector-owned command
+// template must run through another reviewed connector transport such as SSH.
+// The caller connector still owns the command shape, output parsing, and
+// safety limits; the gateway only routes the command to the selected transport.
+type CommandRunRequest struct {
+	Mode               string
+	TransportTargetRef string
+	Command            string
+	TimeoutSeconds     int
+}
+
+// CommandRunResult is the captured result of one connector transport command.
+type CommandRunResult struct {
+	Stdout     string `json:"stdout"`
+	Stderr     string `json:"stderr"`
+	ExitCode   int    `json:"exit_code"`
+	DurationMS int64  `json:"duration_ms"`
+}
+
+// CommandTransport is a generic command transport capability injected by the
+// gateway. It intentionally returns only captured process output so structured
+// connectors such as Docker can stay independent from SSH internals.
+type CommandTransport interface {
+	RuntimeCapability
+	RunConnectorCommand(ctx context.Context, request CommandRunRequest) (CommandRunResult, error)
 }
 
 // RuntimeCapabilityResolver resolves reviewed connector-owned capabilities

--- a/backend/internal/connectors/docker/docker.go
+++ b/backend/internal/connectors/docker/docker.go
@@ -1,0 +1,844 @@
+// Package dockerconnector defines the Docker connector contract.
+package dockerconnector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+const (
+	Kind    = "docker"
+	Label   = "Docker"
+	Version = "0.2"
+
+	ActionVersion          = "docker_version"
+	ActionListContainers   = "list_containers"
+	ActionInspectContainer = "inspect_container"
+	ActionContainerLogs    = "container_logs"
+	ActionStartContainer   = "start_container"
+	ActionStopContainer    = "stop_container"
+	ActionRestartContainer = "restart_container"
+
+	defaultLogTail     = 200
+	maxLogTail         = 2000
+	maxLogBytes        = 256 << 10
+	maxInspectBytes    = 512 << 10
+	maxDockerReasonLen = 2000
+)
+
+var (
+	ErrUnsupportedAction = errors.New("unsupported docker connector action")
+	ErrMissingTransport  = errors.New("docker connector command transport is unavailable")
+	ErrInvalidConfig     = errors.New("docker connector target config is invalid")
+	ErrScopeDenied       = errors.New("docker container is outside this credential profile scope")
+)
+
+type Connector struct{}
+
+func New() Connector {
+	return Connector{}
+}
+
+func (Connector) Kind() string {
+	return Kind
+}
+
+func (Connector) Label() string {
+	return Label
+}
+
+func (Connector) Version() string {
+	return Version
+}
+
+func (Connector) TargetSchema() connectors.Schema {
+	return connectors.Schema{Fields: []connectors.Field{
+		{
+			Name:        "connection_mode",
+			Label:       "Connection mode",
+			Type:        connectors.FieldSelect,
+			Required:    true,
+			Default:     "over_ssh",
+			Description: "Run bounded Docker CLI templates through an SSH connector profile.",
+			Options: []connectors.FieldOption{
+				{Value: "over_ssh", Label: "Over SSH"},
+			},
+		},
+		{
+			Name:        "transport_target_ref",
+			Label:       "SSH transport profile",
+			Type:        connectors.FieldString,
+			Required:    true,
+			Description: "SSH connector target/profile ref used to run docker commands.",
+		},
+		{
+			Name:        "docker_command",
+			Label:       "Docker command",
+			Type:        connectors.FieldString,
+			Default:     "docker",
+			Description: "Docker CLI command on the remote host. Keep this as docker unless the host uses a wrapper path.",
+		},
+	}}
+}
+
+func (Connector) CredentialSchemas() []connectors.CredentialSchema {
+	return []connectors.CredentialSchema{
+		{
+			Kind:        "container_scope",
+			Label:       "Container scope",
+			Description: "Restrict this profile to all containers or to selected container names/IDs/patterns.",
+			Schema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "scope_mode",
+					Label:       "Scope",
+					Type:        connectors.FieldSelect,
+					Required:    true,
+					Default:     "all",
+					Description: "Use selected when this token should only see and operate on specific containers.",
+					Options: []connectors.FieldOption{
+						{Value: "all", Label: "All containers"},
+						{Value: "selected", Label: "Selected containers"},
+					},
+				},
+				{
+					Name:        "allowed_containers",
+					Label:       "Allowed containers",
+					Type:        connectors.FieldMultiline,
+					Description: "One container name, full ID, or ID prefix per line.",
+				},
+				{
+					Name:        "allowed_patterns",
+					Label:       "Allowed name patterns",
+					Type:        connectors.FieldMultiline,
+					Description: "Optional shell-style name patterns such as app-* or project_web_*.",
+				},
+			}},
+		},
+	}
+}
+
+func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (connectors.ConnectorHelp, error) {
+	title := "Docker target"
+	if strings.TrimSpace(target.Name) != "" {
+		title = "Docker target: " + target.Name
+	}
+	return connectors.ConnectorHelp{
+		Title:       title,
+		Summary:     "Inspect and control Docker containers through bounded Docker CLI templates and AIPermission approval rules.",
+		Connector:   Label,
+		ConnectorID: Kind,
+		Usage: []string{
+			"Use list_containers before targeting a container by name or ID.",
+			"Use container_logs with a bounded tail value for recent logs.",
+			"Use inspect_container for redacted Docker metadata. Environment variables are masked.",
+			"Use start_container, stop_container, or restart_container only when the operator intends a container lifecycle change.",
+		},
+		Warnings: []string{
+			"Docker actions run through a selected transport profile. The Docker connector does not expose arbitrary docker exec, prune, rm, or shell access.",
+			"Credential profile scope can restrict AI access to one container or a small allowed set.",
+			"Container logs may contain secrets. Redaction is best-effort; avoid requesting sensitive logs unless approved.",
+		},
+	}, nil
+}
+
+func (Connector) GetActionList(context.Context, connectors.TargetView, connectors.CredentialProfileView) ([]connectors.ActionDefinition, error) {
+	return []connectors.ActionDefinition{
+		{
+			Name:        ActionVersion,
+			Label:       "Docker version",
+			Description: "Read Docker client/server version metadata.",
+			Category:    "metadata",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{},
+			OutputHint:  connectors.OutputHint{Format: "json", MaxBytes: 64 << 10},
+		},
+		{
+			Name:        ActionListContainers,
+			Label:       "List containers",
+			Description: "List containers visible to this credential profile scope.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "all", Label: "Include stopped", Type: connectors.FieldBoolean, Default: true},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxRows: 500},
+		},
+		{
+			Name:        ActionInspectContainer,
+			Label:       "Inspect container",
+			Description: "Read redacted Docker inspect metadata for one scoped container.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "container", Label: "Container", Type: connectors.FieldString, Required: true},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: maxInspectBytes},
+		},
+		{
+			Name:        ActionContainerLogs,
+			Label:       "Container logs",
+			Description: "Read a bounded tail of one scoped container's logs.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "container", Label: "Container", Type: connectors.FieldString, Required: true},
+				{Name: "tail", Label: "Tail lines", Type: connectors.FieldNumber, Default: defaultLogTail},
+			}},
+			OutputHint: connectors.OutputHint{Format: "text", MaxBytes: maxLogBytes},
+		},
+		{
+			Name:        ActionStartContainer,
+			Label:       "Start container",
+			Description: "Start one scoped Docker container.",
+			Category:    "lifecycle",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "container", Label: "Container", Type: connectors.FieldString, Required: true},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+		{
+			Name:        ActionStopContainer,
+			Label:       "Stop container",
+			Description: "Stop one scoped Docker container.",
+			Category:    "lifecycle",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "container", Label: "Container", Type: connectors.FieldString, Required: true},
+				{Name: "timeout_seconds", Label: "Timeout seconds", Type: connectors.FieldNumber, Default: 10},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+		{
+			Name:        ActionRestartContainer,
+			Label:       "Restart container",
+			Description: "Restart one scoped Docker container.",
+			Category:    "lifecycle",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "container", Label: "Container", Type: connectors.FieldString, Required: true},
+				{Name: "timeout_seconds", Label: "Timeout seconds", Type: connectors.FieldNumber, Default: 10},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+	}, nil
+}
+
+func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) (connectors.PreparedAction, error) {
+	input := copyMap(req.Input)
+	if len(req.Reason) > maxDockerReasonLen {
+		return connectors.PreparedAction{}, fmt.Errorf("reason is too large")
+	}
+	risk := connectors.RiskRead
+	title := ""
+	summary := ""
+	switch req.ActionName {
+	case ActionVersion:
+		title = "Read Docker version"
+		summary = "Read Docker client/server version metadata."
+	case ActionListContainers:
+		input["all"] = boolValue(input, "all", true)
+		title = "List Docker containers"
+		summary = "List containers visible to this credential profile scope."
+	case ActionInspectContainer:
+		container, err := normalizeContainerInput(input)
+		if err != nil {
+			return connectors.PreparedAction{}, err
+		}
+		input["container"] = container
+		title = "Inspect Docker container"
+		summary = container
+	case ActionContainerLogs:
+		container, err := normalizeContainerInput(input)
+		if err != nil {
+			return connectors.PreparedAction{}, err
+		}
+		input["container"] = container
+		input["tail"] = normalizeInt(input, "tail", defaultLogTail, 1, maxLogTail)
+		title = "Read Docker container logs"
+		summary = fmt.Sprintf("%s tail=%d", container, input["tail"])
+	case ActionStartContainer:
+		risk = connectors.RiskWrite
+		container, err := normalizeContainerInput(input)
+		if err != nil {
+			return connectors.PreparedAction{}, err
+		}
+		input["container"] = container
+		title = "Start Docker container"
+		summary = container
+	case ActionStopContainer:
+		risk = connectors.RiskWrite
+		container, err := normalizeContainerInput(input)
+		if err != nil {
+			return connectors.PreparedAction{}, err
+		}
+		input["container"] = container
+		input["timeout_seconds"] = normalizeInt(input, "timeout_seconds", 10, 1, 120)
+		title = "Stop Docker container"
+		summary = fmt.Sprintf("%s timeout=%ss", container, fmt.Sprint(input["timeout_seconds"]))
+	case ActionRestartContainer:
+		risk = connectors.RiskWrite
+		container, err := normalizeContainerInput(input)
+		if err != nil {
+			return connectors.PreparedAction{}, err
+		}
+		input["container"] = container
+		input["timeout_seconds"] = normalizeInt(input, "timeout_seconds", 10, 1, 120)
+		title = "Restart Docker container"
+		summary = fmt.Sprintf("%s timeout=%ss", container, fmt.Sprint(input["timeout_seconds"]))
+	default:
+		return connectors.PreparedAction{}, ErrUnsupportedAction
+	}
+	return connectors.PreparedAction{
+		ConnectorKind: Kind,
+		TargetRef:     req.Target.Ref,
+		ProfileID:     req.Profile.ID,
+		ActionName:    req.ActionName,
+		Risk:          risk,
+		Title:         title,
+		Summary:       summary,
+		Preview:       input,
+		Payload:       input,
+		ContextMaterial: map[string]any{
+			"target":          req.Target.Name,
+			"profile":         req.Profile.Label,
+			"connection_mode": connectionMode(req.Target),
+			"scope_mode":      scopeMode(req.Profile),
+		},
+	}, nil
+}
+
+func (Connector) ExecuteAction(ctx context.Context, runtime connectors.RuntimeContext, action connectors.PreparedAction) (connectors.ActionResult, error) {
+	client, err := newDockerClient(runtime)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	switch action.ActionName {
+	case ActionVersion:
+		return executeVersion(ctx, client)
+	case ActionListContainers:
+		return executeListContainers(ctx, client, action.Payload)
+	case ActionInspectContainer:
+		return executeInspectContainer(ctx, client, action.Payload)
+	case ActionContainerLogs:
+		return executeContainerLogs(ctx, client, action.Payload)
+	case ActionStartContainer:
+		return executeContainerLifecycle(ctx, client, action.Payload, "start")
+	case ActionStopContainer:
+		return executeContainerLifecycle(ctx, client, action.Payload, "stop")
+	case ActionRestartContainer:
+		return executeContainerLifecycle(ctx, client, action.Payload, "restart")
+	default:
+		return connectors.ActionResult{}, ErrUnsupportedAction
+	}
+}
+
+func (Connector) TestConnection(ctx context.Context, runtime connectors.RuntimeContext) (connectors.TestResult, error) {
+	client, err := newDockerClient(runtime)
+	if err != nil {
+		return connectors.TestResult{Status: connectors.TestUnknownError, Message: err.Error()}, nil
+	}
+	result, err := client.run(ctx, "docker version --format '{{json .}}'", 15)
+	if err != nil {
+		return connectors.TestResult{Status: connectors.TestFailedNetwork, Message: err.Error()}, nil
+	}
+	if result.ExitCode != 0 {
+		return connectors.TestResult{Status: connectors.TestFailedPermission, Message: dockerCommandError("docker version", result).Error()}, nil
+	}
+	return connectors.TestResult{
+		Status:  connectors.TestOK,
+		Message: "Docker connection ok.",
+		Details: map[string]any{
+			"duration_ms": result.DurationMS,
+			"mode":        connectionMode(runtime.Target),
+		},
+	}, nil
+}
+
+type dockerClient struct {
+	runtime   connectors.RuntimeContext
+	transport connectors.CommandTransport
+	command   string
+	scope     dockerScope
+}
+
+func newDockerClient(runtime connectors.RuntimeContext) (*dockerClient, error) {
+	transport, _ := runtime.Capability(connectors.CommandTransportCapabilityName).(connectors.CommandTransport)
+	if transport == nil {
+		return nil, ErrMissingTransport
+	}
+	command := dockerCommand(runtime.Target)
+	if command == "" {
+		return nil, fmt.Errorf("%w: docker_command is required", ErrInvalidConfig)
+	}
+	return &dockerClient{
+		runtime:   runtime,
+		transport: transport,
+		command:   command,
+		scope:     dockerScopeFromProfile(runtime.Profile),
+	}, nil
+}
+
+func (client *dockerClient) run(ctx context.Context, command string, timeoutSeconds int) (connectors.CommandRunResult, error) {
+	return client.transport.RunConnectorCommand(ctx, connectors.CommandRunRequest{
+		Mode:               connectionMode(client.runtime.Target),
+		TransportTargetRef: strings.TrimSpace(stringValue(client.runtime.Target.Config, "transport_target_ref")),
+		Command:            command,
+		TimeoutSeconds:     timeoutSeconds,
+	})
+}
+
+func executeVersion(ctx context.Context, client *dockerClient) (connectors.ActionResult, error) {
+	result, err := client.run(ctx, client.command+" version --format '{{json .}}'", 15)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	if result.ExitCode != 0 {
+		return connectors.ActionResult{}, dockerCommandError("docker version", result)
+	}
+	var output any
+	if err := json.Unmarshal([]byte(result.Stdout), &output); err != nil {
+		output = map[string]any{"raw": truncateString(result.Stdout, maxLogBytes)}
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"version":     output,
+			"duration_ms": result.DurationMS,
+		},
+		DisplayText: truncateString(result.Stdout, 4000),
+	}, nil
+}
+
+func executeListContainers(ctx context.Context, client *dockerClient, input map[string]any) (connectors.ActionResult, error) {
+	containers, err := client.listContainers(ctx, boolValue(input, "all", true))
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	sort.SliceStable(containers, func(i, j int) bool {
+		return strings.ToLower(containers[i].Name) < strings.ToLower(containers[j].Name)
+	})
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"containers": containers,
+			"count":      len(containers),
+			"scope_mode": client.scope.mode,
+		},
+		DisplayText: containersDisplay(containers),
+	}, nil
+}
+
+func executeInspectContainer(ctx context.Context, client *dockerClient, input map[string]any) (connectors.ActionResult, error) {
+	container, err := client.resolveContainer(ctx, stringValue(input, "container"))
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	result, err := client.run(ctx, client.command+" inspect -- "+shellQuote(container.Ref()), 20)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	if result.ExitCode != 0 {
+		return connectors.ActionResult{}, dockerCommandError("docker inspect", result)
+	}
+	if len(result.Stdout) > maxInspectBytes {
+		return connectors.ActionResult{}, fmt.Errorf("docker inspect output is larger than %d bytes", maxInspectBytes)
+	}
+	raw := result.Stdout
+	var inspect []map[string]any
+	if err := json.Unmarshal([]byte(raw), &inspect); err != nil {
+		return connectors.ActionResult{}, fmt.Errorf("parse docker inspect output: %w", err)
+	}
+	redacted := redactInspect(inspect)
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"container": container,
+			"inspect":   redacted,
+		},
+		DisplayText: fmt.Sprintf("Inspected Docker container %s.", container.Name),
+	}, nil
+}
+
+func executeContainerLogs(ctx context.Context, client *dockerClient, input map[string]any) (connectors.ActionResult, error) {
+	container, err := client.resolveContainer(ctx, stringValue(input, "container"))
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	tail := normalizeInt(input, "tail", defaultLogTail, 1, maxLogTail)
+	result, err := client.run(ctx, fmt.Sprintf("%s logs --tail %d --timestamps -- %s 2>&1", client.command, tail, shellQuote(container.Ref())), 30)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	if result.ExitCode != 0 {
+		return connectors.ActionResult{}, dockerCommandError("docker logs", result)
+	}
+	logs := truncateString(result.Stdout, maxLogBytes)
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"container":   container,
+			"tail":        tail,
+			"logs":        logs,
+			"duration_ms": result.DurationMS,
+		},
+		DisplayText: logs,
+	}, nil
+}
+
+func executeContainerLifecycle(ctx context.Context, client *dockerClient, input map[string]any, operation string) (connectors.ActionResult, error) {
+	container, err := client.resolveContainer(ctx, stringValue(input, "container"))
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	timeout := normalizeInt(input, "timeout_seconds", 10, 1, 120)
+	command := fmt.Sprintf("%s %s", client.command, operation)
+	if operation == "stop" || operation == "restart" {
+		command = fmt.Sprintf("%s %s --time %d", client.command, operation, timeout)
+	}
+	result, err := client.run(ctx, command+" -- "+shellQuote(container.Ref())+" 2>&1", timeout+20)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	if result.ExitCode != 0 {
+		return connectors.ActionResult{}, dockerCommandError("docker "+operation, result)
+	}
+	output := map[string]any{
+		"container":   container,
+		"operation":   operation,
+		"response":    strings.TrimSpace(result.Stdout),
+		"duration_ms": result.DurationMS,
+	}
+	if refreshed, err := client.resolveContainer(ctx, container.Ref()); err == nil {
+		output["container"] = refreshed
+	} else {
+		output["refresh_error"] = err.Error()
+	}
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      output,
+		DisplayText: fmt.Sprintf("Docker container %s %s completed.", container.Name, operation),
+	}, nil
+}
+
+type DockerContainer struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Image   string `json:"image"`
+	Command string `json:"command,omitempty"`
+	State   string `json:"state"`
+	Status  string `json:"status"`
+	Ports   string `json:"ports,omitempty"`
+	Labels  string `json:"labels,omitempty"`
+}
+
+func (container DockerContainer) Ref() string {
+	if strings.TrimSpace(container.Name) != "" {
+		return container.Name
+	}
+	return container.ID
+}
+
+func (client *dockerClient) listContainers(ctx context.Context, includeStopped bool) ([]DockerContainer, error) {
+	args := "ps --no-trunc --format '{{json .}}'"
+	if includeStopped {
+		args = "ps -a --no-trunc --format '{{json .}}'"
+	}
+	result, err := client.run(ctx, client.command+" "+args, 20)
+	if err != nil {
+		return nil, err
+	}
+	if result.ExitCode != 0 {
+		return nil, dockerCommandError("docker ps", result)
+	}
+	containers, err := parseDockerPS(result.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	filtered := containers[:0]
+	for _, container := range containers {
+		if client.scope.allows(container) {
+			filtered = append(filtered, container)
+		}
+	}
+	return filtered, nil
+}
+
+func (client *dockerClient) resolveContainer(ctx context.Context, requested string) (DockerContainer, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return DockerContainer{}, fmt.Errorf("container is required")
+	}
+	containers, err := client.listContainers(ctx, true)
+	if err != nil {
+		return DockerContainer{}, err
+	}
+	for _, container := range containers {
+		if container.Name == requested || container.ID == requested || strings.HasPrefix(container.ID, requested) {
+			return container, nil
+		}
+	}
+	return DockerContainer{}, fmt.Errorf("%w: %s", ErrScopeDenied, requested)
+}
+
+func parseDockerPS(data string) ([]DockerContainer, error) {
+	var containers []DockerContainer
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			return nil, fmt.Errorf("parse docker ps row: %w", err)
+		}
+		container := DockerContainer{
+			ID:      strings.TrimSpace(stringValue(row, "ID")),
+			Name:    strings.TrimSpace(stringValue(row, "Names")),
+			Image:   strings.TrimSpace(stringValue(row, "Image")),
+			Command: strings.TrimSpace(stringValue(row, "Command")),
+			State:   strings.TrimSpace(stringValue(row, "State")),
+			Status:  strings.TrimSpace(stringValue(row, "Status")),
+			Ports:   strings.TrimSpace(stringValue(row, "Ports")),
+			Labels:  strings.TrimSpace(stringValue(row, "Labels")),
+		}
+		if container.ID == "" && container.Name == "" {
+			continue
+		}
+		containers = append(containers, container)
+	}
+	return containers, nil
+}
+
+type dockerScope struct {
+	mode     string
+	exact    []string
+	patterns []string
+}
+
+func dockerScopeFromProfile(profile connectors.CredentialProfileView) dockerScope {
+	mode := scopeMode(profile)
+	return dockerScope{
+		mode:     mode,
+		exact:    splitLines(stringValue(profile.Public, "allowed_containers")),
+		patterns: splitLines(stringValue(profile.Public, "allowed_patterns")),
+	}
+}
+
+func (scope dockerScope) allows(container DockerContainer) bool {
+	if scope.mode != "selected" {
+		return true
+	}
+	candidates := []string{container.ID, container.Name}
+	if len(container.ID) >= 12 {
+		candidates = append(candidates, container.ID[:12])
+	}
+	for _, allowed := range scope.exact {
+		for _, candidate := range candidates {
+			if allowed == candidate || strings.HasPrefix(container.ID, allowed) {
+				return true
+			}
+		}
+	}
+	for _, pattern := range scope.patterns {
+		if ok, _ := path.Match(pattern, container.Name); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func scopeMode(profile connectors.CredentialProfileView) string {
+	mode := strings.TrimSpace(stringValue(profile.Public, "scope_mode"))
+	if mode == "selected" {
+		return "selected"
+	}
+	return "all"
+}
+
+func connectionMode(target connectors.TargetView) string {
+	mode := strings.TrimSpace(stringValue(target.Config, "connection_mode"))
+	if mode == "" {
+		return "over_ssh"
+	}
+	return mode
+}
+
+func dockerCommand(target connectors.TargetView) string {
+	value := strings.TrimSpace(stringValue(target.Config, "docker_command"))
+	if value == "" {
+		value = "docker"
+	}
+	if strings.ContainsAny(value, "\n\r\t;&|`$<>") {
+		return ""
+	}
+	return value
+}
+
+func normalizeContainerInput(input map[string]any) (string, error) {
+	container := strings.TrimSpace(stringValue(input, "container"))
+	if container == "" {
+		return "", fmt.Errorf("container is required")
+	}
+	if strings.ContainsAny(container, "\x00\n\r") {
+		return "", fmt.Errorf("container contains unsupported characters")
+	}
+	return container, nil
+}
+
+func dockerCommandError(command string, result connectors.CommandRunResult) error {
+	message := strings.TrimSpace(result.Stderr)
+	if message == "" {
+		message = strings.TrimSpace(result.Stdout)
+	}
+	if message == "" {
+		message = fmt.Sprintf("%s failed with exit code %d", command, result.ExitCode)
+	}
+	return fmt.Errorf("%s failed: %s", command, truncateString(message, 4000))
+}
+
+func containersDisplay(containers []DockerContainer) string {
+	if len(containers) == 0 {
+		return "No Docker containers matched this profile scope."
+	}
+	lines := make([]string, 0, len(containers))
+	for _, container := range containers {
+		lines = append(lines, fmt.Sprintf("%s\t%s\t%s\t%s", container.Name, container.Image, container.State, container.Status))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func redactInspect(items []map[string]any) []map[string]any {
+	for _, item := range items {
+		if config, ok := item["Config"].(map[string]any); ok {
+			if env, ok := config["Env"].([]any); ok {
+				redacted := make([]any, 0, len(env))
+				for _, value := range env {
+					text := fmt.Sprint(value)
+					name, _, found := strings.Cut(text, "=")
+					if found && strings.TrimSpace(name) != "" {
+						redacted = append(redacted, name+"=***")
+					} else {
+						redacted = append(redacted, "***")
+					}
+				}
+				config["Env"] = redacted
+			}
+		}
+	}
+	return items
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+func splitLines(value string) []string {
+	var out []string
+	for _, line := range strings.Split(value, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func copyMap(in map[string]any) map[string]any {
+	out := map[string]any{}
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func stringValue(values map[string]any, key string) string {
+	if values == nil {
+		return ""
+	}
+	switch value := values[key].(type) {
+	case string:
+		return value
+	case fmt.Stringer:
+		return value.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+func boolValue(values map[string]any, key string, fallback bool) bool {
+	if values == nil {
+		return fallback
+	}
+	switch value := values[key].(type) {
+	case bool:
+		return value
+	case string:
+		parsed, err := strconv.ParseBool(value)
+		if err == nil {
+			return parsed
+		}
+	case float64:
+		return value != 0
+	case int:
+		return value != 0
+	}
+	return fallback
+}
+
+func normalizeInt(values map[string]any, key string, fallback int, minValue int, maxValue int) int {
+	value := intValue(values, key, fallback)
+	if value < minValue {
+		return minValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}
+
+func intValue(values map[string]any, key string, fallback int) int {
+	if values == nil {
+		return fallback
+	}
+	switch value := values[key].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		parsed, err := value.Int64()
+		if err == nil {
+			return int(parsed)
+		}
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(value))
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func truncateString(value string, maxBytes int) string {
+	if maxBytes <= 0 || len(value) <= maxBytes {
+		return value
+	}
+	return value[:maxBytes] + "\n...[truncated]"
+}

--- a/backend/internal/connectors/docker/docker_test.go
+++ b/backend/internal/connectors/docker/docker_test.go
@@ -1,0 +1,182 @@
+package dockerconnector
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+func TestPrepareActionRejectsEmptyContainer(t *testing.T) {
+	_, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     dockerTarget(),
+		Profile:    dockerProfile("selected"),
+		ActionName: ActionContainerLogs,
+		Input:      map[string]any{"container": " "},
+	})
+	if err == nil {
+		t.Fatal("expected empty container error")
+	}
+}
+
+func TestExecuteActionFiltersContainersByProfileScope(t *testing.T) {
+	transport := &fakeCommandTransport{
+		results: map[string]connectors.CommandRunResult{
+			"docker ps -a --no-trunc --format '{{json .}}'": {Stdout: strings.Join([]string{
+				`{"ID":"111111111111","Names":"api","Image":"app:latest","State":"running","Status":"Up 1 hour"}`,
+				`{"ID":"222222222222","Names":"db","Image":"postgres:16","State":"running","Status":"Up 1 hour"}`,
+			}, "\n")},
+		},
+	}
+	result, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       dockerTarget(),
+		Profile:      dockerProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}, connectors.PreparedAction{ActionName: ActionListContainers, Payload: map[string]any{"all": true}})
+	if err != nil {
+		t.Fatalf("execute list: %v", err)
+	}
+	output, _ := result.Output.(map[string]any)
+	containers, _ := output["containers"].([]DockerContainer)
+	if len(containers) != 1 || containers[0].Name != "api" {
+		t.Fatalf("unexpected containers: %#v", containers)
+	}
+}
+
+func TestExecuteActionRejectsOutOfScopeContainer(t *testing.T) {
+	transport := &fakeCommandTransport{
+		results: map[string]connectors.CommandRunResult{
+			"docker ps -a --no-trunc --format '{{json .}}'": {Stdout: strings.Join([]string{
+				`{"ID":"111111111111","Names":"api","Image":"app:latest","State":"running","Status":"Up 1 hour"}`,
+				`{"ID":"222222222222","Names":"db","Image":"postgres:16","State":"running","Status":"Up 1 hour"}`,
+			}, "\n")},
+		},
+	}
+	_, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       dockerTarget(),
+		Profile:      dockerProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}, connectors.PreparedAction{ActionName: ActionContainerLogs, Payload: map[string]any{"container": "db", "tail": 20}})
+	if err == nil || !strings.Contains(err.Error(), ErrScopeDenied.Error()) {
+		t.Fatalf("expected scope denied error, got %v", err)
+	}
+}
+
+func TestInspectRedactsEnvironment(t *testing.T) {
+	transport := &fakeCommandTransport{
+		results: map[string]connectors.CommandRunResult{
+			"docker ps -a --no-trunc --format '{{json .}}'": {Stdout: `{"ID":"111111111111","Names":"api","Image":"app:latest","State":"running","Status":"Up 1 hour"}`},
+			"docker inspect -- 'api'":                       {Stdout: `[{"Config":{"Env":["TOKEN=secret","DEBUG=true"]}}]`},
+		},
+	}
+	result, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       dockerTarget(),
+		Profile:      dockerProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}, connectors.PreparedAction{ActionName: ActionInspectContainer, Payload: map[string]any{"container": "api"}})
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if strings.Contains(toJSON(t, result.Output), "secret") {
+		t.Fatalf("inspect output contains unredacted secret: %#v", result.Output)
+	}
+}
+
+func TestLifecycleReturnsRefreshedContainerState(t *testing.T) {
+	transport := &fakeCommandTransport{
+		sequences: map[string][]connectors.CommandRunResult{
+			"docker ps -a --no-trunc --format '{{json .}}'": {
+				{Stdout: `{"ID":"111111111111","Names":"api","Image":"app:latest","State":"exited","Status":"Exited (0) 1 minute ago"}`},
+				{Stdout: `{"ID":"111111111111","Names":"api","Image":"app:latest","State":"running","Status":"Up 2 seconds"}`},
+			},
+		},
+		results: map[string]connectors.CommandRunResult{
+			"docker start -- 'api' 2>&1": {Stdout: "api\n"},
+		},
+	}
+	result, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       dockerTarget(),
+		Profile:      dockerProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}, connectors.PreparedAction{ActionName: ActionStartContainer, Payload: map[string]any{"container": "api"}})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	output, _ := result.Output.(map[string]any)
+	container, _ := output["container"].(DockerContainer)
+	if container.State != "running" {
+		t.Fatalf("expected refreshed running state, got %#v", container)
+	}
+}
+
+func dockerTarget() connectors.TargetView {
+	return connectors.TargetView{
+		ID:            1,
+		Ref:           "docker:1:10",
+		ConnectorKind: Kind,
+		Name:          "docker-host",
+		Config:        map[string]any{"connection_mode": "over_ssh", "transport_target_ref": "ssh:2:20", "docker_command": "docker"},
+	}
+}
+
+func dockerProfile(scopeMode string) connectors.CredentialProfileView {
+	return connectors.CredentialProfileView{
+		ID:            10,
+		TargetID:      1,
+		ConnectorKind: Kind,
+		Kind:          "container_scope",
+		Label:         "api-only",
+		Public:        map[string]any{"scope_mode": scopeMode, "allowed_containers": "api"},
+	}
+}
+
+type fakeCapabilities struct {
+	transport connectors.CommandTransport
+}
+
+func (capabilities fakeCapabilities) RuntimeCapability(name string) connectors.RuntimeCapability {
+	if name == connectors.CommandTransportCapabilityName {
+		return capabilities.transport
+	}
+	return nil
+}
+
+type fakeCommandTransport struct {
+	results   map[string]connectors.CommandRunResult
+	sequences map[string][]connectors.CommandRunResult
+	calls     map[string]int
+}
+
+func (transport *fakeCommandTransport) ConnectorRuntimeCapability() string {
+	return connectors.CommandTransportCapabilityName
+}
+
+func (transport *fakeCommandTransport) RunConnectorCommand(_ context.Context, request connectors.CommandRunRequest) (connectors.CommandRunResult, error) {
+	if sequence := transport.sequences[request.Command]; len(sequence) > 0 {
+		if transport.calls == nil {
+			transport.calls = map[string]int{}
+		}
+		index := transport.calls[request.Command]
+		if index >= len(sequence) {
+			index = len(sequence) - 1
+		}
+		transport.calls[request.Command]++
+		return sequence[index], nil
+	}
+	result, ok := transport.results[request.Command]
+	if !ok {
+		return connectors.CommandRunResult{ExitCode: 127, Stderr: "unexpected command: " + request.Command}, nil
+	}
+	return result, nil
+}
+
+func toJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+	return string(data)
+}

--- a/backend/internal/connectors/ssh/apiadapter/adapter.go
+++ b/backend/internal/connectors/ssh/apiadapter/adapter.go
@@ -476,6 +476,31 @@ func (conn sshTCPConn) Close() error {
 	return clientErr
 }
 
+func (adapter) RunConnectorCommand(ctx context.Context, server connectorapi.GatewayServer, runtime connectorapi.GatewayRuntime, targetRef string, command string) (connectors.CommandRunResult, error) {
+	gateway, err := serverFrom(server)
+	if err != nil {
+		return connectors.CommandRunResult{}, err
+	}
+	runtimeID, err := runtimeIDForTargetRef(ctx, runtime, targetRef)
+	if err != nil {
+		return connectors.CommandRunResult{}, err
+	}
+	target, privateKey, err := targetMaterial(ctx, runtime, runtimeID)
+	if err != nil {
+		return connectors.CommandRunResult{}, fmt.Errorf("resolve ssh material: %w", err)
+	}
+	result, err := execution.RunCommand(ctx, executionTarget(gateway, target, privateKey), command)
+	if err != nil {
+		return connectors.CommandRunResult{}, err
+	}
+	return connectors.CommandRunResult{
+		Stdout:     result.Stdout,
+		Stderr:     result.Stderr,
+		ExitCode:   result.ExitCode,
+		DurationMS: result.DurationMS,
+	}, nil
+}
+
 func (adapter) SupportsRunning(prepared actions.PreparedRequest) bool {
 	return prepared.Target.ConnectorKind == sshconnector.Kind && prepared.Action.ActionName == sshconnector.ActionExec
 }

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -1,9 +1,9 @@
 # MCP Tools
 
 The MCP surface is connector-first. AIPermission does not expose separate
-product-specific MCP wrappers for SSH, database, cache, or queue products. SSH,
-Postgres, Redis, RabbitMQ, and future integrations are reached through the same
-connector target/action pipeline.
+product-specific MCP wrappers for SSH, database, cache, queue, or container
+products. SSH, Postgres, Redis, RabbitMQ, Docker, and future integrations are
+reached through the same connector target/action pipeline.
 
 Recommended package use:
 
@@ -51,6 +51,7 @@ ssh:3:1
 postgres:7:2
 redis:8:3
 rabbitmq:9:4
+docker:10:5
 ```
 
 The profile chooses which stored credential is used. The connector action still
@@ -58,8 +59,8 @@ runs locally through the gateway; AIPermission does not host a remote connector
 service.
 
 Clients should discover targets and actions at runtime. Do not hardcode SSH,
-Postgres, Redis, or RabbitMQ as special MCP modes; future connector kinds use
-the same tools and `target_ref` shape.
+Postgres, Redis, RabbitMQ, or Docker as special MCP modes; future connector
+kinds use the same tools and `target_ref` shape.
 
 ## list_connector_targets
 
@@ -143,6 +144,13 @@ queue listing, queue detail reads, binding listing, and bounded message peeking
 with `ack_requeue_true`, plus explicit `publish_message` writes. Message
 payload previews and published payloads may contain secrets or customer data;
 prefer approval-required access until the workflow is trusted.
+
+Docker actions include version metadata, scoped container listing, redacted
+container inspect metadata, bounded container log tails, and explicit
+start/stop/restart lifecycle actions. Docker profiles can be scoped to all
+containers, selected names/IDs, or name patterns. If a token is bound to a
+profile that allows one container, MCP can only list or operate on that
+container through Docker actions.
 
 ## call_connector_action
 

--- a/docs/development/add-a-connector.md
+++ b/docs/development/add-a-connector.md
@@ -69,9 +69,9 @@ These rules are part of the connector contract:
 Connector-specific gateway capabilities live behind adapter contracts in
 `internal/api/connector_api_adapters.go`. SSH uses those contracts for
 persistent PTY sessions, SFTP transfer, host-key approval, key
-generation/import, and remote authorized_keys cleanup. Generic route handlers
-must ask the adapter what the connector supports instead of branching on a
-connector kind.
+generation/import, reviewed TCP transport, reviewed command transport, and
+remote authorized_keys cleanup. Generic route handlers must ask the adapter
+what the connector supports instead of branching on a connector kind.
 
 Adapter methods use the typed `connectorapi.GatewayRuntime`,
 `connectorapi.GatewayServer`, `connectorapi.TargetLifecycleGateway`, and
@@ -184,6 +184,18 @@ adapters. Normal structured connectors should not depend on arbitrary gateway
 services. If a new connector needs a capability similar to live terminals,
 file transfer, or async progress, first define a reusable typed adapter
 contract and document why the shared action runner is not enough.
+
+Use existing reviewed capabilities before inventing connector-specific routes:
+
+- `NetworkTransport` opens direct or Over SSH TCP connections for protocol
+  connectors such as Postgres, Redis, and RabbitMQ.
+- `CommandTransport` runs bounded connector-owned command templates through a
+  reviewed connector transport such as SSH. Docker uses this for fixed Docker
+  CLI templates while keeping arbitrary shell and `docker exec` out of scope.
+
+Do not import the SSH connector package from another connector. Ask for a
+generic capability such as `NetworkTransport` or `CommandTransport`; the
+gateway resolves the selected transport profile.
 
 ## Frontend Templates
 

--- a/docs/mvp/scope.md
+++ b/docs/mvp/scope.md
@@ -11,7 +11,7 @@ Main target:
 The MVP is not a DevOps platform. It does not own production operations. It gives a developer a controlled, token-scoped, auditable execution channel for debugging, maintenance, incident triage, and temporary AI-assisted automation.
 
 The MVP does not introduce first-class management modules for every external
-system. It introduces one connector pipeline. SSH, Postgres, Redis, RabbitMQ, and future
+system. It introduces one connector pipeline. SSH, Postgres, Redis, RabbitMQ, Docker, and future
 integrations are connector kinds that provide their own actions while sharing
 the same target/profile/action permission model. If an allowed SSH target has
 the needed CLI tools and access, the AI can operate at command level through
@@ -37,6 +37,8 @@ The gateway itself is local-only. It is not designed to run on a remote server f
   SFTP transfer, and host-key approval
 - built-in Postgres connector with schema/table inspection and bounded
   read-only query actions
+- built-in Redis, RabbitMQ, and Docker connectors for scoped cache, queue, and
+  container operations through the shared connector pipeline
 - API token creation and revocation
 - token-to-target/profile/action permissions
 - execution rules: `always_run`, `approval_required`, `blocked`

--- a/docs/skills/aipermission-docs/SKILL.md
+++ b/docs/skills/aipermission-docs/SKILL.md
@@ -133,7 +133,7 @@ Use the established aipermission naming:
 - `gateway` is the local backend that owns credentials, policy, execution, approvals, and audit.
 - `MCP client` means Cursor, Windsurf, or another AI tool integration.
 - `API token` means the gateway access token used by MCP/API clients.
-- `connector target` means a saved SSH, Postgres, Redis, RabbitMQ, or future integration target.
+- `connector target` means a saved SSH, Postgres, Redis, RabbitMQ, Docker, or future integration target.
 - `server` is acceptable only when specifically describing an SSH connector target.
 - `database` means a configured Postgres connector target/profile.
 - `execution rule` means `always_run`, `approval_required`, or `blocked`.

--- a/docs/whatis-aipermission.md
+++ b/docs/whatis-aipermission.md
@@ -13,13 +13,14 @@ Related central notes:
 operate on connector targets without receiving SSH private keys, SSH passwords,
 database credentials, API credentials, or other connector secrets.
 
-The current model ships with SSH, Postgres, Redis, and RabbitMQ connectors. SSH
-provides live terminal/file-transfer actions, Postgres provides structured
-metadata and bounded read-only query actions, Redis provides bounded key
-browsing plus explicit write/delete actions, and RabbitMQ provides queue
-metadata, bindings, bounded message previews, and explicit message publishing.
-They use the same target, credential profile, token permission, approval,
-history, and audit pipeline.
+The current model ships with SSH, Postgres, Redis, RabbitMQ, and Docker
+connectors. SSH provides live terminal/file-transfer actions, Postgres provides
+structured metadata and bounded read-only query actions, Redis provides bounded
+key browsing plus explicit write/delete actions, RabbitMQ provides queue
+metadata, bindings, bounded message previews, and explicit message publishing,
+and Docker provides scoped container inventory, logs, redacted inspect metadata,
+and explicit lifecycle actions. They use the same target, credential profile,
+token permission, approval, history, and audit pipeline.
 
 The product is intentionally not positioned as a full DevOps platform.
 
@@ -56,6 +57,7 @@ When a developer debugs a real system with an AI assistant, the assistant often 
 - "Run this on core-1."
 - "Check Kubernetes state on control-1."
 - "Inspect worker-3 logs."
+- "Restart only the API container on this Docker host."
 - "Check this readonly PostgreSQL table."
 
 Without a tool like aipermission, the developer becomes a terminal operator:
@@ -144,7 +146,7 @@ aipermission gateway
         | auth + permission check + approval flow
         v
 Connector target
-SSH server / Postgres database / future local integration
+SSH server / Postgres database / Redis cache / RabbitMQ broker / Docker host / future local integration
 ```
 
 The AI assistant does not receive SSH credentials or database passwords.
@@ -232,12 +234,13 @@ allowed connector targets:
 - ssh:core-1/admin -> read_console always_run
 - postgres:main-db/readonly -> query_readonly approval_required
 - redis:cache/ops -> get_key approval_required
+- docker:prod-docker/api-only -> container_logs approval_required
 ```
 
 The AI assistant can see and use only the connector targets and actions allowed
 by that token. For example, if the token can access five SSH targets, one
-Postgres target, and one Redis target, `list_connector_targets` returns only
-those target/profile refs.
+Postgres target, one Redis target, and one Docker profile scoped to a single
+container, `list_connector_targets` returns only those target/profile refs.
 
 If the same token exists in more than one unlocked database, MCP authentication returns a conflict. The gateway does not guess which workspace should receive the command.
 
@@ -253,7 +256,7 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-SSH, Postgres, Redis, RabbitMQ, and future integrations are exposed as
+SSH, Postgres, Redis, RabbitMQ, Docker, and future integrations are exposed as
 connector actions instead of separate product-specific MCP tools.
 
 ## Connector Action Flow

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS build
+FROM node:24-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS build
 
 WORKDIR /app
 

--- a/frontend/e2e/app.spec.js
+++ b/frontend/e2e/app.spec.js
@@ -146,7 +146,7 @@ test("renders settings retention controls", async ({ page }) => {
   await page.getByRole("link", { name: /Settings/ }).click();
 
   await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Backup" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Backup", exact: true })).toBeVisible();
   await page.getByLabel("Command history days").fill("14");
   await page.getByLabel("Audit log days").fill("14");
   await page.getByRole("button", { name: "Save retention" }).click();

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^1.20.0",
+        "lucide-react": "^1.21.0",
         "monaco-editor": "^0.53.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -2217,9 +2217,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.20.0.tgz",
-      "integrity": "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^1.20.0",
+    "lucide-react": "^1.21.0",
     "monaco-editor": "^0.53.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/frontend/src/connectors/templates/docker/console.jsx
+++ b/frontend/src/connectors/templates/docker/console.jsx
@@ -1,0 +1,564 @@
+import { Container, FileJson, LoaderCircle, Play, Power, RefreshCcw, RotateCcw, Square } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "../../../components/ui/badge";
+import { Button } from "../../../components/ui/button";
+import { CopyButton } from "../../../components/ui/copy-button";
+import { Dialog } from "../../../components/ui/dialog";
+import { Input } from "../../../components/ui/form";
+import { TerminalBlock } from "../../../components/ui/terminal-block";
+import { apiPost } from "../../../lib/api";
+
+export function DockerConnectorConsoleTemplate({ target, approvals, theme, session, onNewStructuredSession, onRefreshActivity }) {
+  const activeSession = session || { active: false, startedAt: "" };
+  const [containers, setContainers] = useState([]);
+  const [selectedID, setSelectedID] = useState("");
+  const [filter, setFilter] = useState("");
+  const [tail, setTail] = useState(200);
+  const [viewMode, setViewMode] = useState("logs");
+  const [result, setResult] = useState(null);
+  const [resultSearch, setResultSearch] = useState("");
+  const [state, setState] = useState({ state: "idle", error: "", message: "" });
+  const [confirmDialog, setConfirmDialog] = useState({ open: false, title: "", description: "", details: [], actionName: "", pending: false });
+  const panelClass = theme === "light" ? "bg-white text-stone-900" : "bg-[#1e1e1e] text-stone-100";
+  const mutedClass = theme === "light" ? "text-stone-500" : "text-stone-400";
+  const borderClass = theme === "light" ? "border-stone-200" : "border-stone-700";
+  const subtlePanelClass = theme === "light" ? "bg-stone-50" : "bg-[#252526]";
+  const inputClass = theme === "light" ? "border-stone-300 bg-white text-stone-900 placeholder:text-stone-400" : "border-stone-700 bg-[#1a1a1a] text-stone-100 placeholder:text-stone-500";
+  const rowHoverClass = theme === "light" ? "hover:bg-stone-50" : "hover:bg-stone-800/60";
+  const activeRowClass = theme === "light" ? "border-emerald-200 bg-emerald-50 text-emerald-950" : "border-emerald-700 bg-emerald-950/40 text-emerald-100";
+  const activeItems = useMemo(() => (approvals?.data || []).filter((item) => item.target_ref === target.ref), [approvals?.data, target.ref]);
+  const latestAction = activeItems[0] || null;
+  const selectedContainer = containers.find((container) => container.id === selectedID || container.name === selectedID) || null;
+  const showingInspect = viewMode === "inspect";
+  const filteredContainers = useMemo(() => {
+    const query = filter.trim().toLowerCase();
+    if (!query) return containers;
+    return containers.filter((container) => [container.name, container.image, container.state, container.status, container.ports].some((value) => String(value || "").toLowerCase().includes(query)));
+  }, [containers, filter]);
+
+  useEffect(() => {
+    setContainers([]);
+    setSelectedID("");
+    setFilter("");
+    setViewMode("logs");
+    setResult(null);
+    setResultSearch("");
+    setState({ state: "idle", error: "", message: "" });
+  }, [target.ref, activeSession.active, activeSession.startedAt]);
+
+  useEffect(() => {
+    if (!activeSession.active) return;
+    void refreshContainers();
+  }, [activeSession.active, activeSession.startedAt, target.ref]);
+
+  async function runDockerAction({ actionName, input = {}, reason, busy = "running", showResult = true }) {
+    setState({ state: busy, error: "", message: "" });
+    try {
+      const item = await apiPost("/api/connector-actions/local-run", {
+        target_ref: target.ref,
+        action_name: actionName,
+        input,
+        reason,
+      });
+      setState({ state: "idle", error: "", message: showResult ? item.display_text || "" : "" });
+      if (showResult) setResult(item);
+      await onRefreshActivity?.();
+      return item;
+    } catch (error) {
+      setState({ state: "error", error: error.message || "Docker action failed.", message: "" });
+      throw error;
+    }
+  }
+
+  async function refreshContainers() {
+    const item = await runDockerAction({
+      actionName: "list_containers",
+      input: { all: true },
+      reason: "manual Docker browser container list",
+      busy: "loading",
+      showResult: false,
+    });
+    const next = item.output?.containers || [];
+    setContainers(next);
+    setSelectedID((current) => (current && next.some((container) => container.id === current || container.name === current) ? current : ""));
+  }
+
+  async function readLogs(container = selectedContainer) {
+    if (!container) return;
+    setViewMode("logs");
+    await runDockerAction({
+      actionName: "container_logs",
+      input: { container: container.name || container.id, tail: Number(tail) || 200 },
+      reason: "manual Docker browser logs read",
+      busy: "loading",
+    });
+  }
+
+  function selectContainer(container) {
+    if (selectedContainer && (selectedContainer.id === container.id || selectedContainer.name === container.name)) {
+      setSelectedID("");
+      setResult(null);
+      setResultSearch("");
+      return;
+    }
+    setSelectedID(container.id || container.name);
+    setResult(null);
+    setResultSearch("");
+    if (viewMode === "inspect") {
+      void inspectContainer(container);
+    } else {
+      void readLogs(container);
+    }
+  }
+
+  async function inspectContainer(container = selectedContainer) {
+    if (!container) return;
+    setViewMode("inspect");
+    await runDockerAction({
+      actionName: "inspect_container",
+      input: { container: container.name || container.id },
+      reason: "manual Docker browser inspect",
+      busy: "loading",
+    });
+  }
+
+  function openLifecycle(actionName) {
+    if (!selectedContainer) return;
+    const verb = actionName.replace("_container", "");
+    setConfirmDialog({
+      open: true,
+      title: `${capitalize(verb)} Docker container`,
+      description: `This will ${verb} the selected container through the Docker connector.`,
+      details: [
+        { label: "Container", value: selectedContainer.name || selectedContainer.id },
+        { label: "Image", value: selectedContainer.image },
+        { label: "Current status", value: selectedContainer.status },
+      ],
+      actionName,
+      pending: false,
+    });
+  }
+
+  async function confirmLifecycle() {
+    if (!confirmDialog.actionName || !selectedContainer) return;
+    setConfirmDialog((current) => ({ ...current, pending: true }));
+    const input = { container: selectedContainer.name || selectedContainer.id };
+    if (confirmDialog.actionName === "stop_container" || confirmDialog.actionName === "restart_container") {
+      input.timeout_seconds = 10;
+    }
+    try {
+      await runDockerAction({
+        actionName: confirmDialog.actionName,
+        input,
+        reason: "manual Docker browser lifecycle action",
+        busy: "writing",
+      });
+      setConfirmDialog({ open: false, title: "", description: "", details: [], actionName: "", pending: false });
+      await refreshContainers();
+    } catch {
+      setConfirmDialog((current) => ({ ...current, pending: false }));
+    }
+  }
+
+  if (!activeSession.active) {
+    return (
+      <div className={`grid min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
+        <div className="grid place-items-center p-8 text-center">
+          <div className="grid max-w-lg gap-4">
+            <Container className={`mx-auto h-10 w-10 ${mutedClass}`} />
+            <div>
+              <h3 className="text-lg font-semibold">No active Docker session</h3>
+              <p className={`mt-2 text-sm ${mutedClass}`}>Start a structured session to browse scoped Docker containers through the connector approval, history, and audit pipeline.</p>
+            </div>
+            <Button type="button" className="mx-auto" onClick={onNewStructuredSession}>
+              Start Docker session
+            </Button>
+          </div>
+        </div>
+        <DockerEndpointFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
+      <div className="grid min-h-0 gap-4 overflow-hidden p-4 lg:grid-cols-[360px_minmax(0,1fr)]">
+        <section className={`grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+          <div className={`border-b p-3 ${borderClass}`}>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold">Containers</p>
+                <p className={`text-xs ${mutedClass}`}>{containers.length} visible in this profile scope</p>
+              </div>
+              <div className="flex items-center gap-2">
+                {latestAction ? <Badge tone={latestAction.status === "failed" ? "bad" : latestAction.status === "completed" ? "good" : "warn"}>{latestAction.action_name}</Badge> : null}
+                <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Refresh containers" onClick={refreshContainers} disabled={state.state !== "idle"}>
+                  <RefreshCcw className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          </div>
+          <div className={`border-b p-3 ${borderClass}`}>
+            <Input className={inputClass} value={filter} onChange={(event) => setFilter(event.target.value)} placeholder="Search containers" />
+          </div>
+          <div className="min-h-0 overflow-auto">
+            {filteredContainers.length === 0 ? (
+              <div className={`p-4 text-sm ${mutedClass}`}>No containers matched this scope or search.</div>
+            ) : (
+              filteredContainers.map((container) => {
+                const active = selectedContainer && (selectedContainer.id === container.id || selectedContainer.name === container.name);
+                return (
+                  <button
+                    type="button"
+                    key={container.id || container.name}
+                    className={`grid w-full gap-1 border-b px-3 py-3 text-left text-sm ${borderClass} ${rowHoverClass} ${active ? activeRowClass : ""}`}
+                    onClick={() => selectContainer(container)}
+                  >
+                    <span className="flex min-w-0 items-center justify-between gap-3">
+                      <span className="truncate font-semibold">{container.name || container.id}</span>
+                      <Badge tone={container.state === "running" ? "good" : "neutral"}>{container.state || "unknown"}</Badge>
+                    </span>
+                    <span className={`truncate text-xs ${mutedClass}`}>{container.image}</span>
+                    <span className={`truncate text-xs ${mutedClass}`}>{container.status}</span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </section>
+
+        <section className={`grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+          <div className={`border-b p-3 ${borderClass}`}>
+            <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex min-w-0 items-center gap-2">
+                  <p className="truncate text-sm font-semibold">{selectedContainer?.name || "Select a container"}</p>
+                  {state.state !== "idle" ? (
+                    <span className={`inline-flex shrink-0 items-center gap-1 text-xs ${mutedClass}`}>
+                      <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                      Loading
+                    </span>
+                  ) : null}
+                </div>
+                <p className={`truncate text-xs ${mutedClass}`}>{selectedContainer?.image || "Choose a visible container to read logs, inspect metadata, or run lifecycle actions."}</p>
+              </div>
+              {selectedContainer ? (
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={showingInspect ? () => readLogs() : () => inspectContainer()} disabled={state.state !== "idle"} title={showingInspect ? "Show container logs" : "Inspect container"}>
+                    {showingInspect ? <RefreshCcw className="h-3.5 w-3.5" /> : <FileJson className="h-3.5 w-3.5" />}
+                    {showingInspect ? "Logs" : "Inspect"}
+                  </Button>
+                  {!showingInspect ? (
+                    <>
+                      <label className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
+                        Tail
+                        <Input className={`h-8 w-24 ${inputClass}`} type="number" min="1" max="2000" value={tail} onChange={(event) => setTail(event.target.value)} />
+                      </label>
+                      <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => readLogs()} disabled={state.state !== "idle"} title="Refresh logs">
+                        <RefreshCcw className="h-3.5 w-3.5" />
+                      </Button>
+                    </>
+                  ) : null}
+                  <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openLifecycle("start_container")} disabled={state.state !== "idle"} title="Start container">
+                    <Play className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openLifecycle("stop_container")} disabled={state.state !== "idle"} title="Stop container">
+                    <Square className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openLifecycle("restart_container")} disabled={state.state !== "idle"} title="Restart container">
+                    <RotateCcw className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          </div>
+          {state.error ? (
+            <div className={`border-b px-3 py-2 text-right text-xs text-red-500 ${borderClass}`}>
+              <span className="break-words">{state.error}</span>
+            </div>
+          ) : null}
+          <div className="grid min-h-0 overflow-hidden p-3">
+            {!selectedContainer ? (
+              <div className={`grid place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>Select a container from the list to read its logs.</div>
+            ) : state.state !== "idle" && !result ? (
+              <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>
+                <span className="inline-flex items-center gap-2">
+                  <LoaderCircle className="h-4 w-4 animate-spin" />
+                  Loading {showingInspect ? "inspect metadata" : "logs"} for {selectedContainer.name || selectedContainer.id}...
+                </span>
+              </div>
+            ) : result ? (
+              <DockerResultView item={result} search={resultSearch} onSearch={setResultSearch} inputClass={inputClass} />
+            ) : (
+              <div className={`grid place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>Logs will appear here after the container is loaded.</div>
+            )}
+          </div>
+        </section>
+      </div>
+      <DockerEndpointFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
+      <Dialog
+        open={confirmDialog.open}
+        title={confirmDialog.title}
+        description={confirmDialog.description}
+        size="md"
+        onClose={() => setConfirmDialog({ open: false, title: "", description: "", details: [], actionName: "", pending: false })}
+        closeDisabled={confirmDialog.pending}
+      >
+        <div className="grid gap-4">
+          <div className="grid gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
+            {confirmDialog.details.map((detail) => (
+              <div className="grid grid-cols-[120px_minmax(0,1fr)] gap-3" key={detail.label}>
+                <span className="font-semibold">{detail.label}</span>
+                <span className="min-w-0 break-words font-mono text-xs">{detail.value || "-"}</span>
+              </div>
+            ))}
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => setConfirmDialog({ open: false, title: "", description: "", details: [], actionName: "", pending: false })} disabled={confirmDialog.pending}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={confirmLifecycle} disabled={confirmDialog.pending}>
+              <Power className="h-4 w-4" />
+              {confirmDialog.pending ? "Running..." : "Run action"}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    </div>
+  );
+}
+
+function DockerResultView({ item, search, onSearch, inputClass }) {
+  const output = item.output || {};
+  const isLogs = item.action_name === "container_logs" && output.logs;
+  const isInspect = item.action_name === "inspect_container";
+  const text = isLogs ? formatDockerLogs(output.logs) : JSON.stringify(output, null, 2);
+  const copyValue = output.logs ? output.logs : JSON.stringify(output, null, 2);
+  const title = dockerResultTitle(item);
+  const subtitle = dockerResultSubtitle(item, output);
+  if (isInspect) {
+    const rawValue = JSON.stringify(output, null, 2);
+    return (
+      <div className="grid min-h-0 grid-rows-[auto_minmax(0,450px)_auto_minmax(0,1fr)] overflow-hidden">
+        <DockerResultHeader title={title} subtitle={subtitle} />
+        <DockerInspectSummary output={output} />
+        <div className="mt-3 flex items-center justify-between gap-3">
+          <p className="truncate text-xs font-semibold uppercase tracking-wide text-stone-500">Docker inspect raw data</p>
+          <div className="flex min-w-0 items-center justify-end gap-2">
+            <Input className={`h-8 w-56 text-xs ${inputClass || ""}`} value={search} onChange={(event) => onSearch?.(event.target.value)} placeholder="Search raw data" />
+            <CopyButton value={rawValue} variant="outline" className="h-8 px-2 text-xs" />
+          </div>
+        </div>
+        <div className="mt-2 grid min-h-0 overflow-hidden">
+          <TerminalBlock className="min-h-0 whitespace-pre-wrap break-words text-xs [overflow-wrap:anywhere]" surface="dark">
+            <HighlightedText text={rawValue} query={search} />
+          </TerminalBlock>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden">
+      <DockerResultHeader title={title} subtitle={subtitle} copyValue={copyValue} search={search} onSearch={onSearch} inputClass={inputClass} />
+      <TerminalBlock
+        className={isLogs ? "h-full min-h-0 max-h-full overflow-auto whitespace-pre text-xs" : "min-h-0 whitespace-pre-wrap break-words text-xs [overflow-wrap:anywhere]"}
+        surface={isLogs ? "log" : "dark"}
+        style={isLogs ? { whiteSpace: "pre", overflowWrap: "normal", wordBreak: "normal" } : { whiteSpace: "pre-wrap", overflowWrap: "anywhere", wordBreak: "break-word" }}
+      >
+        <HighlightedText text={text} query={search} />
+      </TerminalBlock>
+    </div>
+  );
+}
+
+function DockerResultHeader({ title, subtitle, copyValue, search, onSearch, inputClass }) {
+  return (
+    <div className="mb-2 flex items-center justify-between gap-3">
+      <div className="min-w-0">
+        <p className="truncate text-xs font-semibold uppercase tracking-wide text-stone-500">{title}</p>
+        {subtitle ? <p className="truncate text-xs text-stone-500">{subtitle}</p> : null}
+      </div>
+      <div className="flex min-w-0 items-center justify-end gap-2">
+        {onSearch ? <Input className={`h-8 w-56 text-xs ${inputClass || ""}`} value={search} onChange={(event) => onSearch(event.target.value)} placeholder="Search logs" /> : null}
+        {copyValue ? <CopyButton value={copyValue} variant="outline" className="h-8 px-2 text-xs" /> : null}
+      </div>
+    </div>
+  );
+}
+
+function HighlightedText({ text, query }) {
+  const value = String(text || "");
+  const needle = String(query || "");
+  if (!needle.trim()) return value;
+  const lowerValue = value.toLowerCase();
+  const lowerNeedle = needle.toLowerCase();
+  const parts = [];
+  let index = 0;
+  let matchIndex = lowerValue.indexOf(lowerNeedle, index);
+  let key = 0;
+  while (matchIndex !== -1) {
+    if (matchIndex > index) parts.push(value.slice(index, matchIndex));
+    parts.push(
+      <mark key={`m-${key++}`} className="rounded bg-yellow-300 px-0.5 text-stone-950">
+        {value.slice(matchIndex, matchIndex + needle.length)}
+      </mark>
+    );
+    index = matchIndex + needle.length;
+    matchIndex = lowerValue.indexOf(lowerNeedle, index);
+  }
+  if (index < value.length) parts.push(value.slice(index));
+  return parts;
+}
+
+function dockerResultTitle(item) {
+  if (item.action_name === "container_logs") return "Container logs";
+  if (item.action_name === "inspect_container") return "Docker inspect metadata";
+  return String(item.action_name || "Docker action").replaceAll("_", " ");
+}
+
+function dockerResultSubtitle(item, output) {
+  if (item.action_name === "container_logs") {
+    const container = output.container || {};
+    const name = container.name || container.id || "";
+    const tail = output.tail ? `tail ${output.tail}` : "";
+    return [name, tail].filter(Boolean).join(" · ");
+  }
+  if (item.action_name === "inspect_container") {
+    const container = output.container || {};
+    return container.name || container.id || "";
+  }
+  return item.display_text || "";
+}
+
+function DockerInspectSummary({ output }) {
+  const inspect = Array.isArray(output.inspect) ? output.inspect[0] || {} : {};
+  const container = output.container || {};
+  const state = inspect.State || {};
+  const config = inspect.Config || {};
+  const hostConfig = inspect.HostConfig || {};
+  const networkSettings = inspect.NetworkSettings || {};
+  const ports = summarizePorts(networkSettings.Ports);
+  const networks = summarizeNetworks(networkSettings.Networks);
+  const mounts = Array.isArray(inspect.Mounts) ? inspect.Mounts : [];
+  const labels = config.Labels && typeof config.Labels === "object" ? config.Labels : {};
+  const health = state.Health || {};
+  const rows = [
+    ["Name", stripSlash(inspect.Name) || container.name],
+    ["Image", config.Image || container.image || inspect.Image],
+    ["State", [state.Status || container.state, state.Running === true ? "running" : "", state.Restarting === true ? "restarting" : ""].filter(Boolean).join(" / ")],
+    ["Status", container.status],
+    ["Created", inspect.Created],
+    ["Started", state.StartedAt],
+    ["Finished", state.FinishedAt],
+    ["Exit code", state.ExitCode],
+    ["Health", health.Status],
+    ["Restart count", inspect.RestartCount],
+    ["Entrypoint", arrayOrString(config.Entrypoint)],
+    ["Command", arrayOrString(config.Cmd)],
+    ["Working dir", config.WorkingDir],
+    ["User", config.User],
+    ["Network mode", hostConfig.NetworkMode],
+    ["Networks", networks],
+    ["Ports", ports],
+    ["Mounts", mounts.map((mount) => `${mount.Type || "mount"} ${mount.Source || ""} -> ${mount.Destination || ""}`).filter(Boolean).join("\n")],
+    ["Labels", Object.keys(labels).length ? `${Object.keys(labels).length} labels` : ""],
+  ].filter(([, value]) => value !== undefined && value !== null && String(value).trim() !== "");
+
+  return (
+    <div className="min-h-0 overflow-auto rounded-md border border-stone-700 bg-[#1a1a1a] p-3">
+      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+        {rows.map(([label, value]) => (
+          <div key={label} className="min-w-0 rounded border border-stone-700 bg-[#202020] p-2">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-stone-500">{label}</p>
+            <p className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-stone-100">{String(value)}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function formatDockerLogs(logs) {
+  return String(logs || "")
+    .split("\n")
+    .map((line) => formatDockerLogLine(line))
+    .join("\n");
+}
+
+function formatDockerLogLine(line) {
+  const text = String(line || "");
+  if (!text.trim()) return text;
+  const firstBrace = text.indexOf("{");
+  const lastBrace = text.lastIndexOf("}");
+  if (firstBrace < 0 || lastBrace <= firstBrace) return text;
+  const prefixText = text.slice(0, firstBrace).trim();
+  const jsonText = text.slice(firstBrace, lastBrace + 1);
+  try {
+    const payload = JSON.parse(jsonText);
+    const timestamp = payload.Timestamp || prefixText || "";
+    const level = payload.Level || payload.level || payload.Severity || "";
+    const message = payload.MessageTemplate || payload.RenderedMessage || payload.Message || payload.message || jsonText;
+    const lines = [];
+    const prefix = [timestamp, level ? `[${level}]` : ""].filter(Boolean).join(" ");
+    lines.push(prefix || "Docker log");
+    lines.push(`  ${String(message)}`);
+    if (payload.Exception) lines.push(`  Exception: ${String(payload.Exception)}`);
+    const properties = payload.Properties && typeof payload.Properties === "object" ? payload.Properties : null;
+    if (properties) {
+      const details = Object.entries(properties)
+        .slice(0, 8)
+        .map(([key, value]) => `${key}=${shortValue(value)}`);
+      if (details.length > 0) lines.push(`  ${details.join(" ")}`);
+    }
+    return lines.join("\n");
+  } catch {
+    return text;
+  }
+}
+
+function stripSlash(value) {
+  return String(value || "").replace(/^\//, "");
+}
+
+function arrayOrString(value) {
+  if (Array.isArray(value)) return value.join(" ");
+  return value;
+}
+
+function summarizePorts(ports) {
+  if (!ports || typeof ports !== "object") return "";
+  return Object.entries(ports)
+    .map(([containerPort, bindings]) => {
+      if (!Array.isArray(bindings) || bindings.length === 0) return containerPort;
+      return bindings.map((binding) => `${binding.HostIp || "0.0.0.0"}:${binding.HostPort || ""}->${containerPort}`).join("\n");
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function summarizeNetworks(networks) {
+  if (!networks || typeof networks !== "object") return "";
+  return Object.entries(networks)
+    .map(([name, network]) => `${name}${network?.IPAddress ? ` ${network.IPAddress}` : ""}`)
+    .join("\n");
+}
+
+function shortValue(value) {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (!text) return "";
+  return text.length > 80 ? `${text.slice(0, 77)}...` : text;
+}
+
+function DockerEndpointFooter({ target, borderClass, mutedClass }) {
+  return (
+    <div className={`flex min-h-[44px] items-center justify-between gap-3 border-t px-4 py-2 text-xs ${borderClass}`}>
+      <span className={mutedClass}>Docker transport</span>
+      <span className="truncate font-mono">{target.config?.transport_target_ref || "not configured"}</span>
+    </div>
+  );
+}
+
+function capitalize(value) {
+  const text = String(value || "");
+  return text ? text[0].toUpperCase() + text.slice(1) : text;
+}

--- a/frontend/src/connectors/templates/docker/credential-form.jsx
+++ b/frontend/src/connectors/templates/docker/credential-form.jsx
@@ -1,0 +1,71 @@
+import { Container, Plus } from "lucide-react";
+import { Button } from "../../../components/ui/button";
+import { Field, Input, Select, Textarea } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+
+export function DockerCredentialFormTemplate({ targets, form, formMode = "create", state, onChange, onSubmit }) {
+  const dockerTargets = targets.filter((target) => target.connector_kind === "docker");
+  const editing = formMode === "edit";
+  return (
+    <form className="grid gap-4" onSubmit={onSubmit}>
+      {dockerTargets.length === 0 ? (
+        <Notice tone="warn">Create a Docker connector target before adding a Docker credential scope.</Notice>
+      ) : (
+        <Notice tone="good">
+          {editing ? "Update this Docker scope. Token permissions bound to this profile will use the new container scope immediately." : "Create a Docker scope, then bind tokens to this profile from Console or Tokens."}
+        </Notice>
+      )}
+      <Field>
+        Connector target
+        <Select value={form.target_id} onChange={(event) => onChange({ ...form, target_id: event.target.value })} disabled={editing} required>
+          <option value="" disabled>
+            Select Docker target
+          </option>
+          {dockerTargets.map((target) => (
+            <option value={target.id} key={target.id}>
+              {target.name} · {target.config?.transport_target_ref || "no transport"}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange({ ...form, profile_label: event.target.value })} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange({ ...form, risk_label: event.target.value })} />
+        </Field>
+      </div>
+      <Field>
+        Container scope
+        <Select value={form.scope_mode} onChange={(event) => onChange({ ...form, scope_mode: event.target.value })}>
+          <option value="all">All containers</option>
+          <option value="selected">Selected containers</option>
+        </Select>
+      </Field>
+      {form.scope_mode === "selected" ? (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Field>
+            Allowed containers
+            <Textarea rows={6} value={form.allowed_containers} onChange={(event) => onChange({ ...form, allowed_containers: event.target.value })} placeholder={"api\nweb\ncontainer-id-prefix"} />
+          </Field>
+          <Field>
+            Allowed name patterns
+            <Textarea rows={6} value={form.allowed_patterns} onChange={(event) => onChange({ ...form, allowed_patterns: event.target.value })} placeholder={"project-api-*\n*_worker"} />
+          </Field>
+        </div>
+      ) : null}
+      {state.state === "error" ? <Notice tone="bad">{state.error}</Notice> : null}
+      <Button type="submit" disabled={state.state === "saving" || dockerTargets.length === 0}>
+        <Plus className="h-4 w-4" />
+        {state.state === "saving" ? "Saving..." : editing ? "Save Docker scope" : "Create Docker scope"}
+      </Button>
+      <Notice>
+        <Container className="mr-2 inline h-4 w-4" />
+        Docker scopes contain public container allowlists only. Lifecycle writes still require token action permission and approval policy.
+      </Notice>
+    </form>
+  );
+}

--- a/frontend/src/connectors/templates/docker/form.jsx
+++ b/frontend/src/connectors/templates/docker/form.jsx
@@ -1,0 +1,77 @@
+import { Field, Input, Select, Textarea } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+
+export function DockerConnectorFormTemplate({ form, targets = [], onChange }) {
+  const sshProfiles = sshProfileOptions(targets);
+  return (
+    <>
+      <Notice tone="good">
+        Docker actions run through bounded command templates over an SSH connector profile. Start lifecycle actions in Prompt mode until the workflow is trusted.
+      </Notice>
+      <Field>
+        Connector name
+        <Input value={form.name} onChange={(event) => onChange("name", event.target.value)} required />
+      </Field>
+      <Field>
+        SSH transport profile
+        <Select value={form.transport_target_ref} onChange={(event) => onChange("transport_target_ref", event.target.value)} required>
+          <option value="" disabled>
+            Select SSH profile
+          </option>
+          {sshProfiles.map((profile) => (
+            <option value={profile.ref} key={profile.ref}>
+              {profile.label}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <Field>
+        Docker command
+        <Input value={form.docker_command} onChange={(event) => onChange("docker_command", event.target.value)} required />
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange("profile_label", event.target.value)} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange("risk_label", event.target.value)} />
+        </Field>
+      </div>
+      <Field>
+        Container scope
+        <Select value={form.scope_mode} onChange={(event) => onChange("scope_mode", event.target.value)}>
+          <option value="all">All containers</option>
+          <option value="selected">Selected containers</option>
+        </Select>
+      </Field>
+      {form.scope_mode === "selected" ? (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Field>
+            Allowed containers
+            <Textarea rows={5} value={form.allowed_containers} onChange={(event) => onChange("allowed_containers", event.target.value)} placeholder={"api\nweb\nf6fc4f91e616"} />
+          </Field>
+          <Field>
+            Allowed name patterns
+            <Textarea rows={5} value={form.allowed_patterns} onChange={(event) => onChange("allowed_patterns", event.target.value)} placeholder={"project-api-*\n*_worker"} />
+          </Field>
+        </div>
+      ) : null}
+      <Notice>
+        For one-container AI access, choose Selected containers and enter exactly that container name or ID. List/logs/restart actions are enforced against this profile scope.
+      </Notice>
+    </>
+  );
+}
+
+function sshProfileOptions(targets) {
+  return (targets || [])
+    .filter((target) => target.connector_kind === "ssh")
+    .flatMap((target) =>
+      (target.profiles || []).map((profile) => ({
+        ref: profile.ref || `${target.connector_kind}:${target.id}:${profile.id}`,
+        label: `${target.name} / ${profile.label} · ${target.config?.host || "host"}:${target.config?.port || 22}`,
+      }))
+    );
+}

--- a/frontend/src/connectors/templates/docker/index.jsx
+++ b/frontend/src/connectors/templates/docker/index.jsx
@@ -1,0 +1,15 @@
+import { DockerConnectorConsoleTemplate } from "./console";
+import { DockerCredentialFormTemplate } from "./credential-form";
+import { DockerConnectorFormTemplate } from "./form";
+import { DockerConnectorRowActionsTemplate } from "./list-item";
+import { DockerConnectorOperationsTemplate } from "./operations";
+import * as model from "./model";
+
+export default Object.freeze({
+  Console: DockerConnectorConsoleTemplate,
+  CredentialForm: DockerCredentialFormTemplate,
+  Form: DockerConnectorFormTemplate,
+  model,
+  Operations: DockerConnectorOperationsTemplate,
+  RowActions: DockerConnectorRowActionsTemplate,
+});

--- a/frontend/src/connectors/templates/docker/list-item.jsx
+++ b/frontend/src/connectors/templates/docker/list-item.jsx
@@ -1,0 +1,3 @@
+export function DockerConnectorRowActionsTemplate() {
+  return null;
+}

--- a/frontend/src/connectors/templates/docker/metadata.json
+++ b/frontend/src/connectors/templates/docker/metadata.json
@@ -1,0 +1,8 @@
+{
+  "kind": "docker",
+  "label": "Docker",
+  "summary": "Bounded container inventory, logs, inspect, and lifecycle actions through an SSH transport profile.",
+  "version": "0.2",
+  "icon": "server",
+  "badge_tone": "neutral"
+}

--- a/frontend/src/connectors/templates/docker/model.js
+++ b/frontend/src/connectors/templates/docker/model.js
@@ -1,0 +1,273 @@
+import { apiDelete, apiPost, apiPut } from "../../../lib/api";
+import { createTargetWithProfile, updateTargetWithProfile } from "../target-profile-save";
+
+const emptyDockerCredentialForm = { target_id: "", profile_label: "all-containers", scope_mode: "all", allowed_containers: "", allowed_patterns: "", risk_label: "container access" };
+
+export function emptyForm() {
+  return {
+    connector_kind: "docker",
+    name: "docker-host",
+    connection_mode: "over_ssh",
+    transport_target_ref: "",
+    docker_command: "docker",
+    profile_label: "all-containers",
+    scope_mode: "all",
+    allowed_containers: "",
+    allowed_patterns: "",
+    risk_label: "container access",
+  };
+}
+
+export function formFromTarget({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : {});
+  return {
+    connector_kind: "docker",
+    profile_id: selectedProfile.id ? String(selectedProfile.id) : "",
+    name: target.name || "",
+    connection_mode: target.config?.connection_mode || "over_ssh",
+    transport_target_ref: target.config?.transport_target_ref || "",
+    docker_command: target.config?.docker_command || "docker",
+    profile_label: selectedProfile.label || "all-containers",
+    scope_mode: selectedProfile.public?.scope_mode || "all",
+    allowed_containers: selectedProfile.public?.allowed_containers || "",
+    allowed_patterns: selectedProfile.public?.allowed_patterns || "",
+    risk_label: selectedProfile.risk_label || "container access",
+  };
+}
+
+export function activeCredential() {
+  return null;
+}
+
+export function syncForm({ form }) {
+  if (form.connector_kind !== "docker") return form;
+  return { ...form, connection_mode: "over_ssh", docker_command: form.docker_command || "docker" };
+}
+
+export function submitDisabled({ state, form }) {
+  return state.state === "saving" || !form.transport_target_ref;
+}
+
+export function submitLabel({ state, mode }) {
+  if (state.state === "saving") return "Saving...";
+  return mode === "edit" ? "Save changes" : "Create connector";
+}
+
+export async function save({ mode, form, target }) {
+  if (mode === "edit") {
+    await updateTarget({ form, target });
+    return;
+  }
+  await createTarget({ form });
+}
+
+export async function deleteTarget({ target }) {
+  await apiDelete(`/api/connector-targets/${target.id}`);
+}
+
+export function emptyCredentialState({ targets = [] } = {}) {
+  const firstTarget = targets.find((target) => target.connector_kind === "docker");
+  return {
+    form: {
+      ...emptyDockerCredentialForm,
+      target_id: String(firstTarget?.id || ""),
+    },
+  };
+}
+
+export function credentialStateFromRow({ row }) {
+  return {
+    form: {
+      target_id: String(row.target_id || ""),
+      profile_label: row.name,
+      scope_mode: row.profile?.public?.scope_mode || "all",
+      allowed_containers: row.profile?.public?.allowed_containers || "",
+      allowed_patterns: row.profile?.public?.allowed_patterns || "",
+      risk_label: row.profile?.risk_label || "",
+    },
+  };
+}
+
+export function credentialFormProps({ targets, formState, setFormState, formMode, state, onSubmit }) {
+  return {
+    form: formState.form,
+    formMode,
+    targets,
+    state,
+    onChange: (form) => setFormState({ form }),
+    onSubmit: (event) => onSubmit(event, formMode === "edit" ? "update" : "create"),
+  };
+}
+
+export async function saveCredential({ operation, row, formState }) {
+  const form = formState.form;
+  const payload = {
+    kind: "container_scope",
+    label: form.profile_label,
+    public: {
+      scope_mode: form.scope_mode || "all",
+      allowed_containers: form.allowed_containers || "",
+      allowed_patterns: form.allowed_patterns || "",
+    },
+    secret: {},
+    risk_label: form.risk_label,
+  };
+  if (operation === "create") {
+    await apiPost(`/api/connector-targets/${form.target_id}/profiles`, payload);
+    return { message: "Docker credential scope created." };
+  }
+  if (operation === "update") {
+    if (!row) throw new Error("Docker credential scope is not loaded.");
+    await apiPut(`/api/connector-targets/${form.target_id}/profiles/${row.id}`, payload);
+    return { message: "Docker credential scope updated." };
+  }
+  throw new Error("Unsupported Docker credential operation.");
+}
+
+export async function deleteCredential({ row }) {
+  await apiDelete(`/api/connector-targets/${row.target_id}/profiles/${row.id}`);
+}
+
+export function credentialRows({ targets }) {
+  return targets.flatMap((target) =>
+    (target.profiles || [])
+      .filter((profile) => target.connector_kind === "docker")
+      .map((profile) => ({
+        row_id: `${target.connector_kind}:${target.id}:${profile.id}`,
+        connector_kind: target.connector_kind,
+        resource_kind: "credential_profile",
+        connector_label: "Docker",
+        id: profile.id,
+        target_id: target.id,
+        name: profile.label,
+        kind: profile.kind,
+        profile,
+        target_label: target.name,
+        target_detail: targetEndpoint({ target }),
+        metadata: credentialMetadata(profile),
+        delete_disabled: "",
+      }))
+  );
+}
+
+export async function test({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!selectedProfile) throw new Error("Docker profile is not loaded.");
+  const data = await apiPost(`/api/connector-targets/${target.id}/profiles/${selectedProfile.id}/test`, {});
+  return { ok: data.ok, error: data.message || null, data };
+}
+
+export function canEdit() {
+  return true;
+}
+
+export function canDelete() {
+  return true;
+}
+
+export function credentialHint() {
+  return null;
+}
+
+export function targetEndpoint({ target }) {
+  const profile = target.config?.transport_target_ref || "no transport";
+  return `${target.config?.docker_command || "docker"} · ${profile}`;
+}
+
+export function targetDisplayName({ target }) {
+  if (!target) return "Docker target";
+  return target.target_name || target.name || "Docker target";
+}
+
+export function targetSubtitle({ target }) {
+  return targetEndpoint({ target });
+}
+
+export function targetProfileLabel({ target }) {
+  return target?.profile_label || "container scope";
+}
+
+export function usesLiveConsole() {
+  return false;
+}
+
+export function deleteDialog({ target }) {
+  return {
+    title: target ? `Delete ${target.name}` : "Delete connector",
+    description: "Remove this Docker connector target, credential scopes, and token action permissions from aipermission.",
+    details: [
+      { label: "Connector", value: target?.name },
+      { label: "Reference", value: target ? `${target.connector_kind}:${target.id}` : "" },
+    ],
+    notice: "This removes the connector target and its local permission metadata. It does not change Docker containers.",
+    actions: [
+      { label: "Cancel", action: "close", variant: "outline" },
+      { label: "Delete connector", pendingLabel: "Deleting...", removeKey: false },
+    ],
+  };
+}
+
+async function createTarget({ form }) {
+  await createTargetWithProfile({
+    targetPayload: {
+      connector_kind: "docker",
+      name: form.name,
+      config: dockerTargetConfigFromForm(form),
+    },
+    profilePayload: dockerProfilePayloadFromForm(form),
+  });
+}
+
+async function updateTarget({ form, target }) {
+  const profile = target?.profiles?.find((item) => Number(item.id) === Number(form.profile_id)) || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!target || !profile) throw new Error("Docker connector profile is not loaded.");
+  await updateTargetWithProfile({
+    targetID: target.id,
+    profileID: profile.id,
+    targetPayload: {
+      name: form.name,
+      config: dockerTargetConfigFromForm(form),
+    },
+    profilePayload: dockerProfilePayloadFromForm(form, profile.kind || "container_scope"),
+  });
+}
+
+function dockerTargetConfigFromForm(form) {
+  return {
+    connection_mode: "over_ssh",
+    transport_target_ref: form.transport_target_ref || "",
+    docker_command: form.docker_command || "docker",
+  };
+}
+
+function dockerProfilePayloadFromForm(form, kind = "container_scope") {
+  return {
+    kind,
+    label: form.profile_label,
+    public: {
+      scope_mode: form.scope_mode || "all",
+      allowed_containers: form.allowed_containers || "",
+      allowed_patterns: form.allowed_patterns || "",
+    },
+    secret: {},
+    risk_label: form.risk_label || "container access",
+  };
+}
+
+function credentialMetadata(profile) {
+  const scope = profile.public?.scope_mode === "selected" ? "selected containers" : "all containers";
+  const names = splitLines(profile.public?.allowed_containers || "");
+  const patterns = splitLines(profile.public?.allowed_patterns || "");
+  const items = [`scope: ${scope}`];
+  if (names.length > 0) items.push(`names: ${names.slice(0, 3).join(", ")}${names.length > 3 ? ` +${names.length - 3}` : ""}`);
+  if (patterns.length > 0) items.push(`patterns: ${patterns.slice(0, 3).join(", ")}${patterns.length > 3 ? ` +${patterns.length - 3}` : ""}`);
+  if (profile.risk_label) items.push(`risk: ${profile.risk_label}`);
+  return items;
+}
+
+function splitLines(value) {
+  return String(value || "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}

--- a/frontend/src/connectors/templates/docker/operations.jsx
+++ b/frontend/src/connectors/templates/docker/operations.jsx
@@ -1,0 +1,3 @@
+export function DockerConnectorOperationsTemplate() {
+  return null;
+}

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -236,7 +236,9 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.7"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.8"/);
+  assert.match(releaseSource, /Docker connector/);
+  assert.match(releaseSource, /Docker is now a built-in connector/);
   assert.match(releaseSource, /Maintenance and backup providers/);
   assert.match(releaseSource, /Settings now includes a local-only realtime Maintenance Console/);
   assert.match(releaseSource, /Backup providers are storage metadata only/);

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,35 @@
-export const appVersion = "0.2.7";
+export const appVersion = "0.2.8";
 
 export const changelogEntries = [
+  {
+    version: "0.2.8",
+    label: "Docker connector",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Docker is now a built-in connector that runs bounded Docker CLI templates through an SSH transport profile.",
+          "Docker actions cover version metadata, scoped container listing, redacted inspect metadata, bounded log tails, and explicit start/stop/restart lifecycle operations.",
+          "Docker Console adds a profile-scoped container browser with logs, inspect output, and lifecycle confirmation dialogs.",
+          "Docker credential profiles can scope a token to all containers, selected container names/IDs, or name patterns.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Connectors can now use a generic command transport capability for reviewed command templates without importing SSH-specific code.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "Docker does not expose arbitrary docker exec, container/image removal, prune, shell, or raw Docker command execution in this MVP.",
+          "Docker inspect output masks container environment values before returning structured output.",
+          "Container-targeted Docker actions resolve the requested container and enforce the credential profile scope before execution.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.7",
     label: "Maintenance and backup providers",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^1.20.0",
+        "lucide-react": "^1.21.0",
         "monaco-editor": "^0.53.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -2190,9 +2190,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.20.0.tgz",
-      "integrity": "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,7 +2564,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -8,9 +8,9 @@ credentials, or other connector secrets.
 
 The gateway is intentionally local-only. Run it on the developer machine and
 keep the URL on `localhost`; remote systems are connector targets, not places
-to host the gateway for LAN or internet users. SSH, Postgres, Redis, and RabbitMQ are
-built-in connectors that use the same target/profile/action permission model
-as future connectors.
+to host the gateway for LAN or internet users. SSH, Postgres, Redis, RabbitMQ,
+and Docker are built-in connectors that use the same target/profile/action
+permission model as future connectors.
 
 ![AIPermission demo: AI operates through approval-based connector access](https://raw.githubusercontent.com/aipermission/aipermission/main/docs/assets/demo/aipermission-demo.gif)
 
@@ -61,9 +61,10 @@ The generated MCP config contains a bearer token. Keep it private. For project-l
 - `call_connector_action`
 - `get_connector_action_request`
 
-All integration work goes through connector targets. SSH, Postgres, Redis, RabbitMQ, and future
-connectors share the same model: target, credential profile, connector action,
-token action permission, approval, history, and audit.
+All integration work goes through connector targets. SSH, Postgres, Redis,
+RabbitMQ, Docker, and future connectors share the same model: target,
+credential profile, connector action, token action permission, approval,
+history, and audit.
 
 For SSH, call `get_connector_actions(target_ref)` to discover actions such as
 `exec`, `read_console`, `restart_console_session`, `browse_remote_files`, and
@@ -84,6 +85,14 @@ browser actions such as `overview`, `list_vhosts`, `list_queues`, `get_queue`,
 `list_bindings`, `peek_messages`, and `publish_message`. Message payload
 previews and published payloads can contain secrets or customer data; use short
 reasons and prefer approval-required access until the workflow is trusted.
+
+For Docker, call `get_connector_actions(target_ref)` to discover bounded
+container actions such as `docker_version`, `list_containers`,
+`inspect_container`, `container_logs`, `start_container`, `stop_container`, and
+`restart_container`. Docker credential profiles can scope a token to all
+containers, selected container names/IDs, or name patterns. The Docker
+connector does not expose arbitrary `docker exec`, prune, removal, shell, or raw
+Docker command execution.
 
 Connector responses can include `approval_pending` or `running`. Poll
 `get_connector_action_request(request_id)` until the request reaches a terminal

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Highlights

- Adds Docker as a built-in connector over an SSH transport profile.
- Adds scoped Docker actions for version metadata, container listing, redacted inspect output, bounded logs, and explicit start/stop/restart lifecycle operations.
- Updates MCP/package metadata and public docs for AIPermission v0.2.8.

## Changes

### Added

- Docker backend connector with scoped credential profiles and bounded Docker CLI templates.
- Docker Console browser for logs, inspect metadata, and lifecycle controls.
- Command transport capability for structured connectors that need reviewed command templates over existing transports.

### Changed

- Refreshes safe dependency pins without merging bot-authored commits.
- Tightens one Playwright heading selector to avoid strict-mode ambiguity.

## Security

- Docker connector does not expose arbitrary `docker exec`, image/container removal, prune, shell, or raw Docker command execution.
- Docker inspect output masks container environment values before returning data to UI, MCP, history, or audit.
- Container actions resolve and enforce the credential profile scope before reading logs, inspecting metadata, or changing lifecycle state.

## Validation

- `make release-check`
- `docker compose up -d --build --force-recreate`
- MCP dogfood: `list_containers`, `container_logs`, `inspect_container`, `stop_container`, `start_container`, `restart_container` on `watb-webui`

## Notes

- Dependabot PRs are intentionally not merged directly. Safe changes were reproduced as maintainer-authored commits.
