### PR TITLE
Release 0.2.9 Docker completion

### DIFF
--- a/.github/profile/README.md
+++ b/.github/profile/README.md
@@ -3,9 +3,9 @@
   <h1>AIPermission</h1>
   <p><strong>Local permission gateway for AI agents.</strong></p>
   <p>
-    Let AI assistants inspect and fix your own servers through scoped tokens,
-    approval flows, live consoles, and audit history without giving the AI your
-    SSH keys.
+    Let AI assistants work through local connector targets with scoped tokens,
+    approval flows, live views, and audit history without giving the AI your
+    private credentials.
   </p>
   <p>
     <a href="https://github.com/aipermission/aipermission"><strong>Repository</strong></a>
@@ -28,13 +28,13 @@
 
 ## What We Are Building
 
-AIPermission is for developers who already manage VPSes, containers, clusters,
-or private services and want an AI assistant to help without receiving raw
-credentials.
+AIPermission is for developers who already manage VPSes, containers, databases,
+queues, caches, or private services and want an AI assistant to help without
+receiving raw credentials.
 
 ```txt
-developer machine -> local AIPermission gateway -> SSH targets
-AI client         -> MCP token                 -> scoped tools
+developer machine -> local AIPermission gateway -> connector targets
+AI client         -> MCP token                 -> scoped actions
 ```
 
 The gateway owns credentials, permissions, approvals, persistent console
@@ -45,10 +45,10 @@ sessions, messages, history, and audit logs.
 | Principle | What it means |
 | --- | --- |
 | Local-only | The gateway runs on the developer's own machine and stays bound to localhost. |
-| Credential boundary | SSH private keys and database passwords never leave the gateway. |
-| Scoped tokens | Each AI/client token sees only the servers explicitly granted to it. |
+| Credential boundary | SSH keys, database passwords, API tokens, and connector secrets never leave the gateway. |
+| Scoped tokens | Each AI/client token sees only the connector targets and actions explicitly granted to it. |
 | Human control | Commands can require Run / Decline approval before execution. |
-| Observable work | Users can watch the same live console, send notes, and review history. |
+| Observable work | Users can watch live connector views, send notes, and review history. |
 
 ## Start Here
 
@@ -61,8 +61,8 @@ sessions, messages, history, and audit logs.
 
 AIPermission is pre-1.0 local developer software. It is not a LAN-shared
 operations panel, hosted service, team RBAC product, or production DevOps
-platform. Remote machines belong in the Servers list as SSH targets; they should
-not host the gateway for other clients.
+platform. Remote systems belong in the Connectors list as connector targets;
+they should not host the gateway for other clients.
 
 If you like the idea, try the RC, file issues, and help us make AI-assisted
 server work safer and less tedious.

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,63 @@
+name: Publish Container Images
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+      - "v*.*.*-rc.*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish GHCR images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Prepare tags
+        id: meta
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Set up Docker Buildx
+        run: docker buildx create --use
+
+      - name: Publish backend image
+        run: |
+          tags=(
+            --tag ghcr.io/aipermission/aipermission-backend:${{ steps.meta.outputs.tag }}
+            --tag ghcr.io/aipermission/aipermission-backend:${{ steps.meta.outputs.version }}
+          )
+          if [[ "${{ steps.meta.outputs.version }}" != *-* ]]; then
+            tags+=(--tag ghcr.io/aipermission/aipermission-backend:latest)
+          fi
+          docker buildx build \
+            --platform linux/amd64 \
+            "${tags[@]}" \
+            --push \
+            ./backend
+
+      - name: Publish frontend image
+        run: |
+          tags=(
+            --tag ghcr.io/aipermission/aipermission-frontend:${{ steps.meta.outputs.tag }}
+            --tag ghcr.io/aipermission/aipermission-frontend:${{ steps.meta.outputs.version }}
+          )
+          if [[ "${{ steps.meta.outputs.version }}" != *-* ]]; then
+            tags+=(--tag ghcr.io/aipermission/aipermission-frontend:latest)
+          fi
+          docker buildx build \
+            --platform linux/amd64 \
+            --build-arg VITE_API_URL="" \
+            --build-arg VITE_MCP_API_URL="" \
+            "${tags[@]}" \
+            --push \
+            ./frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-06-23
+
+### Added
+
+- Added Docker inventory actions for scoped image, network, and volume reads.
+- Added Docker Console inventory tabs for Containers, Images, Networks, and
+  Volumes, with searchable metadata and raw JSON copy/search views.
+- Added Docker container health and Docker Compose project/service metadata to
+  scoped container list output when Docker labels/status expose it.
+- Added a tag-triggered GitHub Actions workflow for publishing ready-to-run
+  backend and frontend images to GitHub Container Registry.
+- Added `docker-compose.release.yml` for users who want to pull published images
+  instead of building from source.
+
+### Security
+
+- Selected Docker credential profiles only expose images used by visible
+  containers, and derive networks/volumes from scoped container inspect output.
+- Prebuilt-image Compose keeps the UI port bound to `127.0.0.1` and does not
+  change AIPermission's local-only gateway boundary.
+- Docker still does not expose arbitrary `docker exec`, container/image
+  removal, prune, shell, or raw Docker command execution.
+
 ## [0.2.8] - 2026-06-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project uses semantic versioning once public releases begin.
   Volumes, with searchable metadata and raw JSON copy/search views.
 - Added Docker container health and Docker Compose project/service metadata to
   scoped container list output when Docker labels/status expose it.
+- Added scoped `container_exec` for bounded non-interactive commands inside one
+  visible container.
+- Added live Docker container console sessions that reuse the same terminal
+  component as SSH console while entering a selected container through the
+  configured SSH transport profile.
 - Added a tag-triggered GitHub Actions workflow for publishing ready-to-run
   backend and frontend images to GitHub Container Registry.
 - Added `docker-compose.release.yml` for users who want to pull published images
@@ -27,8 +32,9 @@ and this project uses semantic versioning once public releases begin.
   containers, and derive networks/volumes from scoped container inspect output.
 - Prebuilt-image Compose keeps the UI port bound to `127.0.0.1` and does not
   change AIPermission's local-only gateway boundary.
-- Docker still does not expose arbitrary `docker exec`, container/image
-  removal, prune, shell, or raw Docker command execution.
+- Docker `container_exec` and live container console are scoped to one visible
+  container. Docker still does not expose arbitrary host-level Docker commands,
+  container/image removal, prune, or raw Docker command execution.
 
 ## [0.2.8] - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Implemented:
   browsing, vhost metadata, binding inspection, bounded message peeking, and
   explicit message publishing
 - built-in Docker connector over an SSH transport profile, with scoped
-  container inventory, redacted inspect metadata, bounded logs, and explicit
-  start/stop/restart actions
+  container/image/network/volume inventory, redacted inspect metadata, bounded
+  logs, and explicit start/stop/restart actions
 - Docker credential profiles can scope MCP access to all containers, selected
   container names/IDs, or name patterns, so one token can be limited to a
   single container on a shared Docker host.
@@ -190,10 +190,24 @@ Requirements:
 - Docker and Docker Compose
 - Node.js only if you are running the MCP bridge from source during development
 
-Start the gateway:
+Start the gateway from source:
 
 ```bash
 docker compose up -d --build
+```
+
+Or use published release images:
+
+```bash
+docker compose -f docker-compose.release.yml pull
+docker compose -f docker-compose.release.yml up -d
+```
+
+To pin a specific release image, set `AIPERMISSION_VERSION` without the leading
+`v`:
+
+```bash
+AIPERMISSION_VERSION=0.2.9 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, clone the repository with Git's default text handling or make sure
@@ -225,7 +239,13 @@ MCP clients use:
 http://localhost:3210
 ```
 
-The Docker Compose UI port binds to `127.0.0.1` by default. The backend is not published as a separate host port in Docker Compose; the frontend proxies `/api` to the backend inside the shared local container namespace. The backend itself refuses to start when `AIPERMISSION_BACKEND_HOST` is set to `0.0.0.0` or any non-loopback address. AIPermission is local-only: do not publish Compose ports on `0.0.0.0` or a LAN interface. Remote/LAN mode is intentionally not supported.
+The Docker Compose UI port binds to `127.0.0.1` by default in both source-build
+and prebuilt-image Compose files. The backend is not published as a separate
+host port in Docker Compose; the frontend proxies `/api` to the backend inside
+the shared local container namespace. The backend itself refuses to start when
+`AIPERMISSION_BACKEND_HOST` is set to `0.0.0.0` or any non-loopback address.
+AIPermission is local-only: do not publish Compose ports on `0.0.0.0` or a LAN
+interface. Remote/LAN mode is intentionally not supported.
 
 If AIPermission runs in Docker on a Linux host and a connector target points at
 a service running on that same host, use `host.docker.internal` as the connector
@@ -345,6 +365,14 @@ as `overview`, `list_vhosts`, `list_queues`, `get_queue`, `list_bindings`, and
 `peek_messages`, and `publish_message`. Treat message payload previews and
 message publishing as sensitive queue access; previews use bounded
 count/truncation limits and `ack_requeue_true`.
+
+For Docker, call `get_connector_actions(target_ref)` to discover bounded
+actions such as `docker_version`, `list_containers`, `list_images`,
+`list_networks`, `list_volumes`, `inspect_container`, `container_logs`,
+`start_container`, `stop_container`, and `restart_container`. Docker credential
+profiles can scope a token to all containers, selected container names/IDs, or
+name patterns. The Docker connector does not expose arbitrary `docker exec`,
+prune, removal, shell, or raw Docker command execution.
 
 If an action returns `approval_pending` or `running`, the response includes an
 `assistant_hint` telling the AI to poll `get_connector_action_request` until the

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Implemented:
   explicit message publishing
 - built-in Docker connector over an SSH transport profile, with scoped
   container/image/network/volume inventory, redacted inspect metadata, bounded
-  logs, and explicit start/stop/restart actions
+  logs, scoped container exec, live container console, and explicit
+  start/stop/restart actions
 - Docker credential profiles can scope MCP access to all containers, selected
   container names/IDs, or name patterns, so one token can be limited to a
   single container on a shared Docker host.
@@ -369,10 +370,11 @@ count/truncation limits and `ack_requeue_true`.
 For Docker, call `get_connector_actions(target_ref)` to discover bounded
 actions such as `docker_version`, `list_containers`, `list_images`,
 `list_networks`, `list_volumes`, `inspect_container`, `container_logs`,
-`start_container`, `stop_container`, and `restart_container`. Docker credential
-profiles can scope a token to all containers, selected container names/IDs, or
-name patterns. The Docker connector does not expose arbitrary `docker exec`,
-prune, removal, shell, or raw Docker command execution.
+`container_exec`, `start_container`, `stop_container`, and `restart_container`.
+Docker credential profiles can scope a token to all containers, selected
+container names/IDs, or name patterns. `container_exec` and the live container
+console are scoped to one visible container; arbitrary host-level Docker
+commands, prune, removal, and raw Docker command execution are not exposed.
 
 If an action returns `approval_pending` or `running`, the response includes an
 `assistant_hint` telling the AI to poll `get_connector_action_request` until the

--- a/backend/internal/api/console_runtime.go
+++ b/backend/internal/api/console_runtime.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *Server) runtimeConsoleOpener(runtime *databaseRuntime) console.RuntimeOpener {
-	return func(ctx context.Context, runtimeID int64, rows int, cols int) (*console.RuntimeSession, error) {
+	return func(ctx context.Context, runtimeID int64, rows int, cols int, params map[string]any) (*console.RuntimeSession, error) {
 		targetRef, err := liveConsoleTargetRefForRuntimeID(ctx, runtime, runtimeID)
 		if err != nil {
 			return nil, err
@@ -21,6 +21,6 @@ func (s *Server) runtimeConsoleOpener(runtime *databaseRuntime) console.RuntimeO
 		if adapter == nil {
 			return nil, connectortargets.ErrInvalidTargetRef
 		}
-		return adapter.OpenLiveConsole(ctx, s, runtime, runtimeID, rows, cols)
+		return adapter.OpenLiveConsole(ctx, s, runtime, runtimeID, rows, cols, params)
 	}
 }

--- a/backend/internal/api/routes_test.go
+++ b/backend/internal/api/routes_test.go
@@ -1909,7 +1909,7 @@ func TestCreateConsoleSessionReturnsHostKeyConflict(t *testing.T) {
 		t.Fatalf("parse public key: %v", err)
 	}
 	runtime := fixture.server.activeRuntime()
-	runtime.consoleSessions = console.NewManager(fixture.db, func(context.Context, int64, int, int) (*console.RuntimeSession, error) {
+	runtime.consoleSessions = console.NewManager(fixture.db, func(context.Context, int64, int, int, map[string]any) (*console.RuntimeSession, error) {
 		return nil, fmt.Errorf("ssh dial: %w", execution.NewUnknownHostKeyError("[example.test]:22", publicKey))
 	}, fixture.server.runtimeRedactor(runtime))
 

--- a/backend/internal/connectorapi/registry.go
+++ b/backend/internal/connectorapi/registry.go
@@ -169,7 +169,7 @@ type LiveConsoleTargetAdapter interface {
 // LiveConsoleTransportAdapter opens a connector-owned persistent runtime for
 // the generic live console manager.
 type LiveConsoleTransportAdapter interface {
-	OpenLiveConsole(ctx context.Context, server GatewayServer, runtime GatewayRuntime, runtimeID int64, rows int, cols int) (*console.RuntimeSession, error)
+	OpenLiveConsole(ctx context.Context, server GatewayServer, runtime GatewayRuntime, runtimeID int64, rows int, cols int, params map[string]any) (*console.RuntimeSession, error)
 }
 
 // TCPTransportAdapter lets one connector provide a reviewed TCP transport for

--- a/backend/internal/connectors/builtin/registry.go
+++ b/backend/internal/connectors/builtin/registry.go
@@ -5,6 +5,7 @@ package builtin
 import (
 	"github.com/aipermission/aipermission/backend/internal/connectors"
 	dockerconnector "github.com/aipermission/aipermission/backend/internal/connectors/docker"
+	_ "github.com/aipermission/aipermission/backend/internal/connectors/docker/apiadapter"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
 	rabbitmqconnector "github.com/aipermission/aipermission/backend/internal/connectors/rabbitmq"
 	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"

--- a/backend/internal/connectors/builtin/registry_test.go
+++ b/backend/internal/connectors/builtin/registry_test.go
@@ -130,6 +130,9 @@ func builtInDeterminismSamples(t *testing.T, kind string) (connectors.TargetView
 			}, map[string]map[string]any{
 				dockerconnector.ActionVersion:          {},
 				dockerconnector.ActionListContainers:   {"all": true},
+				dockerconnector.ActionListImages:       {},
+				dockerconnector.ActionListNetworks:     {},
+				dockerconnector.ActionListVolumes:      {},
 				dockerconnector.ActionInspectContainer: {"container": "api"},
 				dockerconnector.ActionContainerLogs:    {"container": "api", "tail": 100},
 				dockerconnector.ActionStartContainer:   {"container": "api"},

--- a/backend/internal/connectors/builtin/registry_test.go
+++ b/backend/internal/connectors/builtin/registry_test.go
@@ -135,6 +135,7 @@ func builtInDeterminismSamples(t *testing.T, kind string) (connectors.TargetView
 				dockerconnector.ActionListVolumes:      {},
 				dockerconnector.ActionInspectContainer: {"container": "api"},
 				dockerconnector.ActionContainerLogs:    {"container": "api", "tail": 100},
+				dockerconnector.ActionContainerExec:    {"container": "api", "command": "printf ok"},
 				dockerconnector.ActionStartContainer:   {"container": "api"},
 				dockerconnector.ActionStopContainer:    {"container": "api", "timeout_seconds": 10},
 				dockerconnector.ActionRestartContainer: {"container": "api", "timeout_seconds": 10},

--- a/backend/internal/connectors/docker/apiadapter/adapter.go
+++ b/backend/internal/connectors/docker/apiadapter/adapter.go
@@ -1,0 +1,146 @@
+// Package apiadapter registers Docker connector runtime adapters.
+package apiadapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aipermission/aipermission/backend/internal/connectorapi"
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	dockerconnector "github.com/aipermission/aipermission/backend/internal/connectors/docker"
+	sshapiadapter "github.com/aipermission/aipermission/backend/internal/connectors/ssh/apiadapter"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
+	"github.com/aipermission/aipermission/backend/internal/console"
+)
+
+type adapter struct{}
+
+func init() {
+	connectorapi.Register(dockerconnector.Kind, adapter{})
+}
+
+func (adapter) LiveConsoleCapabilityKind() string {
+	return connectortargets.RuntimeCapabilityLiveConsole
+}
+
+func (adapter) LiveConsoleTargetRef(ctx context.Context, runtime connectorapi.GatewayRuntime, runtimeID int64) (string, error) {
+	target, profile, surface, err := dockerTargetProfileByRuntimeID(ctx, runtime, runtimeID)
+	if err != nil {
+		return "", err
+	}
+	if surface.ConnectorKind != dockerconnector.Kind || surface.CapabilityKind != connectortargets.RuntimeCapabilityLiveConsole {
+		return "", connectortargets.ErrRuntimeSurfaceNotFound
+	}
+	return connectortargets.ConnectorTargetRef(target.ConnectorKind, target.ID, profile.ID), nil
+}
+
+func (adapter) ResolveLiveConsoleMaterial(ctx context.Context, runtime connectorapi.GatewayRuntime, runtimeID int64) (any, any, error) {
+	target, profile, _, err := dockerTargetProfileByRuntimeID(ctx, runtime, runtimeID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return target, profile, nil
+}
+
+func (adapter) LiveConsoleTargetMetadata(target connectors.TargetView, profile connectors.CredentialProfileView) map[string]any {
+	return map[string]any{
+		"label":              target.Name,
+		"connector":          dockerconnector.Kind,
+		"profile":            profile.Label,
+		"transport":          strings.TrimSpace(stringConfigValue(target.Config, "transport_target_ref")),
+		"docker_command":     dockerCommand(target),
+		"container_scope":    strings.TrimSpace(stringConfigValue(profile.Public, "scope_mode")),
+		"allowed_patterns":   strings.TrimSpace(stringConfigValue(profile.Public, "allowed_patterns")),
+		"allowed_containers": strings.TrimSpace(stringConfigValue(profile.Public, "allowed_containers")),
+	}
+}
+
+func (adapter) OpenLiveConsole(ctx context.Context, server connectorapi.GatewayServer, runtime connectorapi.GatewayRuntime, runtimeID int64, rows int, cols int, params map[string]any) (*console.RuntimeSession, error) {
+	target, profile, surface, err := dockerTargetProfileByRuntimeID(ctx, runtime, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	if surface.ConnectorKind != dockerconnector.Kind || surface.CapabilityKind != connectortargets.RuntimeCapabilityLiveConsole {
+		return nil, connectortargets.ErrRuntimeSurfaceNotFound
+	}
+	containerRef := strings.TrimSpace(stringParam(params, "container"))
+	if containerRef == "" {
+		return nil, errors.New("docker container is required")
+	}
+	if !dockerconnector.ProfileAllowsContainerRef(profile, containerRef) {
+		return nil, fmt.Errorf("%w: %s", dockerconnector.ErrScopeDenied, containerRef)
+	}
+	transportRef := strings.TrimSpace(stringConfigValue(target.Config, "transport_target_ref"))
+	if transportRef == "" {
+		return nil, fmt.Errorf("%w: transport_target_ref is required", dockerconnector.ErrInvalidConfig)
+	}
+	command := dockerExecShellCommand(dockerCommand(target), containerRef)
+	return sshapiadapter.OpenLiveConsoleForTargetRef(ctx, server, runtime, transportRef, rows, cols, sshapiadapter.LiveConsoleOptions{
+		ForceShellCommand: command,
+	})
+}
+
+func dockerTargetProfileByRuntimeID(ctx context.Context, runtime connectorapi.GatewayRuntime, runtimeID int64) (connectors.TargetView, connectors.CredentialProfileView, connectortargets.RuntimeSurface, error) {
+	database, err := databaseFrom(runtime)
+	if err != nil {
+		return connectors.TargetView{}, connectors.CredentialProfileView{}, connectortargets.RuntimeSurface{}, err
+	}
+	return connectortargets.NewStore(database).TargetProfileByRuntimeID(ctx, runtimeID)
+}
+
+func databaseFrom(runtime connectorapi.GatewayRuntime) (*sql.DB, error) {
+	if runtime == nil || runtime.ConnectorDatabase() == nil {
+		return nil, fmt.Errorf("database runtime is not available")
+	}
+	return runtime.ConnectorDatabase(), nil
+}
+
+func dockerExecShellCommand(dockerCommand string, containerRef string) string {
+	dockerCommand = strings.TrimSpace(dockerCommand)
+	if dockerCommand == "" {
+		dockerCommand = "docker"
+	}
+	shellProbe := "if command -v bash >/dev/null 2>&1; then exec bash -l; fi; exec sh"
+	return fmt.Sprintf("%s exec -it -- %s sh -lc %s", dockerCommand, shellQuote(containerRef), shellQuote(shellProbe))
+}
+
+func dockerCommand(target connectors.TargetView) string {
+	command := strings.TrimSpace(stringConfigValue(target.Config, "docker_command"))
+	if command == "" {
+		return "docker"
+	}
+	return command
+}
+
+func stringParam(params map[string]any, key string) string {
+	if params == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(params[key]))
+}
+
+func stringConfigValue(values map[string]any, key string) string {
+	if values == nil {
+		return ""
+	}
+	value, ok := values[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/backend/internal/connectors/docker/docker.go
+++ b/backend/internal/connectors/docker/docker.go
@@ -26,6 +26,7 @@ const (
 	ActionListVolumes      = "list_volumes"
 	ActionInspectContainer = "inspect_container"
 	ActionContainerLogs    = "container_logs"
+	ActionContainerExec    = "container_exec"
 	ActionStartContainer   = "start_container"
 	ActionStopContainer    = "stop_container"
 	ActionRestartContainer = "restart_container"
@@ -33,6 +34,8 @@ const (
 	defaultLogTail     = 200
 	maxLogTail         = 2000
 	maxLogBytes        = 256 << 10
+	maxExecCommandLen  = 8000
+	maxExecOutputBytes = 256 << 10
 	maxInspectBytes    = 512 << 10
 	maxDockerReasonLen = 2000
 )
@@ -143,10 +146,12 @@ func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (conne
 			"Use list_images, list_networks, and list_volumes for read-only Docker host inventory.",
 			"Use container_logs with a bounded tail value for recent logs.",
 			"Use inspect_container for redacted Docker metadata. Environment variables are masked.",
+			"Use container_exec for bounded non-interactive commands inside one scoped container.",
 			"Use start_container, stop_container, or restart_container only when the operator intends a container lifecycle change.",
 		},
 		Warnings: []string{
-			"Docker actions run through a selected transport profile. The Docker connector does not expose arbitrary docker exec, prune, rm, or shell access.",
+			"Docker actions run through a selected transport profile. The Docker connector does not expose arbitrary host-level docker commands, prune, rm, or shell access.",
+			"container_exec can change data inside the container. Prefer prompt mode unless the workflow is trusted.",
 			"Credential profile scope can restrict AI access to one container or a small allowed set.",
 			"Container logs may contain secrets. Redaction is best-effort; avoid requesting sensitive logs unless approved.",
 		},
@@ -224,6 +229,21 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 				{Name: "tail", Label: "Tail lines", Type: connectors.FieldNumber, Default: defaultLogTail},
 			}},
 			OutputHint: connectors.OutputHint{Format: "text", MaxBytes: maxLogBytes},
+		},
+		{
+			Name:        ActionContainerExec,
+			Label:       "Exec in container",
+			Description: "Run one bounded non-interactive shell command inside one scoped Docker container.",
+			Category:    "execution",
+			Risk:        connectors.RiskDestructive,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "container", Label: "Container", Type: connectors.FieldString, Required: true},
+				{Name: "command", Label: "Command", Type: connectors.FieldMultiline, Required: true},
+				{Name: "timeout_seconds", Label: "Timeout seconds", Type: connectors.FieldNumber, Default: 30},
+				{Name: "user", Label: "User", Type: connectors.FieldString, Description: "Optional container user."},
+				{Name: "workdir", Label: "Working directory", Type: connectors.FieldString, Description: "Optional container working directory."},
+			}},
+			OutputHint: connectors.OutputHint{Format: "text", MaxBytes: maxExecOutputBytes},
 		},
 		{
 			Name:        ActionStartContainer,
@@ -305,6 +325,23 @@ func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) 
 		input["tail"] = normalizeInt(input, "tail", defaultLogTail, 1, maxLogTail)
 		title = "Read Docker container logs"
 		summary = fmt.Sprintf("%s tail=%d", container, input["tail"])
+	case ActionContainerExec:
+		risk = connectors.RiskDestructive
+		container, err := normalizeContainerInput(input)
+		if err != nil {
+			return connectors.PreparedAction{}, err
+		}
+		command, err := normalizeExecCommandInput(input)
+		if err != nil {
+			return connectors.PreparedAction{}, err
+		}
+		input["container"] = container
+		input["command"] = command
+		input["timeout_seconds"] = normalizeInt(input, "timeout_seconds", 30, 1, 600)
+		input["user"] = normalizeDockerOptionInput(input, "user")
+		input["workdir"] = normalizeDockerOptionInput(input, "workdir")
+		title = "Exec inside Docker container"
+		summary = fmt.Sprintf("%s: %s", container, firstLine(command))
 	case ActionStartContainer:
 		risk = connectors.RiskWrite
 		container, err := normalizeContainerInput(input)
@@ -376,6 +413,8 @@ func (Connector) ExecuteAction(ctx context.Context, runtime connectors.RuntimeCo
 		return executeInspectContainer(ctx, client, action.Payload)
 	case ActionContainerLogs:
 		return executeContainerLogs(ctx, client, action.Payload)
+	case ActionContainerExec:
+		return executeContainerExec(ctx, client, action.Payload)
 	case ActionStartContainer:
 		return executeContainerLifecycle(ctx, client, action.Payload, "start")
 	case ActionStopContainer:
@@ -585,6 +624,58 @@ func executeContainerLogs(ctx context.Context, client *dockerClient, input map[s
 			"duration_ms": result.DurationMS,
 		},
 		DisplayText: logs,
+	}, nil
+}
+
+func executeContainerExec(ctx context.Context, client *dockerClient, input map[string]any) (connectors.ActionResult, error) {
+	container, err := client.resolveContainer(ctx, stringValue(input, "container"))
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	commandText, err := normalizeExecCommandInput(input)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	timeout := normalizeInt(input, "timeout_seconds", 30, 1, 600)
+	var options []string
+	if user := normalizeDockerOptionInput(input, "user"); user != "" {
+		options = append(options, "--user", shellQuote(user))
+	}
+	if workdir := normalizeDockerOptionInput(input, "workdir"); workdir != "" {
+		options = append(options, "--workdir", shellQuote(workdir))
+	}
+	optionText := ""
+	if len(options) > 0 {
+		optionText = strings.Join(options, " ") + " "
+	}
+	result, err := client.run(ctx, fmt.Sprintf("%s exec %s-- %s sh -lc %s 2>&1", client.command, optionText, shellQuote(container.Ref()), shellQuote(commandText)), timeout+5)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	outputText := truncateString(result.Stdout, maxExecOutputBytes)
+	status := connectors.ResultCompleted
+	errorText := ""
+	if result.ExitCode != 0 {
+		status = connectors.ResultFailed
+		errorText = fmt.Sprintf("docker exec exited with code %d", result.ExitCode)
+		if strings.TrimSpace(result.Stderr) != "" {
+			errorText += ": " + truncateString(strings.TrimSpace(result.Stderr), 1000)
+		}
+	}
+	return connectors.ActionResult{
+		Status: status,
+		Output: map[string]any{
+			"container":       container,
+			"command":         commandText,
+			"exit_code":       result.ExitCode,
+			"output":          outputText,
+			"timeout_seconds": timeout,
+			"user":            normalizeDockerOptionInput(input, "user"),
+			"workdir":         normalizeDockerOptionInput(input, "workdir"),
+			"duration_ms":     result.DurationMS,
+		},
+		DisplayText: outputText,
+		Error:       errorText,
 	}, nil
 }
 
@@ -1044,6 +1135,14 @@ func dockerScopeFromProfile(profile connectors.CredentialProfileView) dockerScop
 	}
 }
 
+func ProfileAllowsContainerRef(profile connectors.CredentialProfileView, containerRef string) bool {
+	containerRef = strings.TrimSpace(containerRef)
+	if containerRef == "" {
+		return false
+	}
+	return dockerScopeFromProfile(profile).allows(DockerContainer{ID: containerRef, Name: containerRef})
+}
+
 func (scope dockerScope) allows(container DockerContainer) bool {
 	if scope.mode != "selected" {
 		return true
@@ -1103,6 +1202,36 @@ func normalizeContainerInput(input map[string]any) (string, error) {
 		return "", fmt.Errorf("container contains unsupported characters")
 	}
 	return container, nil
+}
+
+func normalizeExecCommandInput(input map[string]any) (string, error) {
+	command := strings.TrimSpace(stringValue(input, "command"))
+	if command == "" {
+		return "", fmt.Errorf("command is required")
+	}
+	if len(command) > maxExecCommandLen {
+		return "", fmt.Errorf("command is larger than %d bytes", maxExecCommandLen)
+	}
+	if strings.ContainsRune(command, '\x00') {
+		return "", fmt.Errorf("command contains unsupported characters")
+	}
+	return command, nil
+}
+
+func normalizeDockerOptionInput(input map[string]any, key string) string {
+	value := strings.TrimSpace(stringValue(input, key))
+	if value == "" || strings.ContainsAny(value, "\x00\n\r") {
+		return ""
+	}
+	return value
+}
+
+func firstLine(value string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(value), "\n")
+	if len(line) > 120 {
+		return line[:117] + "..."
+	}
+	return line
 }
 
 func dockerCommandError(command string, result connectors.CommandRunResult) error {

--- a/backend/internal/connectors/docker/docker.go
+++ b/backend/internal/connectors/docker/docker.go
@@ -21,6 +21,9 @@ const (
 
 	ActionVersion          = "docker_version"
 	ActionListContainers   = "list_containers"
+	ActionListImages       = "list_images"
+	ActionListNetworks     = "list_networks"
+	ActionListVolumes      = "list_volumes"
 	ActionInspectContainer = "inspect_container"
 	ActionContainerLogs    = "container_logs"
 	ActionStartContainer   = "start_container"
@@ -137,6 +140,7 @@ func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (conne
 		ConnectorID: Kind,
 		Usage: []string{
 			"Use list_containers before targeting a container by name or ID.",
+			"Use list_images, list_networks, and list_volumes for read-only Docker host inventory.",
 			"Use container_logs with a bounded tail value for recent logs.",
 			"Use inspect_container for redacted Docker metadata. Environment variables are masked.",
 			"Use start_container, stop_container, or restart_container only when the operator intends a container lifecycle change.",
@@ -170,6 +174,33 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 				{Name: "all", Label: "Include stopped", Type: connectors.FieldBoolean, Default: true},
 			}},
 			OutputHint: connectors.OutputHint{Format: "json", MaxRows: 500},
+		},
+		{
+			Name:        ActionListImages,
+			Label:       "List images",
+			Description: "List Docker images visible to this credential profile scope.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{},
+			OutputHint:  connectors.OutputHint{Format: "json", MaxRows: 500},
+		},
+		{
+			Name:        ActionListNetworks,
+			Label:       "List networks",
+			Description: "List Docker networks. Selected scopes only return networks attached to scoped containers.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{},
+			OutputHint:  connectors.OutputHint{Format: "json", MaxRows: 500},
+		},
+		{
+			Name:        ActionListVolumes,
+			Label:       "List volumes",
+			Description: "List Docker volumes. Selected scopes only return volumes mounted by scoped containers.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{},
+			OutputHint:  connectors.OutputHint{Format: "json", MaxRows: 500},
 		},
 		{
 			Name:        ActionInspectContainer,
@@ -248,6 +279,15 @@ func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) 
 		input["all"] = boolValue(input, "all", true)
 		title = "List Docker containers"
 		summary = "List containers visible to this credential profile scope."
+	case ActionListImages:
+		title = "List Docker images"
+		summary = "List Docker images visible to this credential profile scope."
+	case ActionListNetworks:
+		title = "List Docker networks"
+		summary = "List Docker networks visible to this credential profile scope."
+	case ActionListVolumes:
+		title = "List Docker volumes"
+		summary = "List Docker volumes visible to this credential profile scope."
 	case ActionInspectContainer:
 		container, err := normalizeContainerInput(input)
 		if err != nil {
@@ -326,6 +366,12 @@ func (Connector) ExecuteAction(ctx context.Context, runtime connectors.RuntimeCo
 		return executeVersion(ctx, client)
 	case ActionListContainers:
 		return executeListContainers(ctx, client, action.Payload)
+	case ActionListImages:
+		return executeListImages(ctx, client)
+	case ActionListNetworks:
+		return executeListNetworks(ctx, client)
+	case ActionListVolumes:
+		return executeListVolumes(ctx, client)
 	case ActionInspectContainer:
 		return executeInspectContainer(ctx, client, action.Payload)
 	case ActionContainerLogs:
@@ -437,6 +483,54 @@ func executeListContainers(ctx context.Context, client *dockerClient, input map[
 	}, nil
 }
 
+func executeListImages(ctx context.Context, client *dockerClient) (connectors.ActionResult, error) {
+	images, err := client.listImages(ctx)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"images":     images,
+			"count":      len(images),
+			"scope_mode": client.scope.mode,
+		},
+		DisplayText: imagesDisplay(images),
+	}, nil
+}
+
+func executeListNetworks(ctx context.Context, client *dockerClient) (connectors.ActionResult, error) {
+	networks, err := client.listNetworks(ctx)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"networks":   networks,
+			"count":      len(networks),
+			"scope_mode": client.scope.mode,
+		},
+		DisplayText: networksDisplay(networks),
+	}, nil
+}
+
+func executeListVolumes(ctx context.Context, client *dockerClient) (connectors.ActionResult, error) {
+	volumes, err := client.listVolumes(ctx)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"volumes":    volumes,
+			"count":      len(volumes),
+			"scope_mode": client.scope.mode,
+		},
+		DisplayText: volumesDisplay(volumes),
+	}, nil
+}
+
 func executeInspectContainer(ctx context.Context, client *dockerClient, input map[string]any) (connectors.ActionResult, error) {
 	container, err := client.resolveContainer(ctx, stringValue(input, "container"))
 	if err != nil {
@@ -530,14 +624,60 @@ func executeContainerLifecycle(ctx context.Context, client *dockerClient, input 
 }
 
 type DockerContainer struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Image   string `json:"image"`
-	Command string `json:"command,omitempty"`
-	State   string `json:"state"`
-	Status  string `json:"status"`
-	Ports   string `json:"ports,omitempty"`
-	Labels  string `json:"labels,omitempty"`
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Image          string `json:"image"`
+	Command        string `json:"command,omitempty"`
+	State          string `json:"state"`
+	Status         string `json:"status"`
+	Health         string `json:"health,omitempty"`
+	Ports          string `json:"ports,omitempty"`
+	Labels         string `json:"labels,omitempty"`
+	ComposeProject string `json:"compose_project,omitempty"`
+	ComposeService string `json:"compose_service,omitempty"`
+}
+
+type DockerImage struct {
+	ID           string `json:"id,omitempty"`
+	Repository   string `json:"repository,omitempty"`
+	Tag          string `json:"tag,omitempty"`
+	Digest       string `json:"digest,omitempty"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	CreatedSince string `json:"created_since,omitempty"`
+	Size         string `json:"size,omitempty"`
+	Containers   int    `json:"containers,omitempty"`
+}
+
+type DockerNetwork struct {
+	ID         string `json:"id,omitempty"`
+	Name       string `json:"name"`
+	Driver     string `json:"driver,omitempty"`
+	Scope      string `json:"scope,omitempty"`
+	IPv6       string `json:"ipv6,omitempty"`
+	Internal   string `json:"internal,omitempty"`
+	Labels     string `json:"labels,omitempty"`
+	Containers int    `json:"containers,omitempty"`
+}
+
+type DockerVolume struct {
+	Name       string `json:"name"`
+	Driver     string `json:"driver,omitempty"`
+	Scope      string `json:"scope,omitempty"`
+	Mountpoint string `json:"mountpoint,omitempty"`
+	Labels     string `json:"labels,omitempty"`
+	Containers int    `json:"containers,omitempty"`
+}
+
+func (image DockerImage) Ref() string {
+	repository := strings.TrimSpace(image.Repository)
+	tag := strings.TrimSpace(image.Tag)
+	if repository == "" {
+		return strings.TrimSpace(image.ID)
+	}
+	if tag == "" || tag == "<none>" {
+		return repository
+	}
+	return repository + ":" + tag
 }
 
 func (container DockerContainer) Ref() string {
@@ -570,6 +710,191 @@ func (client *dockerClient) listContainers(ctx context.Context, includeStopped b
 		}
 	}
 	return filtered, nil
+}
+
+func (client *dockerClient) listImages(ctx context.Context) ([]DockerImage, error) {
+	result, err := client.run(ctx, client.command+" image ls --no-trunc --format '{{json .}}'", 20)
+	if err != nil {
+		return nil, err
+	}
+	if result.ExitCode != 0 {
+		return nil, dockerCommandError("docker image ls", result)
+	}
+	images, err := parseDockerImages(result.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	containers, err := client.listContainers(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	counts := map[string]int{}
+	for _, container := range containers {
+		imageRef := strings.TrimSpace(container.Image)
+		if imageRef == "" {
+			continue
+		}
+		counts[imageRef]++
+	}
+	filtered := images[:0]
+	for _, image := range images {
+		ref := image.Ref()
+		count := counts[ref]
+		if count == 0 && image.Tag != "" {
+			count = counts[image.Repository+":"+image.Tag]
+		}
+		if client.scope.mode == "selected" && count == 0 {
+			continue
+		}
+		image.Containers = count
+		filtered = append(filtered, image)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return strings.ToLower(filtered[i].Ref()) < strings.ToLower(filtered[j].Ref())
+	})
+	return filtered, nil
+}
+
+func (client *dockerClient) listNetworks(ctx context.Context) ([]DockerNetwork, error) {
+	if client.scope.mode == "selected" {
+		return client.scopedNetworksFromInspect(ctx)
+	}
+	result, err := client.run(ctx, client.command+" network ls --no-trunc --format '{{json .}}'", 20)
+	if err != nil {
+		return nil, err
+	}
+	if result.ExitCode != 0 {
+		return nil, dockerCommandError("docker network ls", result)
+	}
+	networks, err := parseDockerNetworks(result.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(networks, func(i, j int) bool {
+		return strings.ToLower(networks[i].Name) < strings.ToLower(networks[j].Name)
+	})
+	return networks, nil
+}
+
+func (client *dockerClient) listVolumes(ctx context.Context) ([]DockerVolume, error) {
+	if client.scope.mode == "selected" {
+		return client.scopedVolumesFromInspect(ctx)
+	}
+	result, err := client.run(ctx, client.command+" volume ls --format '{{json .}}'", 20)
+	if err != nil {
+		return nil, err
+	}
+	if result.ExitCode != 0 {
+		return nil, dockerCommandError("docker volume ls", result)
+	}
+	volumes, err := parseDockerVolumes(result.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(volumes, func(i, j int) bool {
+		return strings.ToLower(volumes[i].Name) < strings.ToLower(volumes[j].Name)
+	})
+	return volumes, nil
+}
+
+func (client *dockerClient) scopedNetworksFromInspect(ctx context.Context) ([]DockerNetwork, error) {
+	inspect, err := client.inspectScopedContainers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byName := map[string]DockerNetwork{}
+	for _, item := range inspect {
+		settings, _ := item["NetworkSettings"].(map[string]any)
+		networks, _ := settings["Networks"].(map[string]any)
+		for name, raw := range networks {
+			network := byName[name]
+			network.Name = name
+			network.Scope = "container"
+			network.Containers++
+			if data, ok := raw.(map[string]any); ok {
+				if network.ID == "" {
+					network.ID = strings.TrimSpace(stringValue(data, "NetworkID"))
+				}
+				if network.Driver == "" {
+					network.Driver = strings.TrimSpace(stringValue(data, "Driver"))
+				}
+			}
+			byName[name] = network
+		}
+	}
+	networks := make([]DockerNetwork, 0, len(byName))
+	for _, network := range byName {
+		networks = append(networks, network)
+	}
+	sort.SliceStable(networks, func(i, j int) bool {
+		return strings.ToLower(networks[i].Name) < strings.ToLower(networks[j].Name)
+	})
+	return networks, nil
+}
+
+func (client *dockerClient) scopedVolumesFromInspect(ctx context.Context) ([]DockerVolume, error) {
+	inspect, err := client.inspectScopedContainers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byName := map[string]DockerVolume{}
+	for _, item := range inspect {
+		mounts, _ := item["Mounts"].([]any)
+		for _, raw := range mounts {
+			mount, _ := raw.(map[string]any)
+			if strings.TrimSpace(stringValue(mount, "Type")) != "volume" {
+				continue
+			}
+			name := strings.TrimSpace(stringValue(mount, "Name"))
+			if name == "" {
+				continue
+			}
+			volume := byName[name]
+			volume.Name = name
+			volume.Driver = strings.TrimSpace(stringValue(mount, "Driver"))
+			volume.Mountpoint = strings.TrimSpace(stringValue(mount, "Source"))
+			volume.Scope = "container"
+			volume.Containers++
+			byName[name] = volume
+		}
+	}
+	volumes := make([]DockerVolume, 0, len(byName))
+	for _, volume := range byName {
+		volumes = append(volumes, volume)
+	}
+	sort.SliceStable(volumes, func(i, j int) bool {
+		return strings.ToLower(volumes[i].Name) < strings.ToLower(volumes[j].Name)
+	})
+	return volumes, nil
+}
+
+func (client *dockerClient) inspectScopedContainers(ctx context.Context) ([]map[string]any, error) {
+	containers, err := client.listContainers(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	if len(containers) == 0 {
+		return nil, nil
+	}
+	args := make([]string, 0, len(containers))
+	for _, container := range containers {
+		args = append(args, shellQuote(container.Ref()))
+	}
+	result, err := client.run(ctx, client.command+" inspect -- "+strings.Join(args, " "), 30)
+	if err != nil {
+		return nil, err
+	}
+	if result.ExitCode != 0 {
+		return nil, dockerCommandError("docker inspect", result)
+	}
+	if len(result.Stdout) > maxInspectBytes {
+		return nil, fmt.Errorf("docker inspect output is larger than %d bytes", maxInspectBytes)
+	}
+	var inspect []map[string]any
+	if err := json.Unmarshal([]byte(result.Stdout), &inspect); err != nil {
+		return nil, fmt.Errorf("parse docker inspect output: %w", err)
+	}
+	return inspect, nil
 }
 
 func (client *dockerClient) resolveContainer(ctx context.Context, requested string) (DockerContainer, error) {
@@ -610,12 +935,98 @@ func parseDockerPS(data string) ([]DockerContainer, error) {
 			Ports:   strings.TrimSpace(stringValue(row, "Ports")),
 			Labels:  strings.TrimSpace(stringValue(row, "Labels")),
 		}
+		labels := parseLabelString(container.Labels)
+		container.ComposeProject = labels["com.docker.compose.project"]
+		container.ComposeService = labels["com.docker.compose.service"]
+		container.Health = parseHealth(container.Status)
 		if container.ID == "" && container.Name == "" {
 			continue
 		}
 		containers = append(containers, container)
 	}
 	return containers, nil
+}
+
+func parseDockerImages(data string) ([]DockerImage, error) {
+	var images []DockerImage
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			return nil, fmt.Errorf("parse docker image row: %w", err)
+		}
+		image := DockerImage{
+			ID:           strings.TrimSpace(stringValue(row, "ID")),
+			Repository:   strings.TrimSpace(stringValue(row, "Repository")),
+			Tag:          strings.TrimSpace(stringValue(row, "Tag")),
+			Digest:       strings.TrimSpace(stringValue(row, "Digest")),
+			CreatedAt:    strings.TrimSpace(stringValue(row, "CreatedAt")),
+			CreatedSince: strings.TrimSpace(stringValue(row, "CreatedSince")),
+			Size:         strings.TrimSpace(stringValue(row, "Size")),
+		}
+		if image.Repository == "" && image.ID == "" {
+			continue
+		}
+		images = append(images, image)
+	}
+	return images, nil
+}
+
+func parseDockerNetworks(data string) ([]DockerNetwork, error) {
+	var networks []DockerNetwork
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			return nil, fmt.Errorf("parse docker network row: %w", err)
+		}
+		network := DockerNetwork{
+			ID:       strings.TrimSpace(stringValue(row, "ID")),
+			Name:     strings.TrimSpace(stringValue(row, "Name")),
+			Driver:   strings.TrimSpace(stringValue(row, "Driver")),
+			Scope:    strings.TrimSpace(stringValue(row, "Scope")),
+			IPv6:     strings.TrimSpace(stringValue(row, "IPv6")),
+			Internal: strings.TrimSpace(stringValue(row, "Internal")),
+			Labels:   strings.TrimSpace(stringValue(row, "Labels")),
+		}
+		if network.Name == "" && network.ID == "" {
+			continue
+		}
+		networks = append(networks, network)
+	}
+	return networks, nil
+}
+
+func parseDockerVolumes(data string) ([]DockerVolume, error) {
+	var volumes []DockerVolume
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			return nil, fmt.Errorf("parse docker volume row: %w", err)
+		}
+		volume := DockerVolume{
+			Name:       strings.TrimSpace(stringValue(row, "Name")),
+			Driver:     strings.TrimSpace(stringValue(row, "Driver")),
+			Scope:      strings.TrimSpace(stringValue(row, "Scope")),
+			Mountpoint: strings.TrimSpace(stringValue(row, "Mountpoint")),
+			Labels:     strings.TrimSpace(stringValue(row, "Labels")),
+		}
+		if volume.Name == "" {
+			continue
+		}
+		volumes = append(volumes, volume)
+	}
+	return volumes, nil
 }
 
 type dockerScope struct {
@@ -711,9 +1122,80 @@ func containersDisplay(containers []DockerContainer) string {
 	}
 	lines := make([]string, 0, len(containers))
 	for _, container := range containers {
-		lines = append(lines, fmt.Sprintf("%s\t%s\t%s\t%s", container.Name, container.Image, container.State, container.Status))
+		meta := []string{container.State}
+		if container.Health != "" {
+			meta = append(meta, container.Health)
+		}
+		if container.ComposeProject != "" {
+			meta = append(meta, "project="+container.ComposeProject)
+		}
+		lines = append(lines, fmt.Sprintf("%s\t%s\t%s\t%s", container.Name, container.Image, strings.Join(meta, " "), container.Status))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func imagesDisplay(images []DockerImage) string {
+	if len(images) == 0 {
+		return "No Docker images matched this profile scope."
+	}
+	lines := make([]string, 0, len(images))
+	for _, image := range images {
+		lines = append(lines, fmt.Sprintf("%s\t%s\tcontainers=%d", image.Ref(), image.Size, image.Containers))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func networksDisplay(networks []DockerNetwork) string {
+	if len(networks) == 0 {
+		return "No Docker networks matched this profile scope."
+	}
+	lines := make([]string, 0, len(networks))
+	for _, network := range networks {
+		lines = append(lines, fmt.Sprintf("%s\t%s\t%s\tcontainers=%d", network.Name, network.Driver, network.Scope, network.Containers))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func volumesDisplay(volumes []DockerVolume) string {
+	if len(volumes) == 0 {
+		return "No Docker volumes matched this profile scope."
+	}
+	lines := make([]string, 0, len(volumes))
+	for _, volume := range volumes {
+		lines = append(lines, fmt.Sprintf("%s\t%s\t%s\tcontainers=%d", volume.Name, volume.Driver, volume.Scope, volume.Containers))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func parseLabelString(value string) map[string]string {
+	labels := map[string]string{}
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, val, found := strings.Cut(part, "=")
+		if !found {
+			labels[part] = ""
+			continue
+		}
+		labels[strings.TrimSpace(key)] = strings.TrimSpace(val)
+	}
+	return labels
+}
+
+func parseHealth(status string) string {
+	lower := strings.ToLower(status)
+	switch {
+	case strings.Contains(lower, "(healthy)"):
+		return "healthy"
+	case strings.Contains(lower, "(unhealthy)"):
+		return "unhealthy"
+	case strings.Contains(lower, "(health: starting)"):
+		return "starting"
+	default:
+		return ""
+	}
 }
 
 func redactInspect(items []map[string]any) []map[string]any {

--- a/backend/internal/connectors/docker/docker_test.go
+++ b/backend/internal/connectors/docker/docker_test.go
@@ -111,6 +111,81 @@ func TestLifecycleReturnsRefreshedContainerState(t *testing.T) {
 	}
 }
 
+func TestListImagesFiltersBySelectedScope(t *testing.T) {
+	transport := &fakeCommandTransport{
+		results: map[string]connectors.CommandRunResult{
+			"docker image ls --no-trunc --format '{{json .}}'": {Stdout: strings.Join([]string{
+				`{"ID":"sha256:aaa","Repository":"app","Tag":"latest","Size":"100MB"}`,
+				`{"ID":"sha256:bbb","Repository":"postgres","Tag":"16","Size":"400MB"}`,
+			}, "\n")},
+			"docker ps -a --no-trunc --format '{{json .}}'": {Stdout: strings.Join([]string{
+				`{"ID":"111111111111","Names":"api","Image":"app:latest","State":"running","Status":"Up 1 hour"}`,
+				`{"ID":"222222222222","Names":"db","Image":"postgres:16","State":"running","Status":"Up 1 hour"}`,
+			}, "\n")},
+		},
+	}
+	result, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       dockerTarget(),
+		Profile:      dockerProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}, connectors.PreparedAction{ActionName: ActionListImages, Payload: map[string]any{}})
+	if err != nil {
+		t.Fatalf("list images: %v", err)
+	}
+	output, _ := result.Output.(map[string]any)
+	images, _ := output["images"].([]DockerImage)
+	if len(images) != 1 || images[0].Ref() != "app:latest" || images[0].Containers != 1 {
+		t.Fatalf("unexpected scoped images: %#v", images)
+	}
+}
+
+func TestListNetworksAndVolumesUseScopedInspect(t *testing.T) {
+	transport := &fakeCommandTransport{
+		results: map[string]connectors.CommandRunResult{
+			"docker ps -a --no-trunc --format '{{json .}}'": {Stdout: strings.Join([]string{
+				`{"ID":"111111111111","Names":"api","Image":"app:latest","State":"running","Status":"Up 1 hour (healthy)","Labels":"com.docker.compose.project=watb,com.docker.compose.service=api"}`,
+				`{"ID":"222222222222","Names":"db","Image":"postgres:16","State":"running","Status":"Up 1 hour"}`,
+			}, "\n")},
+			"docker inspect -- 'api'": {Stdout: `[{
+				"NetworkSettings":{"Networks":{"frontend":{"NetworkID":"net1","Driver":"bridge"}}},
+				"Mounts":[{"Type":"volume","Name":"api-data","Driver":"local","Source":"/var/lib/docker/volumes/api-data/_data"}]
+			}]`},
+		},
+	}
+	runtime := connectors.RuntimeContext{
+		Target:       dockerTarget(),
+		Profile:      dockerProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}
+	networkResult, err := New().ExecuteAction(context.Background(), runtime, connectors.PreparedAction{ActionName: ActionListNetworks, Payload: map[string]any{}})
+	if err != nil {
+		t.Fatalf("list networks: %v", err)
+	}
+	networkOutput, _ := networkResult.Output.(map[string]any)
+	networks, _ := networkOutput["networks"].([]DockerNetwork)
+	if len(networks) != 1 || networks[0].Name != "frontend" || networks[0].Containers != 1 {
+		t.Fatalf("unexpected scoped networks: %#v", networks)
+	}
+
+	volumeResult, err := New().ExecuteAction(context.Background(), runtime, connectors.PreparedAction{ActionName: ActionListVolumes, Payload: map[string]any{}})
+	if err != nil {
+		t.Fatalf("list volumes: %v", err)
+	}
+	volumeOutput, _ := volumeResult.Output.(map[string]any)
+	volumes, _ := volumeOutput["volumes"].([]DockerVolume)
+	if len(volumes) != 1 || volumes[0].Name != "api-data" || volumes[0].Containers != 1 {
+		t.Fatalf("unexpected scoped volumes: %#v", volumes)
+	}
+
+	containers, err := parseDockerPS(transport.results["docker ps -a --no-trunc --format '{{json .}}'"].Stdout)
+	if err != nil {
+		t.Fatalf("parse containers: %v", err)
+	}
+	if containers[0].Health != "healthy" || containers[0].ComposeProject != "watb" || containers[0].ComposeService != "api" {
+		t.Fatalf("expected enriched compose metadata, got %#v", containers[0])
+	}
+}
+
 func dockerTarget() connectors.TargetView {
 	return connectors.TargetView{
 		ID:            1,

--- a/backend/internal/connectors/docker/docker_test.go
+++ b/backend/internal/connectors/docker/docker_test.go
@@ -111,6 +111,50 @@ func TestLifecycleReturnsRefreshedContainerState(t *testing.T) {
 	}
 }
 
+func TestContainerExecRunsBoundedCommandInsideScopedContainer(t *testing.T) {
+	transport := &fakeCommandTransport{
+		results: map[string]connectors.CommandRunResult{
+			"docker ps -a --no-trunc --format '{{json .}}'": {Stdout: `{"ID":"111111111111","Names":"api","Image":"app:latest","State":"running","Status":"Up 1 hour"}`},
+			"docker exec -- 'api' sh -lc 'printf hi' 2>&1":  {Stdout: "hi", ExitCode: 0, DurationMS: 7},
+		},
+	}
+	result, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       dockerTarget(),
+		Profile:      dockerProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}, connectors.PreparedAction{ActionName: ActionContainerExec, Payload: map[string]any{"container": "api", "command": "printf hi"}})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if result.Status != connectors.ResultCompleted || result.DisplayText != "hi" {
+		t.Fatalf("unexpected exec result: %#v", result)
+	}
+	output, _ := result.Output.(map[string]any)
+	if output["exit_code"] != 0 || output["container"] == nil {
+		t.Fatalf("unexpected exec output: %#v", output)
+	}
+}
+
+func TestContainerExecReturnsFailedStatusForNonZeroExit(t *testing.T) {
+	transport := &fakeCommandTransport{
+		results: map[string]connectors.CommandRunResult{
+			"docker ps -a --no-trunc --format '{{json .}}'":   {Stdout: `{"ID":"111111111111","Names":"api","Image":"app:latest","State":"running","Status":"Up 1 hour"}`},
+			"docker exec -- 'api' sh -lc 'cat /missing' 2>&1": {Stdout: "missing\n", ExitCode: 1},
+		},
+	}
+	result, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       dockerTarget(),
+		Profile:      dockerProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}, connectors.PreparedAction{ActionName: ActionContainerExec, Payload: map[string]any{"container": "api", "command": "cat /missing"}})
+	if err != nil {
+		t.Fatalf("exec failed result should not be transport error: %v", err)
+	}
+	if result.Status != connectors.ResultFailed || !strings.Contains(result.Error, "code 1") {
+		t.Fatalf("unexpected failed exec result: %#v", result)
+	}
+}
+
 func TestListImagesFiltersBySelectedScope(t *testing.T) {
 	transport := &fakeCommandTransport{
 		results: map[string]connectors.CommandRunResult{

--- a/backend/internal/connectors/ssh/apiadapter/adapter.go
+++ b/backend/internal/connectors/ssh/apiadapter/adapter.go
@@ -39,6 +39,11 @@ const (
 	maxConfigParseBytes      = 256 * 1024
 )
 
+type LiveConsoleOptions struct {
+	ForceShellCommand        string
+	StartupInputAfterConnect string
+}
+
 type adapter struct{}
 
 func init() {
@@ -322,7 +327,7 @@ func (adapter) LiveConsoleActionName() string {
 	return sshconnector.ActionExec
 }
 
-func (adapter) OpenLiveConsole(ctx context.Context, server connectorapi.GatewayServer, runtime connectorapi.GatewayRuntime, runtimeID int64, rows int, cols int) (*console.RuntimeSession, error) {
+func (adapter) OpenLiveConsole(ctx context.Context, server connectorapi.GatewayServer, runtime connectorapi.GatewayRuntime, runtimeID int64, rows int, cols int, _ map[string]any) (*console.RuntimeSession, error) {
 	gateway, err := serverFrom(server)
 	if err != nil {
 		return nil, err
@@ -330,6 +335,32 @@ func (adapter) OpenLiveConsole(ctx context.Context, server connectorapi.GatewayS
 	target, privateKey, err := targetMaterial(ctx, runtime, runtimeID)
 	if err != nil {
 		return nil, fmt.Errorf("resolve ssh material: %w", err)
+	}
+	return openLiveConsoleWithMaterial(ctx, gateway, target, privateKey, rows, cols, LiveConsoleOptions{})
+}
+
+func OpenLiveConsoleForTargetRef(ctx context.Context, server connectorapi.GatewayServer, runtime connectorapi.GatewayRuntime, targetRef string, rows int, cols int, options LiveConsoleOptions) (*console.RuntimeSession, error) {
+	gateway, err := serverFrom(server)
+	if err != nil {
+		return nil, err
+	}
+	runtimeID, err := runtimeIDForTargetRef(ctx, runtime, targetRef)
+	if err != nil {
+		return nil, err
+	}
+	target, privateKey, err := targetMaterial(ctx, runtime, runtimeID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ssh material: %w", err)
+	}
+	return openLiveConsoleWithMaterial(ctx, gateway, target, privateKey, rows, cols, options)
+}
+
+func openLiveConsoleWithMaterial(_ context.Context, gateway connectorapi.GatewayServer, target sshTargetMaterial, privateKey sshkeys.PrivateKey, rows int, cols int, options LiveConsoleOptions) (*console.RuntimeSession, error) {
+	if strings.TrimSpace(options.ForceShellCommand) != "" {
+		target.ForceShellCommand = strings.TrimSpace(options.ForceShellCommand)
+	}
+	if options.StartupInputAfterConnect != "" {
+		target.StartupInputAfterConnect = options.StartupInputAfterConnect
 	}
 	signer, err := ssh.ParsePrivateKey([]byte(privateKey.PrivateKey))
 	if err != nil {

--- a/backend/internal/console/console_session_manager.go
+++ b/backend/internal/console/console_session_manager.go
@@ -102,6 +102,7 @@ func (m *Manager) Create(ctx context.Context, request CreateRequest) (Record, er
 		name:      request.Name,
 		cols:      request.Cols,
 		rows:      request.Rows,
+		params:    cloneParams(request.Params),
 		manager:   m,
 		ctx:       sessionCtx,
 		cancel:    cancel,

--- a/backend/internal/console/console_session_runtime.go
+++ b/backend/internal/console/console_session_runtime.go
@@ -27,7 +27,7 @@ func (s *managedConsoleSession) run() {
 		s.fail("console transport is not configured")
 		return
 	}
-	runtime, err := s.manager.openRuntime(s.ctx, s.runtimeID, s.rows, s.cols)
+	runtime, err := s.manager.openRuntime(s.ctx, s.runtimeID, s.rows, s.cols, cloneParams(s.params))
 	if err != nil {
 		s.markStarted(err)
 		s.fail(err.Error())

--- a/backend/internal/console/console_sessions.go
+++ b/backend/internal/console/console_sessions.go
@@ -60,12 +60,13 @@ type Record struct {
 }
 
 type CreateRequest struct {
-	RuntimeID     int64  `json:"runtime_id"`
-	Name          string `json:"name"`
-	CloseExisting bool   `json:"close_existing"`
-	Cols          int    `json:"cols"`
-	Rows          int    `json:"rows"`
-	WaitForStart  bool   `json:"wait_for_start"`
+	RuntimeID     int64          `json:"runtime_id"`
+	Name          string         `json:"name"`
+	CloseExisting bool           `json:"close_existing"`
+	Cols          int            `json:"cols"`
+	Rows          int            `json:"rows"`
+	WaitForStart  bool           `json:"wait_for_start"`
+	Params        map[string]any `json:"params,omitempty"`
 }
 
 type InputRequest struct {
@@ -81,7 +82,7 @@ type ExecResult struct {
 	DurationMS int64
 }
 
-type RuntimeOpener func(context.Context, int64, int, int) (*RuntimeSession, error)
+type RuntimeOpener func(context.Context, int64, int, int, map[string]any) (*RuntimeSession, error)
 
 type RuntimeSession struct {
 	Stdin                    io.WriteCloser
@@ -131,12 +132,24 @@ func (m *Manager) redactText(value string) string {
 	return m.redact(value)
 }
 
+func cloneParams(params map[string]any) map[string]any {
+	if len(params) == 0 {
+		return nil
+	}
+	clone := make(map[string]any, len(params))
+	for key, value := range params {
+		clone[key] = value
+	}
+	return clone
+}
+
 type managedConsoleSession struct {
 	id        int64
 	runtimeID int64
 	name      string
 	cols      int
 	rows      int
+	params    map[string]any
 	manager   *Manager
 
 	ctx       context.Context

--- a/backend/internal/console/console_sessions_test.go
+++ b/backend/internal/console/console_sessions_test.go
@@ -1179,7 +1179,7 @@ func TestConsoleSessionManagerEnsureReadyReturnsConnectionError(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = database.Close() })
 	runtimeID := insertConsoleTestSSHProfile(t, database, "worker-1", "127.0.0.1", 23)
-	manager := NewManager(database, func(context.Context, int64, int, int) (*RuntimeSession, error) {
+	manager := NewManager(database, func(context.Context, int64, int, int, map[string]any) (*RuntimeSession, error) {
 		return nil, errors.New("transport dial: dial tcp 127.0.0.1:23: connect: connection refused")
 	}, nil)
 

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -11,7 +11,7 @@ import (
 	_ "github.com/mutecomm/go-sqlcipher/v4"
 )
 
-const currentSchemaVersion = 2
+const currentSchemaVersion = 3
 
 func OpenEncrypted(path string, password string) (*sql.DB, error) {
 	return openEncrypted(path, password, true)

--- a/backend/internal/db/migrations.go
+++ b/backend/internal/db/migrations.go
@@ -574,6 +574,23 @@ var migrations = []migration{
 			},
 		),
 	},
+	{
+		version:     3,
+		description: "docker live console runtime surfaces",
+		statements: []string{
+			`INSERT INTO connector_runtime_surfaces (
+				connector_kind, target_id, profile_id, capability_kind, label, status, created_at, updated_at
+			)
+			SELECT p.connector_kind, p.target_id, p.id, 'live_console', p.label, 'active', datetime('now'), datetime('now')
+			FROM connector_credential_profiles p
+			JOIN connector_targets t ON t.id = p.target_id AND t.connector_kind = p.connector_kind
+			WHERE p.connector_kind = 'docker' AND p.status = 'active' AND t.status = 'active'
+			ON CONFLICT(connector_kind, target_id, profile_id, capability_kind) DO UPDATE SET
+				label = excluded.label,
+				status = 'active',
+				updated_at = excluded.updated_at`,
+		},
+	},
 }
 
 func sqlStatements(groups ...[]string) []string {

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,0 +1,42 @@
+name: aipermission
+
+services:
+  backend:
+    image: ghcr.io/aipermission/aipermission-backend:${AIPERMISSION_VERSION:-latest}
+    container_name: aipermission-backend
+    environment:
+      AIPERMISSION_BACKEND_HOST: 127.0.0.1
+      AIPERMISSION_BACKEND_PORT: 8080
+      AIPERMISSION_DATA_PATH: /app/data/aipermission.db
+      AIPERMISSION_GATEWAY_SECRET: ${AIPERMISSION_GATEWAY_SECRET:-}
+      AIPERMISSION_FRONTEND_PORT: ${AIPERMISSION_FRONTEND_PORT:-3210}
+      AIPERMISSION_ALLOWED_ORIGINS: ${AIPERMISSION_ALLOWED_ORIGINS:-}
+    network_mode: "service:frontend"
+    volumes:
+      - aipermission_data:/app/data
+
+  migration:
+    profiles:
+      - migrate
+    image: ghcr.io/aipermission/aipermission-backend:${AIPERMISSION_VERSION:-latest}
+    container_name: aipermission-migration
+    command: ["aipermission"]
+    environment:
+      AIPERMISSION_MIGRATION_MODE: "1"
+      AIPERMISSION_MIGRATION_HOST: 0.0.0.0
+      AIPERMISSION_MIGRATION_PORT: 3211
+      AIPERMISSION_DATA_PATH: /app/data/aipermission.db
+      AIPERMISSION_GATEWAY_SECRET: ${AIPERMISSION_GATEWAY_SECRET:-}
+    ports:
+      - "127.0.0.1:3211:3211"
+    volumes:
+      - aipermission_data:/app/data
+
+  frontend:
+    image: ghcr.io/aipermission/aipermission-frontend:${AIPERMISSION_VERSION:-latest}
+    container_name: aipermission-frontend
+    ports:
+      - "127.0.0.1:${AIPERMISSION_FRONTEND_PORT:-3210}:3210"
+
+volumes:
+  aipermission_data:

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -146,12 +146,14 @@ payload previews and published payloads may contain secrets or customer data;
 prefer approval-required access until the workflow is trusted.
 
 Docker actions include version metadata, scoped container/image/network/volume
-listing, redacted container inspect metadata, bounded container log tails, and
-explicit start/stop/restart lifecycle actions. Docker profiles can be scoped to
-all containers, selected names/IDs, or name patterns. If a token is bound to a
-profile that allows one container, MCP can only list or operate on that
-container through Docker actions; image, network, and volume reads are also
-bounded to the selected container scope where practical.
+listing, redacted container inspect metadata, bounded container log tails,
+scoped `container_exec`, and explicit start/stop/restart lifecycle actions.
+Docker profiles can be scoped to all containers, selected names/IDs, or name
+patterns. If a token is bound to a profile that allows one container, MCP can
+only list or operate on that container through Docker actions; image, network,
+volume reads, `container_exec`, and live container console sessions are bounded
+to the selected container scope where practical. Arbitrary host-level Docker
+commands, prune, removal, and raw Docker command execution are not exposed.
 
 ## call_connector_action
 

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -145,12 +145,13 @@ with `ack_requeue_true`, plus explicit `publish_message` writes. Message
 payload previews and published payloads may contain secrets or customer data;
 prefer approval-required access until the workflow is trusted.
 
-Docker actions include version metadata, scoped container listing, redacted
-container inspect metadata, bounded container log tails, and explicit
-start/stop/restart lifecycle actions. Docker profiles can be scoped to all
-containers, selected names/IDs, or name patterns. If a token is bound to a
+Docker actions include version metadata, scoped container/image/network/volume
+listing, redacted container inspect metadata, bounded container log tails, and
+explicit start/stop/restart lifecycle actions. Docker profiles can be scoped to
+all containers, selected names/IDs, or name patterns. If a token is bound to a
 profile that allows one container, MCP can only list or operate on that
-container through Docker actions.
+container through Docker actions; image, network, and volume reads are also
+bounded to the selected container scope where practical.
 
 ## call_connector_action
 

--- a/docs/development/add-a-connector.md
+++ b/docs/development/add-a-connector.md
@@ -191,7 +191,9 @@ Use existing reviewed capabilities before inventing connector-specific routes:
   connectors such as Postgres, Redis, and RabbitMQ.
 - `CommandTransport` runs bounded connector-owned command templates through a
   reviewed connector transport such as SSH. Docker uses this for fixed Docker
-  CLI templates while keeping arbitrary shell and `docker exec` out of scope.
+  CLI templates while keeping arbitrary host-level shell and raw Docker command
+  execution out of scope. Scoped container exec is modeled as a connector action
+  and must enforce the Docker credential profile scope first.
 
 Do not import the SSH connector package from another connector. Ask for a
 generic capability such as `NetworkTransport` or `CommandTransport`; the

--- a/docs/setup/docker-runtime.md
+++ b/docs/setup/docker-runtime.md
@@ -4,8 +4,24 @@ The default runtime model for the MVP is local Docker.
 
 ## Compose Shape
 
+Build from source:
+
 ```txt
-docker compose up
+docker compose up -d --build
+```
+
+Use published release images:
+
+```txt
+docker compose -f docker-compose.release.yml pull
+docker compose -f docker-compose.release.yml up -d
+```
+
+Pin a specific release image with `AIPERMISSION_VERSION` without the leading
+`v`:
+
+```txt
+AIPERMISSION_VERSION=0.2.9 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, keep shell scripts checked out with LF line endings. Git should do
@@ -21,7 +37,7 @@ web API proxy   -> http://localhost:3210/api
 MCP URL         -> http://localhost:3210
 ```
 
-Compose publishes host ports only on `127.0.0.1` by default. This is an intentional security boundary. After unlock, the web REST API uses a local HttpOnly browser session cookie, but that cookie is a localhost UX/session guard and not a remote multi-user auth model.
+Both Compose files publish host ports only on `127.0.0.1` by default. This is an intentional security boundary. After unlock, the web REST API uses a local HttpOnly browser session cookie, but that cookie is a localhost UX/session guard and not a remote multi-user auth model.
 
 The backend refuses to start when `AIPERMISSION_BACKEND_HOST` is `0.0.0.0` or any non-loopback address. In Docker Compose, the backend shares the frontend network namespace, binds only to `127.0.0.1`, and the frontend nginx proxies `/api` to it. Do not change Compose port bindings to `0.0.0.0` or a LAN address. The localhost bind is the security boundary; Host-header checks are defense in depth only. Remote/LAN access is unsupported.
 

--- a/docs/whatis-aipermission.md
+++ b/docs/whatis-aipermission.md
@@ -18,8 +18,9 @@ connectors. SSH provides live terminal/file-transfer actions, Postgres provides
 structured metadata and bounded read-only query actions, Redis provides bounded
 key browsing plus explicit write/delete actions, RabbitMQ provides queue
 metadata, bindings, bounded message previews, and explicit message publishing,
-and Docker provides scoped container inventory, logs, redacted inspect metadata,
-and explicit lifecycle actions. They use the same target, credential profile,
+and Docker provides scoped container/image/network/volume inventory, logs,
+redacted inspect metadata, and explicit lifecycle actions. They use the same
+target, credential profile,
 token permission, approval, history, and audit pipeline.
 
 The product is intentionally not positioned as a full DevOps platform.

--- a/docs/whatis-aipermission.md
+++ b/docs/whatis-aipermission.md
@@ -19,7 +19,8 @@ structured metadata and bounded read-only query actions, Redis provides bounded
 key browsing plus explicit write/delete actions, RabbitMQ provides queue
 metadata, bindings, bounded message previews, and explicit message publishing,
 and Docker provides scoped container/image/network/volume inventory, logs,
-redacted inspect metadata, and explicit lifecycle actions. They use the same
+redacted inspect metadata, scoped container exec, live container console, and
+explicit lifecycle actions. They use the same
 target, credential profile,
 token permission, approval, history, and audit pipeline.
 
@@ -236,6 +237,7 @@ allowed connector targets:
 - postgres:main-db/readonly -> query_readonly approval_required
 - redis:cache/ops -> get_key approval_required
 - docker:prod-docker/api-only -> container_logs approval_required
+- docker:prod-docker/api-only -> container_exec approval_required
 ```
 
 The AI assistant can see and use only the connector targets and actions allowed

--- a/frontend/src/components/app-shell.jsx
+++ b/frontend/src/components/app-shell.jsx
@@ -247,11 +247,12 @@ export function Shell({ theme, setTheme }) {
     return newConsoleSession(server);
   }
 
-  async function newConsoleSession(server) {
+  async function newConsoleSession(server, options = {}) {
     const session = await apiPost("/api/console/sessions", {
       runtime_id: server.id,
-      name: `${server.name} shell`,
+      name: options.name || `${server.name} shell`,
       close_existing: true,
+      params: options.params || undefined,
     });
     upsertConsoleSession(session);
     attachConsoleSession(session.id);

--- a/frontend/src/connectors/templates/docker/console.jsx
+++ b/frontend/src/connectors/templates/docker/console.jsx
@@ -10,8 +10,11 @@ import { apiPost } from "../../../lib/api";
 
 export function DockerConnectorConsoleTemplate({ target, approvals, theme, session, onNewStructuredSession, onRefreshActivity }) {
   const activeSession = session || { active: false, startedAt: "" };
+  const [resourceView, setResourceView] = useState("containers");
   const [containers, setContainers] = useState([]);
+  const [resources, setResources] = useState({ images: [], networks: [], volumes: [] });
   const [selectedID, setSelectedID] = useState("");
+  const [selectedResourceID, setSelectedResourceID] = useState("");
   const [filter, setFilter] = useState("");
   const [tail, setTail] = useState(200);
   const [viewMode, setViewMode] = useState("logs");
@@ -29,16 +32,21 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
   const activeItems = useMemo(() => (approvals?.data || []).filter((item) => item.target_ref === target.ref), [approvals?.data, target.ref]);
   const latestAction = activeItems[0] || null;
   const selectedContainer = containers.find((container) => container.id === selectedID || container.name === selectedID) || null;
+  const activeResourceList = resourceView === "containers" ? containers : resources[resourceView] || [];
+  const selectedResource = resourceView === "containers" ? selectedContainer : activeResourceList.find((item) => resourceKey(resourceView, item) === selectedResourceID) || null;
   const showingInspect = viewMode === "inspect";
-  const filteredContainers = useMemo(() => {
+  const filteredItems = useMemo(() => {
     const query = filter.trim().toLowerCase();
-    if (!query) return containers;
-    return containers.filter((container) => [container.name, container.image, container.state, container.status, container.ports].some((value) => String(value || "").toLowerCase().includes(query)));
-  }, [containers, filter]);
+    if (!query) return activeResourceList;
+    return activeResourceList.filter((item) => resourceSearchValues(resourceView, item).some((value) => String(value || "").toLowerCase().includes(query)));
+  }, [activeResourceList, filter, resourceView]);
 
   useEffect(() => {
+    setResourceView("containers");
     setContainers([]);
+    setResources({ images: [], networks: [], volumes: [] });
     setSelectedID("");
+    setSelectedResourceID("");
     setFilter("");
     setViewMode("logs");
     setResult(null);
@@ -50,6 +58,11 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
     if (!activeSession.active) return;
     void refreshContainers();
   }, [activeSession.active, activeSession.startedAt, target.ref]);
+
+  useEffect(() => {
+    if (!activeSession.active || resourceView === "containers") return;
+    void refreshResource(resourceView);
+  }, [activeSession.active, activeSession.startedAt, resourceView, target.ref]);
 
   async function runDockerAction({ actionName, input = {}, reason, busy = "running", showResult = true }) {
     setState({ state: busy, error: "", message: "" });
@@ -83,6 +96,25 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
     setSelectedID((current) => (current && next.some((container) => container.id === current || container.name === current) ? current : ""));
   }
 
+  async function refreshResource(kind = resourceView) {
+    if (kind === "containers") {
+      await refreshContainers();
+      return;
+    }
+    const actionName = { images: "list_images", networks: "list_networks", volumes: "list_volumes" }[kind];
+    const outputKey = kind;
+    const item = await runDockerAction({
+      actionName,
+      input: {},
+      reason: `manual Docker browser ${kind} list`,
+      busy: "loading",
+      showResult: false,
+    });
+    const next = item.output?.[outputKey] || [];
+    setResources((current) => ({ ...current, [kind]: next }));
+    setSelectedResourceID((current) => (current && next.some((entry) => resourceKey(kind, entry) === current) ? current : ""));
+  }
+
   async function readLogs(container = selectedContainer) {
     if (!container) return;
     setViewMode("logs");
@@ -109,6 +141,31 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
     } else {
       void readLogs(container);
     }
+  }
+
+  function selectResource(kind, item) {
+    if (kind === "containers") {
+      selectContainer(item);
+      return;
+    }
+    const key = resourceKey(kind, item);
+    if (selectedResourceID === key) {
+      setSelectedResourceID("");
+      return;
+    }
+    setSelectedResourceID(key);
+    setResult(null);
+    setResultSearch("");
+  }
+
+  function switchResourceView(kind) {
+    if (resourceView === kind) return;
+    setResourceView(kind);
+    setFilter("");
+    setResult(null);
+    setResultSearch("");
+    setSelectedID("");
+    setSelectedResourceID("");
   }
 
   async function inspectContainer(container = selectedContainer) {
@@ -183,43 +240,56 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
   return (
     <div className={`grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
       <div className="grid min-h-0 gap-4 overflow-hidden p-4 lg:grid-cols-[360px_minmax(0,1fr)]">
-        <section className={`grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+        <section className={`grid min-h-0 grid-rows-[auto_auto_auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
           <div className={`border-b p-3 ${borderClass}`}>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
-                <p className="text-sm font-semibold">Containers</p>
-                <p className={`text-xs ${mutedClass}`}>{containers.length} visible in this profile scope</p>
+                <p className="text-sm font-semibold">{resourceLabel(resourceView)}</p>
+                <p className={`text-xs ${mutedClass}`}>{activeResourceList.length} visible in this profile scope</p>
               </div>
               <div className="flex items-center gap-2">
                 {latestAction ? <Badge tone={latestAction.status === "failed" ? "bad" : latestAction.status === "completed" ? "good" : "warn"}>{latestAction.action_name}</Badge> : null}
-                <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Refresh containers" onClick={refreshContainers} disabled={state.state !== "idle"}>
+                <Button type="button" variant="outline" className="h-8 w-8 px-0" title={`Refresh ${resourceLabel(resourceView).toLowerCase()}`} onClick={() => refreshResource(resourceView)} disabled={state.state !== "idle"}>
                   <RefreshCcw className="h-3.5 w-3.5" />
                 </Button>
               </div>
             </div>
           </div>
+          <div className={`grid grid-cols-4 gap-1 border-b p-2 ${borderClass}`}>
+            {["containers", "images", "networks", "volumes"].map((kind) => (
+              <button
+                type="button"
+                key={kind}
+                className={`rounded-md px-2 py-1.5 text-xs font-semibold ${resourceView === kind ? "bg-emerald-600 text-white" : theme === "light" ? "text-stone-600 hover:bg-stone-100" : "text-stone-300 hover:bg-stone-800"}`}
+                onClick={() => switchResourceView(kind)}
+              >
+                {resourceTabLabel(kind)}
+              </button>
+            ))}
+          </div>
           <div className={`border-b p-3 ${borderClass}`}>
-            <Input className={inputClass} value={filter} onChange={(event) => setFilter(event.target.value)} placeholder="Search containers" />
+            <Input className={inputClass} value={filter} onChange={(event) => setFilter(event.target.value)} placeholder={`Search ${resourceLabel(resourceView).toLowerCase()}`} />
           </div>
           <div className="min-h-0 overflow-auto">
-            {filteredContainers.length === 0 ? (
-              <div className={`p-4 text-sm ${mutedClass}`}>No containers matched this scope or search.</div>
+            {filteredItems.length === 0 ? (
+              <div className={`p-4 text-sm ${mutedClass}`}>No {resourceLabel(resourceView).toLowerCase()} matched this scope or search.</div>
             ) : (
-              filteredContainers.map((container) => {
-                const active = selectedContainer && (selectedContainer.id === container.id || selectedContainer.name === container.name);
+              filteredItems.map((item) => {
+                const key = resourceKey(resourceView, item);
+                const active = resourceView === "containers" ? selectedContainer && (selectedContainer.id === item.id || selectedContainer.name === item.name) : selectedResourceID === key;
                 return (
                   <button
                     type="button"
-                    key={container.id || container.name}
+                    key={key}
                     className={`grid w-full gap-1 border-b px-3 py-3 text-left text-sm ${borderClass} ${rowHoverClass} ${active ? activeRowClass : ""}`}
-                    onClick={() => selectContainer(container)}
+                    onClick={() => selectResource(resourceView, item)}
                   >
                     <span className="flex min-w-0 items-center justify-between gap-3">
-                      <span className="truncate font-semibold">{container.name || container.id}</span>
-                      <Badge tone={container.state === "running" ? "good" : "neutral"}>{container.state || "unknown"}</Badge>
+                      <span className="truncate font-semibold">{resourcePrimary(resourceView, item)}</span>
+                      <Badge tone={resourceTone(resourceView, item)}>{resourceStatus(resourceView, item)}</Badge>
                     </span>
-                    <span className={`truncate text-xs ${mutedClass}`}>{container.image}</span>
-                    <span className={`truncate text-xs ${mutedClass}`}>{container.status}</span>
+                    <span className={`truncate text-xs ${mutedClass}`}>{resourceSecondary(resourceView, item)}</span>
+                    <span className={`truncate text-xs ${mutedClass}`}>{resourceTertiary(resourceView, item)}</span>
                   </button>
                 );
               })
@@ -232,7 +302,7 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
             <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
               <div className="min-w-0">
                 <div className="flex min-w-0 items-center gap-2">
-                  <p className="truncate text-sm font-semibold">{selectedContainer?.name || "Select a container"}</p>
+                  <p className="truncate text-sm font-semibold">{selectedResource ? resourcePrimary(resourceView, selectedResource) : `Select ${resourceSingular(resourceView)}`}</p>
                   {state.state !== "idle" ? (
                     <span className={`inline-flex shrink-0 items-center gap-1 text-xs ${mutedClass}`}>
                       <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
@@ -240,9 +310,9 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
                     </span>
                   ) : null}
                 </div>
-                <p className={`truncate text-xs ${mutedClass}`}>{selectedContainer?.image || "Choose a visible container to read logs, inspect metadata, or run lifecycle actions."}</p>
+                <p className={`truncate text-xs ${mutedClass}`}>{selectedResource ? resourceSecondary(resourceView, selectedResource) : resourcePlaceholder(resourceView)}</p>
               </div>
-              {selectedContainer ? (
+              {resourceView === "containers" && selectedContainer ? (
                 <div className="flex flex-wrap items-center justify-end gap-2">
                   <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={showingInspect ? () => readLogs() : () => inspectContainer()} disabled={state.state !== "idle"} title={showingInspect ? "Show container logs" : "Inspect container"}>
                     {showingInspect ? <RefreshCcw className="h-3.5 w-3.5" /> : <FileJson className="h-3.5 w-3.5" />}
@@ -278,8 +348,10 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
             </div>
           ) : null}
           <div className="grid min-h-0 overflow-hidden p-3">
-            {!selectedContainer ? (
-              <div className={`grid place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>Select a container from the list to read its logs.</div>
+            {!selectedResource ? (
+              <div className={`grid place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>{resourcePlaceholder(resourceView)}</div>
+            ) : resourceView !== "containers" ? (
+              <DockerResourceDetail resourceView={resourceView} item={selectedResource} search={resultSearch} onSearch={setResultSearch} inputClass={inputClass} />
             ) : state.state !== "idle" && !result ? (
               <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>
                 <span className="inline-flex items-center gap-2">
@@ -478,6 +550,75 @@ function DockerInspectSummary({ output }) {
   );
 }
 
+function DockerResourceDetail({ resourceView, item, search, onSearch, inputClass }) {
+  const rawValue = JSON.stringify(item || {}, null, 2);
+  const rows = resourceDetailRows(resourceView, item);
+  return (
+    <div className="grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden">
+      <DockerResultHeader title={`${resourceSingular(resourceView)} metadata`} subtitle={resourceSecondary(resourceView, item)} />
+      <div className="mb-3 min-h-0 overflow-auto rounded-md border border-stone-700 bg-[#1a1a1a] p-3">
+        <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+          {rows.map(([label, value]) => (
+            <div key={label} className="min-w-0 rounded border border-stone-700 bg-[#202020] p-2">
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-stone-500">{label}</p>
+              <p className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-stone-100">{String(value)}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden">
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <p className="truncate text-xs font-semibold uppercase tracking-wide text-stone-500">{resourceSingular(resourceView)} raw data</p>
+          <div className="flex min-w-0 items-center justify-end gap-2">
+            <Input className={`h-8 w-56 text-xs ${inputClass || ""}`} value={search} onChange={(event) => onSearch?.(event.target.value)} placeholder="Search raw data" />
+            <CopyButton value={rawValue} variant="outline" className="h-8 px-2 text-xs" />
+          </div>
+        </div>
+        <TerminalBlock className="min-h-0 whitespace-pre-wrap break-words text-xs [overflow-wrap:anywhere]" surface="dark">
+          <HighlightedText text={rawValue} query={search} />
+        </TerminalBlock>
+      </div>
+    </div>
+  );
+}
+
+function resourceDetailRows(kind, item = {}) {
+  if (kind === "images") {
+    return [
+      ["Repository", item.repository],
+      ["Tag", item.tag],
+      ["Image ID", item.id],
+      ["Digest", item.digest],
+      ["Size", item.size],
+      ["Created", item.created_since || item.created_at],
+      ["Visible containers", item.containers ?? 0],
+    ].filter(([, value]) => value !== undefined && value !== null && String(value).trim() !== "");
+  }
+  if (kind === "networks") {
+    return [
+      ["Name", item.name],
+      ["Network ID", item.id],
+      ["Driver", item.driver],
+      ["Scope", item.scope],
+      ["IPv6", item.ipv6],
+      ["Internal", item.internal],
+      ["Visible containers", item.containers ?? 0],
+      ["Labels", item.labels],
+    ].filter(([, value]) => value !== undefined && value !== null && String(value).trim() !== "");
+  }
+  if (kind === "volumes") {
+    return [
+      ["Name", item.name],
+      ["Driver", item.driver],
+      ["Scope", item.scope],
+      ["Mountpoint", item.mountpoint],
+      ["Visible containers", item.containers ?? 0],
+      ["Labels", item.labels],
+    ].filter(([, value]) => value !== undefined && value !== null && String(value).trim() !== "");
+  }
+  return Object.entries(item).map(([key, value]) => [key, typeof value === "string" ? value : JSON.stringify(value)]);
+}
+
 function formatDockerLogs(logs) {
   return String(logs || "")
     .split("\n")
@@ -547,6 +688,92 @@ function shortValue(value) {
   const text = typeof value === "string" ? value : JSON.stringify(value);
   if (!text) return "";
   return text.length > 80 ? `${text.slice(0, 77)}...` : text;
+}
+
+function resourceLabel(kind) {
+  if (kind === "images") return "Images";
+  if (kind === "networks") return "Networks";
+  if (kind === "volumes") return "Volumes";
+  return "Containers";
+}
+
+function resourceTabLabel(kind) {
+  if (kind === "containers") return "Ctrs";
+  if (kind === "networks") return "Nets";
+  if (kind === "volumes") return "Vols";
+  return "Images";
+}
+
+function resourceSingular(kind) {
+  if (kind === "images") return "image";
+  if (kind === "networks") return "network";
+  if (kind === "volumes") return "volume";
+  return "container";
+}
+
+function resourceKey(kind, item = {}) {
+  if (kind === "images") return item.id || `${item.repository || ""}:${item.tag || ""}`;
+  if (kind === "networks") return item.id || item.name;
+  if (kind === "volumes") return item.name;
+  return item.id || item.name;
+}
+
+function resourcePrimary(kind, item = {}) {
+  if (kind === "images") return imageRef(item);
+  return item.name || item.id || "-";
+}
+
+function resourceSecondary(kind, item = {}) {
+  if (kind === "containers") return [item.image, item.compose_project ? `project ${item.compose_project}` : ""].filter(Boolean).join(" · ");
+  if (kind === "images") return [item.id, item.size].filter(Boolean).join(" · ");
+  if (kind === "networks") return [item.driver, item.scope].filter(Boolean).join(" · ");
+  if (kind === "volumes") return [item.driver, item.mountpoint].filter(Boolean).join(" · ");
+  return "";
+}
+
+function resourceTertiary(kind, item = {}) {
+  if (kind === "containers") return [item.status, item.compose_service ? `service ${item.compose_service}` : ""].filter(Boolean).join(" · ");
+  if (kind === "images") return [item.created_since || item.created_at, item.containers ? `${item.containers} containers` : ""].filter(Boolean).join(" · ");
+  if (kind === "networks") return item.containers ? `${item.containers} visible containers` : item.labels || "";
+  if (kind === "volumes") return item.containers ? `${item.containers} visible containers` : item.labels || "";
+  return "";
+}
+
+function resourceStatus(kind, item = {}) {
+  if (kind === "containers") return item.health || item.state || "unknown";
+  if (kind === "images") return item.size || "image";
+  if (kind === "networks") return item.driver || "network";
+  if (kind === "volumes") return item.driver || "volume";
+  return "item";
+}
+
+function resourceTone(kind, item = {}) {
+  if (kind === "containers") {
+    if (item.health === "unhealthy") return "bad";
+    if (item.state === "running") return "good";
+    return "neutral";
+  }
+  return "neutral";
+}
+
+function resourceSearchValues(kind, item = {}) {
+  if (kind === "images") return [imageRef(item), item.id, item.size, item.created_since, item.created_at];
+  if (kind === "networks") return [item.name, item.id, item.driver, item.scope, item.labels];
+  if (kind === "volumes") return [item.name, item.driver, item.scope, item.mountpoint, item.labels];
+  return [item.name, item.id, item.image, item.state, item.status, item.health, item.ports, item.compose_project, item.compose_service];
+}
+
+function resourcePlaceholder(kind) {
+  if (kind === "images") return "Select an image to inspect read-only image metadata.";
+  if (kind === "networks") return "Select a network to inspect read-only network metadata.";
+  if (kind === "volumes") return "Select a volume to inspect read-only volume metadata.";
+  return "Choose a visible container to read logs, inspect metadata, or run lifecycle actions.";
+}
+
+function imageRef(item = {}) {
+  if (!item.repository) return item.id || "-";
+  if (!item.tag || item.tag === "<none>") return item.repository;
+  return `${item.repository}:${item.tag}`;
 }
 
 function DockerEndpointFooter({ target, borderClass, mutedClass }) {

--- a/frontend/src/connectors/templates/docker/console.jsx
+++ b/frontend/src/connectors/templates/docker/console.jsx
@@ -1,4 +1,4 @@
-import { Container, FileJson, LoaderCircle, Play, Power, RefreshCcw, RotateCcw, Square } from "lucide-react";
+import { Container, FileJson, LoaderCircle, Play, Power, RefreshCcw, RotateCcw, Square, TerminalSquare, XCircle } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Badge } from "../../../components/ui/badge";
 import { Button } from "../../../components/ui/button";
@@ -8,8 +8,7 @@ import { Input } from "../../../components/ui/form";
 import { TerminalBlock } from "../../../components/ui/terminal-block";
 import { apiPost } from "../../../lib/api";
 
-export function DockerConnectorConsoleTemplate({ target, approvals, theme, session, onNewStructuredSession, onRefreshActivity }) {
-  const activeSession = session || { active: false, startedAt: "" };
+export function DockerConnectorConsoleTemplate({ children, target, approvals, theme, session, selectedSessionLive, selectedRuntimeTarget, onNewLiveSession, onEndLiveSession, onRefreshActivity }) {
   const [resourceView, setResourceView] = useState("containers");
   const [containers, setContainers] = useState([]);
   const [resources, setResources] = useState({ images: [], networks: [], volumes: [] });
@@ -32,6 +31,9 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
   const activeItems = useMemo(() => (approvals?.data || []).filter((item) => item.target_ref === target.ref), [approvals?.data, target.ref]);
   const latestAction = activeItems[0] || null;
   const selectedContainer = containers.find((container) => container.id === selectedID || container.name === selectedID) || null;
+  const selectedContainerRef = selectedContainer ? selectedContainer.name || selectedContainer.id : "";
+  const expectedConsoleSessionName = selectedContainerRef ? dockerConsoleSessionName(target, selectedContainerRef) : "";
+  const selectedContainerConsoleLive = Boolean(selectedSessionLive && session?.name === expectedConsoleSessionName);
   const activeResourceList = resourceView === "containers" ? containers : resources[resourceView] || [];
   const selectedResource = resourceView === "containers" ? selectedContainer : activeResourceList.find((item) => resourceKey(resourceView, item) === selectedResourceID) || null;
   const showingInspect = viewMode === "inspect";
@@ -52,17 +54,16 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
     setResult(null);
     setResultSearch("");
     setState({ state: "idle", error: "", message: "" });
-  }, [target.ref, activeSession.active, activeSession.startedAt]);
+  }, [target.ref]);
 
   useEffect(() => {
-    if (!activeSession.active) return;
     void refreshContainers();
-  }, [activeSession.active, activeSession.startedAt, target.ref]);
+  }, [target.ref]);
 
   useEffect(() => {
-    if (!activeSession.active || resourceView === "containers") return;
+    if (resourceView === "containers") return;
     void refreshResource(resourceView);
-  }, [activeSession.active, activeSession.startedAt, resourceView, target.ref]);
+  }, [resourceView, target.ref]);
 
   async function runDockerAction({ actionName, input = {}, reason, busy = "running", showResult = true }) {
     setState({ state: busy, error: "", message: "" });
@@ -126,6 +127,21 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
     });
   }
 
+  function openContainerConsole(container = selectedContainer) {
+    if (!container) return;
+    setViewMode("console");
+    setResult(null);
+    setResultSearch("");
+  }
+
+  async function startContainerConsole() {
+    if (!selectedContainerRef) return;
+    await onNewLiveSession?.({
+      name: expectedConsoleSessionName,
+      params: { container: selectedContainerRef },
+    });
+  }
+
   function selectContainer(container) {
     if (selectedContainer && (selectedContainer.id === container.id || selectedContainer.name === container.name)) {
       setSelectedID("");
@@ -138,6 +154,8 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
     setResultSearch("");
     if (viewMode === "inspect") {
       void inspectContainer(container);
+    } else if (viewMode === "console") {
+      openContainerConsole(container);
     } else {
       void readLogs(container);
     }
@@ -215,26 +233,6 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
     } catch {
       setConfirmDialog((current) => ({ ...current, pending: false }));
     }
-  }
-
-  if (!activeSession.active) {
-    return (
-      <div className={`grid min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
-        <div className="grid place-items-center p-8 text-center">
-          <div className="grid max-w-lg gap-4">
-            <Container className={`mx-auto h-10 w-10 ${mutedClass}`} />
-            <div>
-              <h3 className="text-lg font-semibold">No active Docker session</h3>
-              <p className={`mt-2 text-sm ${mutedClass}`}>Start a structured session to browse scoped Docker containers through the connector approval, history, and audit pipeline.</p>
-            </div>
-            <Button type="button" className="mx-auto" onClick={onNewStructuredSession}>
-              Start Docker session
-            </Button>
-          </div>
-        </div>
-        <DockerEndpointFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
-      </div>
-    );
   }
 
   return (
@@ -318,7 +316,7 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
                     {showingInspect ? <RefreshCcw className="h-3.5 w-3.5" /> : <FileJson className="h-3.5 w-3.5" />}
                     {showingInspect ? "Logs" : "Inspect"}
                   </Button>
-                  {!showingInspect ? (
+                  {!showingInspect && viewMode !== "console" ? (
                     <>
                       <label className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
                         Tail
@@ -329,6 +327,9 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
                       </Button>
                     </>
                   ) : null}
+                  <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openContainerConsole()} disabled={state.state !== "idle"} title="Open live console inside this container">
+                    <TerminalSquare className="h-3.5 w-3.5" />
+                  </Button>
                   <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openLifecycle("start_container")} disabled={state.state !== "idle"} title="Start container">
                     <Play className="h-3.5 w-3.5" />
                   </Button>
@@ -352,6 +353,22 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
               <div className={`grid place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>{resourcePlaceholder(resourceView)}</div>
             ) : resourceView !== "containers" ? (
               <DockerResourceDetail resourceView={resourceView} item={selectedResource} search={resultSearch} onSearch={setResultSearch} inputClass={inputClass} />
+            ) : viewMode === "console" ? (
+              <DockerContainerConsolePanel
+                target={target}
+                container={selectedContainer}
+                containerRef={selectedContainerRef}
+                selectedRuntimeTarget={selectedRuntimeTarget}
+                session={session}
+                sessionLive={selectedContainerConsoleLive}
+                theme={theme}
+                mutedClass={mutedClass}
+                borderClass={borderClass}
+                onStart={startContainerConsole}
+                onEnd={onEndLiveSession}
+              >
+                {children}
+              </DockerContainerConsolePanel>
             ) : state.state !== "idle" && !result ? (
               <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>
                 <span className="inline-flex items-center gap-2">
@@ -398,6 +415,60 @@ export function DockerConnectorConsoleTemplate({ target, approvals, theme, sessi
       </Dialog>
     </div>
   );
+}
+
+function DockerContainerConsolePanel({ children, target, container, containerRef, selectedRuntimeTarget, session, sessionLive, theme, mutedClass, borderClass, onStart, onEnd }) {
+  const light = theme === "light";
+  if (!container) {
+    return (
+      <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>
+        Select a container, then open a live console inside it.
+      </div>
+    );
+  }
+  if (sessionLive) {
+    return (
+      <div className={`grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass}`}>
+        <div className={`flex min-w-0 items-center justify-between gap-3 border-b px-3 py-2 ${borderClass}`}>
+          <div className="min-w-0">
+            <p className="truncate text-xs font-semibold uppercase tracking-wide text-stone-500">Container console</p>
+            <p className="truncate font-mono text-xs">{containerRef}</p>
+          </div>
+          <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={onEnd} title="Close this container console session">
+            <XCircle className="h-3.5 w-3.5" />
+            End
+          </Button>
+        </div>
+        <div className="min-h-0 overflow-hidden">{children}</div>
+      </div>
+    );
+  }
+  const lastSessionForOtherContainer = session?.id && session?.name !== dockerConsoleSessionName(target, containerRef);
+  return (
+    <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center ${borderClass}`}>
+      <div className="grid max-w-md gap-4">
+        <div className={`mx-auto flex h-12 w-12 items-center justify-center rounded-full border ${light ? "border-stone-200 bg-stone-100" : "border-stone-600 bg-stone-800"}`}>
+          <TerminalSquare className={`h-6 w-6 ${light ? "text-stone-600" : "text-stone-300"}`} />
+        </div>
+        <div className="grid gap-2">
+          <h3 className={`text-base font-semibold ${light ? "text-stone-950" : "text-white"}`}>No active container console</h3>
+          <p className={`text-sm leading-6 ${mutedClass}`}>
+            Start an interactive shell inside <span className="font-mono">{containerRef}</span>. It uses the same live terminal as SSH console.
+          </p>
+          {lastSessionForOtherContainer ? <p className="text-xs text-amber-500">Starting this console will close the current Docker console session for this profile.</p> : null}
+          {!selectedRuntimeTarget ? <p className="text-xs text-red-500">This Docker profile does not have a live runtime surface yet. Save the connector once, then retry.</p> : null}
+        </div>
+        <Button type="button" className="mx-auto" onClick={onStart} disabled={!selectedRuntimeTarget}>
+          <RefreshCcw className="h-4 w-4" />
+          Start Container Console
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function dockerConsoleSessionName(target, containerRef) {
+  return `docker:${target?.ref || "target"}:${containerRef}`;
 }
 
 function DockerResultView({ item, search, onSearch, inputClass }) {

--- a/frontend/src/connectors/templates/docker/model.js
+++ b/frontend/src/connectors/templates/docker/model.js
@@ -188,7 +188,23 @@ export function targetProfileLabel({ target }) {
 }
 
 export function usesLiveConsole() {
-  return false;
+  return true;
+}
+
+export function liveConsoleRuntimeTarget({ target }) {
+  return {
+    id: target.runtime_id,
+    name: targetDisplayName({ target }),
+    host: target.config?.transport_target_ref || "",
+    port: 0,
+    username: target.profile_label || "",
+    description: "Docker container console",
+    connector_ref: target.ref,
+    connector_kind: target.connector_kind,
+    target_id: target.target_id,
+    profile_id: target.profile_id,
+    target,
+  };
 }
 
 export function deleteDialog({ target }) {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -236,9 +236,9 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.8"/);
-  assert.match(releaseSource, /Docker connector/);
-  assert.match(releaseSource, /Docker is now a built-in connector/);
+  assert.match(releaseSource, /appVersion = "0\.2\.9"/);
+  assert.match(releaseSource, /Docker inventory and images/);
+  assert.match(releaseSource, /Docker connector actions now include scoped image/);
   assert.match(releaseSource, /Maintenance and backup providers/);
   assert.match(releaseSource, /Settings now includes a local-only realtime Maintenance Console/);
   assert.match(releaseSource, /Backup providers are storage metadata only/);

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,30 @@
-export const appVersion = "0.2.8";
+export const appVersion = "0.2.9";
 
 export const changelogEntries = [
+  {
+    version: "0.2.9",
+    label: "Docker inventory and images",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Docker connector actions now include scoped image, network, and volume inventory reads.",
+          "Docker Console adds inventory tabs for Containers, Images, Networks, and Volumes with searchable metadata and raw JSON copy views.",
+          "Container lists now surface health and Docker Compose project/service metadata when Docker exposes it.",
+          "Release tags now publish backend and frontend container images to GitHub Container Registry.",
+          "A new docker-compose.release.yml file lets users pull published images instead of building locally.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "Selected Docker credential profiles only expose images used by visible containers, and derive networks/volumes from scoped container inspect data.",
+          "Prebuilt-image Compose keeps ports bound to 127.0.0.1 and does not change the local-only gateway boundary.",
+          "Docker still does not expose arbitrary docker exec, removal, prune, shell, or raw Docker command execution.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.8",
     label: "Docker connector",

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -11,6 +11,8 @@ export const changelogEntries = [
           "Docker connector actions now include scoped image, network, and volume inventory reads.",
           "Docker Console adds inventory tabs for Containers, Images, Networks, and Volumes with searchable metadata and raw JSON copy views.",
           "Container lists now surface health and Docker Compose project/service metadata when Docker exposes it.",
+          "Docker connector actions now include scoped container_exec for bounded non-interactive commands inside one visible container.",
+          "Docker Console can open a live terminal inside a selected container using the same xterm experience as SSH console.",
           "Release tags now publish backend and frontend container images to GitHub Container Registry.",
           "A new docker-compose.release.yml file lets users pull published images instead of building locally.",
         ],
@@ -20,7 +22,7 @@ export const changelogEntries = [
         items: [
           "Selected Docker credential profiles only expose images used by visible containers, and derive networks/volumes from scoped container inspect data.",
           "Prebuilt-image Compose keeps ports bound to 127.0.0.1 and does not change the local-only gateway boundary.",
-          "Docker still does not expose arbitrary docker exec, removal, prune, shell, or raw Docker command execution.",
+          "Docker container_exec and live container console are scoped to one visible container; arbitrary host-level Docker commands, removal, prune, and raw Docker command execution remain unavailable.",
         ],
       },
     ],

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -374,11 +374,11 @@ export function ConsolePage() {
     }
   }
 
-  async function startNewConsoleSession(runtimeTarget) {
+  async function startNewConsoleSession(runtimeTarget, options = {}) {
     if (!runtimeTarget) return;
     setNewSessionError("");
     try {
-      await newConsoleSession(runtimeTarget);
+      await newConsoleSession(runtimeTarget, options);
     } catch (error) {
       const model = getConnectorModel(runtimeTarget.connector_kind);
       const operation = model?.operationFromError?.(error, { operation: "new-session", target: runtimeTarget });
@@ -575,8 +575,12 @@ export function ConsolePage() {
               target={selectedTarget}
               approvals={connectorActionApprovals}
               theme={theme}
-              session={selectedStructuredSession}
+              session={selectedTargetUsesLiveConsole ? selectedSession : selectedStructuredSession}
+              selectedSessionLive={selectedSessionLive}
+              selectedRuntimeTarget={selectedRuntimeTarget}
               onNewStructuredSession={startStructuredConnectorSession}
+              onNewLiveSession={(options = {}) => selectedRuntimeTarget && startNewConsoleSession(selectedRuntimeTarget, options)}
+              onEndLiveSession={() => selectedSession.id && closeConsoleSession(selectedSession.id)}
               onOpenActivity={() => setConnectorActivityOpen(true)}
               onRefreshActivity={loadConnectorActionApprovals}
             >

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -87,12 +87,12 @@ previews and published payloads can contain secrets or customer data; use short
 reasons and prefer approval-required access until the workflow is trusted.
 
 For Docker, call `get_connector_actions(target_ref)` to discover bounded
-container actions such as `docker_version`, `list_containers`,
-`inspect_container`, `container_logs`, `start_container`, `stop_container`, and
-`restart_container`. Docker credential profiles can scope a token to all
-containers, selected container names/IDs, or name patterns. The Docker
-connector does not expose arbitrary `docker exec`, prune, removal, shell, or raw
-Docker command execution.
+actions such as `docker_version`, `list_containers`, `list_images`,
+`list_networks`, `list_volumes`, `inspect_container`, `container_logs`,
+`start_container`, `stop_container`, and `restart_container`. Docker credential
+profiles can scope a token to all containers, selected container names/IDs, or
+name patterns. The Docker connector does not expose arbitrary `docker exec`,
+prune, removal, shell, or raw Docker command execution.
 
 Connector responses can include `approval_pending` or `running`. Poll
 `get_connector_action_request(request_id)` until the request reaches a terminal

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -89,10 +89,12 @@ reasons and prefer approval-required access until the workflow is trusted.
 For Docker, call `get_connector_actions(target_ref)` to discover bounded
 actions such as `docker_version`, `list_containers`, `list_images`,
 `list_networks`, `list_volumes`, `inspect_container`, `container_logs`,
-`start_container`, `stop_container`, and `restart_container`. Docker credential
-profiles can scope a token to all containers, selected container names/IDs, or
-name patterns. The Docker connector does not expose arbitrary `docker exec`,
-prune, removal, shell, or raw Docker command execution.
+`container_exec`, `start_container`, `stop_container`, and `restart_container`.
+Docker credential profiles can scope a token to all containers, selected
+container names/IDs, or name patterns. `container_exec` and live container
+console sessions are scoped to one visible container; arbitrary host-level
+Docker commands, prune, removal, and raw Docker command execution are not
+exposed.
 
 Connector responses can include `approval_pending` or `running`. Poll
 `get_connector_action_request(request_id)` until the request reaches a terminal

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- publish prebuilt Docker image workflow and release compose/docs
- expand Docker connector inventory, inspect/logs, lifecycle, scoped exec, and live container console
- update README, MCP docs, in-app changelog, and package docs for 0.2.9

## Validation

- node scripts/secret-scan.js
- make test
- make build
- make audit
- cd backend && go test -race ./...
- cd backend && go vet ./...
- cd backend && govulncheck ./...
- docker compose config --quiet
- docker compose -f docker-compose.release.yml config --quiet
- cd packages/mcp && npm test
- cd packages/mcp && npm run build
- cd packages/mcp && npm audit --omit=dev --audit-level=moderate
- cd packages/mcp && npm pack --dry-run
- cd packages/npm-placeholder && npm pack --dry-run
- docker compose up -d --build --force-recreate

## Notes

This keeps AIPermission local-only and single-user. Docker access remains scoped to configured connector profiles.