### PR TITLE
Release 0.2.10 Kubernetes connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-06-23
+
+### Added
+
+- Added Kubernetes as a built-in connector that runs bounded `kubectl` templates
+  through an SSH transport profile.
+- Added Kubernetes Console resource tabs for workloads, pods, services,
+  ingress, nodes, and events, with namespace filtering and selected-resource
+  details.
+- Added Kubernetes MCP actions for cluster version, namespaces, workloads, pods,
+  services, ingress, nodes, warning-first events, resource describe, and bounded
+  pod log tails.
+- Added live Kubernetes pod console sessions that reuse the same terminal
+  component as SSH and Docker console while entering one selected pod/container.
+- Added an explicit `rollout_restart` deployment action for operator-approved
+  restarts.
+
+### Fixed
+
+- Fixed manual command history completion for Kubernetes/BusyBox-style path
+  prompts such as `/ #` and `/app $`, so pod-console commands no longer remain
+  stuck as `running`.
+
+### Security
+
+- Kubernetes does not expose raw `kubectl`, manifest apply/edit/delete, pod
+  deletion, scaling, or Secret value browsing.
+- Kubernetes profiles scope access by namespace visibility, and pod logs remain
+  bounded by requested tail limits.
+- `rollout_restart` is the only Kubernetes write action in this release and is
+  still governed by token/action permissions and approval policy.
+
 ## [0.2.9] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ AIPermission is intentionally designed as a local developer gateway.
 
 - The gateway runs on the developer's own machine.
 - Remote systems are connector targets reached from that local gateway.
-- SSH, Postgres, Redis, RabbitMQ, and Docker are built-in connector types, not separate product modes.
+- SSH, Postgres, Redis, RabbitMQ, Docker, and Kubernetes are built-in connector
+  types, not separate product modes.
 - The web UI, REST API, and MCP API are not designed to be shared on a LAN.
 - The project does not support running the gateway as a remote hosted service.
 - The project provides a local browser session after database unlock, not multi-user web auth, team RBAC, or public network hardening.
@@ -143,6 +144,9 @@ Implemented:
 - Docker credential profiles can scope MCP access to all containers, selected
   container names/IDs, or name patterns, so one token can be limited to a
   single container on a shared Docker host.
+- built-in Kubernetes connector over an SSH transport profile, with namespace,
+  workload, pod, service, ingress, node, event, describe, bounded pod-log, live
+  pod-console, and explicit rollout restart actions
 - gateway-generated SSH keys (`ed25519` and `rsa`)
 - explicit existing SSH private key import into the encrypted local vault
 - SSH host import from OpenSSH config files for prefilling connector targets
@@ -208,7 +212,7 @@ To pin a specific release image, set `AIPERMISSION_VERSION` without the leading
 `v`:
 
 ```bash
-AIPERMISSION_VERSION=0.2.9 docker compose -f docker-compose.release.yml up -d
+AIPERMISSION_VERSION=0.2.10 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, clone the repository with Git's default text handling or make sure
@@ -348,8 +352,9 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-The MCP surface is connector-first. SSH, Postgres, Redis, RabbitMQ, Docker, and future integrations use
-the same target/profile/action permission pipeline. `list_connector_targets` is
+The MCP surface is connector-first. SSH, Postgres, Redis, RabbitMQ, Docker,
+Kubernetes, and future integrations use the same target/profile/action permission
+pipeline. `list_connector_targets` is
 permission-scoped, not a live health check. Current reachability is learned when
 the connector action actually runs and returns a dial, timeout, authentication,
 host-key, credential, or service error.
@@ -375,6 +380,13 @@ Docker credential profiles can scope a token to all containers, selected
 container names/IDs, or name patterns. `container_exec` and the live container
 console are scoped to one visible container; arbitrary host-level Docker
 commands, prune, removal, and raw Docker command execution are not exposed.
+
+For Kubernetes, call `get_connector_actions(target_ref)` to discover bounded
+actions such as `cluster_version`, `list_namespaces`, `list_workloads`,
+`list_pods`, `list_services`, `list_ingress`, `list_nodes`, `list_events`,
+`describe_resource`, `get_logs`, and `rollout_restart`. Kubernetes profiles can
+scope access by namespace visibility. Raw `kubectl`, manifest apply/edit/delete,
+pod deletion, scaling, and Secret value browsing are not exposed.
 
 If an action returns `approval_pending` or `running`, the response includes an
 `assistant_hint` telling the AI to poll `get_connector_action_request` until the

--- a/backend/internal/connectors/builtin/registry.go
+++ b/backend/internal/connectors/builtin/registry.go
@@ -6,6 +6,8 @@ import (
 	"github.com/aipermission/aipermission/backend/internal/connectors"
 	dockerconnector "github.com/aipermission/aipermission/backend/internal/connectors/docker"
 	_ "github.com/aipermission/aipermission/backend/internal/connectors/docker/apiadapter"
+	kubernetesconnector "github.com/aipermission/aipermission/backend/internal/connectors/kubernetes"
+	_ "github.com/aipermission/aipermission/backend/internal/connectors/kubernetes/apiadapter"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
 	rabbitmqconnector "github.com/aipermission/aipermission/backend/internal/connectors/rabbitmq"
 	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"
@@ -17,6 +19,7 @@ import (
 func RegisterAll(registry *connectors.Registry) error {
 	for _, connector := range []connectors.Connector{
 		dockerconnector.New(),
+		kubernetesconnector.New(),
 		postgresconnector.New(),
 		rabbitmqconnector.New(),
 		redisconnector.New(),

--- a/backend/internal/connectors/builtin/registry_test.go
+++ b/backend/internal/connectors/builtin/registry_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aipermission/aipermission/backend/internal/connectors"
 	"github.com/aipermission/aipermission/backend/internal/connectors/connectortest"
 	dockerconnector "github.com/aipermission/aipermission/backend/internal/connectors/docker"
+	kubernetesconnector "github.com/aipermission/aipermission/backend/internal/connectors/kubernetes"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
 	rabbitmqconnector "github.com/aipermission/aipermission/backend/internal/connectors/rabbitmq"
 	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"
@@ -25,6 +26,13 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	}
 	if docker.Label() != dockerconnector.Label {
 		t.Fatalf("docker label = %q", docker.Label())
+	}
+	kubernetes, ok := registry.Get(kubernetesconnector.Kind)
+	if !ok {
+		t.Fatal("expected kubernetes connector")
+	}
+	if kubernetes.Label() != kubernetesconnector.Label {
+		t.Fatalf("kubernetes label = %q", kubernetes.Label())
 	}
 
 	postgres, ok := registry.Get(postgresconnector.Kind)
@@ -58,7 +66,7 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	}
 
 	infos := registry.List()
-	if len(infos) != 5 || infos[0].Kind != dockerconnector.Kind || infos[1].Kind != postgresconnector.Kind || infos[2].Kind != rabbitmqconnector.Kind || infos[3].Kind != redisconnector.Kind || infos[4].Kind != sshconnector.Kind {
+	if len(infos) != 6 || infos[0].Kind != dockerconnector.Kind || infos[1].Kind != kubernetesconnector.Kind || infos[2].Kind != postgresconnector.Kind || infos[3].Kind != rabbitmqconnector.Kind || infos[4].Kind != redisconnector.Kind || infos[5].Kind != sshconnector.Kind {
 		t.Fatalf("unexpected connector list: %#v", infos)
 	}
 }
@@ -139,6 +147,33 @@ func builtInDeterminismSamples(t *testing.T, kind string) (connectors.TargetView
 				dockerconnector.ActionStartContainer:   {"container": "api"},
 				dockerconnector.ActionStopContainer:    {"container": "api", "timeout_seconds": 10},
 				dockerconnector.ActionRestartContainer: {"container": "api", "timeout_seconds": 10},
+			}
+	case kubernetesconnector.Kind:
+		return connectors.TargetView{
+				ID:            6,
+				Ref:           "kubernetes:6:60",
+				ConnectorKind: kubernetesconnector.Kind,
+				Name:          "cluster",
+				Config:        map[string]any{"connection_mode": "over_ssh", "transport_target_ref": "ssh:2:20", "kubectl_command": "kubectl"},
+			}, connectors.CredentialProfileView{
+				ID:            60,
+				TargetID:      6,
+				ConnectorKind: kubernetesconnector.Kind,
+				Kind:          "namespace_scope",
+				Label:         "production",
+				Public:        map[string]any{"scope_mode": "selected", "namespaces": "production"},
+			}, map[string]map[string]any{
+				kubernetesconnector.ActionVersion:        {},
+				kubernetesconnector.ActionListNamespaces: {},
+				kubernetesconnector.ActionListWorkloads:  {"namespace": "production"},
+				kubernetesconnector.ActionListPods:       {"namespace": "production"},
+				kubernetesconnector.ActionListServices:   {"namespace": "production"},
+				kubernetesconnector.ActionListIngress:    {"namespace": "production"},
+				kubernetesconnector.ActionListNodes:      {},
+				kubernetesconnector.ActionListEvents:     {"namespace": "production", "limit": 10},
+				kubernetesconnector.ActionDescribe:       {"resource_type": "deployment", "namespace": "production", "name": "api"},
+				kubernetesconnector.ActionLogs:           {"namespace": "production", "pod": "api-123", "container": "api", "tail": 100},
+				kubernetesconnector.ActionRolloutRestart: {"namespace": "production", "deployment": "api"},
 			}
 	case postgresconnector.Kind:
 		return connectors.TargetView{

--- a/backend/internal/connectors/docker/apiadapter/adapter.go
+++ b/backend/internal/connectors/docker/apiadapter/adapter.go
@@ -119,7 +119,11 @@ func stringParam(params map[string]any, key string) string {
 	if params == nil {
 		return ""
 	}
-	return strings.TrimSpace(fmt.Sprint(params[key]))
+	value, ok := params[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
 }
 
 func stringConfigValue(values map[string]any, key string) string {

--- a/backend/internal/connectors/kubernetes/apiadapter/adapter.go
+++ b/backend/internal/connectors/kubernetes/apiadapter/adapter.go
@@ -1,0 +1,166 @@
+// Package apiadapter registers Kubernetes connector runtime adapters.
+package apiadapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/aipermission/aipermission/backend/internal/connectorapi"
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	kubernetesconnector "github.com/aipermission/aipermission/backend/internal/connectors/kubernetes"
+	sshapiadapter "github.com/aipermission/aipermission/backend/internal/connectors/ssh/apiadapter"
+	"github.com/aipermission/aipermission/backend/internal/connectortargets"
+	"github.com/aipermission/aipermission/backend/internal/console"
+)
+
+var kubeConsoleNamePattern = regexp.MustCompile(`^[A-Za-z0-9._:-]+$`)
+
+type adapter struct{}
+
+func init() {
+	connectorapi.Register(kubernetesconnector.Kind, adapter{})
+}
+
+func (adapter) LiveConsoleCapabilityKind() string {
+	return connectortargets.RuntimeCapabilityLiveConsole
+}
+
+func (adapter) LiveConsoleTargetRef(ctx context.Context, runtime connectorapi.GatewayRuntime, runtimeID int64) (string, error) {
+	target, profile, surface, err := kubernetesTargetProfileByRuntimeID(ctx, runtime, runtimeID)
+	if err != nil {
+		return "", err
+	}
+	if surface.ConnectorKind != kubernetesconnector.Kind || surface.CapabilityKind != connectortargets.RuntimeCapabilityLiveConsole {
+		return "", connectortargets.ErrRuntimeSurfaceNotFound
+	}
+	return connectortargets.ConnectorTargetRef(target.ConnectorKind, target.ID, profile.ID), nil
+}
+
+func (adapter) ResolveLiveConsoleMaterial(ctx context.Context, runtime connectorapi.GatewayRuntime, runtimeID int64) (any, any, error) {
+	target, profile, _, err := kubernetesTargetProfileByRuntimeID(ctx, runtime, runtimeID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return target, profile, nil
+}
+
+func (adapter) LiveConsoleTargetMetadata(target connectors.TargetView, profile connectors.CredentialProfileView) map[string]any {
+	return map[string]any{
+		"label":           target.Name,
+		"connector":       kubernetesconnector.Kind,
+		"profile":         profile.Label,
+		"transport":       strings.TrimSpace(stringConfigValue(target.Config, "transport_target_ref")),
+		"kubectl":         kubectlCommand(target),
+		"context":         strings.TrimSpace(stringConfigValue(target.Config, "context")),
+		"default_ns":      strings.TrimSpace(stringConfigValue(target.Config, "default_namespace")),
+		"namespace_scope": strings.TrimSpace(stringConfigValue(profile.Public, "scope_mode")),
+		"namespaces":      strings.TrimSpace(stringConfigValue(profile.Public, "namespaces")),
+	}
+}
+
+func (adapter) OpenLiveConsole(ctx context.Context, server connectorapi.GatewayServer, runtime connectorapi.GatewayRuntime, runtimeID int64, rows int, cols int, params map[string]any) (*console.RuntimeSession, error) {
+	target, profile, surface, err := kubernetesTargetProfileByRuntimeID(ctx, runtime, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	if surface.ConnectorKind != kubernetesconnector.Kind || surface.CapabilityKind != connectortargets.RuntimeCapabilityLiveConsole {
+		return nil, connectortargets.ErrRuntimeSurfaceNotFound
+	}
+	namespace := strings.TrimSpace(stringParam(params, "namespace"))
+	pod := strings.TrimSpace(stringParam(params, "pod"))
+	container := strings.TrimSpace(stringParam(params, "container"))
+	if namespace == "" || pod == "" {
+		return nil, errors.New("kubernetes namespace and pod are required")
+	}
+	for _, value := range []string{namespace, pod, container} {
+		if value != "" && !kubeConsoleNamePattern.MatchString(value) {
+			return nil, fmt.Errorf("invalid kubernetes object name: %s", value)
+		}
+	}
+	if !kubernetesconnector.ProfileAllowsNamespace(profile, namespace) {
+		return nil, fmt.Errorf("%w: %s", kubernetesconnector.ErrScopeDenied, namespace)
+	}
+	transportRef := strings.TrimSpace(stringConfigValue(target.Config, "transport_target_ref"))
+	if transportRef == "" {
+		return nil, fmt.Errorf("%w: transport_target_ref is required", kubernetesconnector.ErrInvalidConfig)
+	}
+	command := kubectlExecShellCommand(target, namespace, pod, container)
+	return sshapiadapter.OpenLiveConsoleForTargetRef(ctx, server, runtime, transportRef, rows, cols, sshapiadapter.LiveConsoleOptions{
+		ForceShellCommand: command,
+	})
+}
+
+func kubernetesTargetProfileByRuntimeID(ctx context.Context, runtime connectorapi.GatewayRuntime, runtimeID int64) (connectors.TargetView, connectors.CredentialProfileView, connectortargets.RuntimeSurface, error) {
+	database, err := databaseFrom(runtime)
+	if err != nil {
+		return connectors.TargetView{}, connectors.CredentialProfileView{}, connectortargets.RuntimeSurface{}, err
+	}
+	return connectortargets.NewStore(database).TargetProfileByRuntimeID(ctx, runtimeID)
+}
+
+func databaseFrom(runtime connectorapi.GatewayRuntime) (*sql.DB, error) {
+	if runtime == nil || runtime.ConnectorDatabase() == nil {
+		return nil, fmt.Errorf("database runtime is not available")
+	}
+	return runtime.ConnectorDatabase(), nil
+}
+
+func kubectlExecShellCommand(target connectors.TargetView, namespace string, pod string, container string) string {
+	command := kubectlCommand(target)
+	contextName := strings.TrimSpace(stringConfigValue(target.Config, "context"))
+	if contextName != "" {
+		command += " --context " + shellQuote(contextName)
+	}
+	command += " exec -it -n " + shellQuote(namespace) + " " + shellQuote(pod)
+	if container != "" {
+		command += " -c " + shellQuote(container)
+	}
+	shellProbe := "if command -v bash >/dev/null 2>&1; then exec bash -l; fi; exec sh"
+	return command + " -- sh -lc " + shellQuote(shellProbe)
+}
+
+func kubectlCommand(target connectors.TargetView) string {
+	command := strings.TrimSpace(stringConfigValue(target.Config, "kubectl_command"))
+	if command == "" {
+		return "kubectl"
+	}
+	return command
+}
+
+func stringParam(params map[string]any, key string) string {
+	if params == nil {
+		return ""
+	}
+	value, ok := params[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func stringConfigValue(values map[string]any, key string) string {
+	if values == nil {
+		return ""
+	}
+	value, ok := values[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/backend/internal/connectors/kubernetes/apiadapter/adapter_test.go
+++ b/backend/internal/connectors/kubernetes/apiadapter/adapter_test.go
@@ -1,0 +1,32 @@
+package apiadapter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+func TestStringParamMissingValueReturnsEmpty(t *testing.T) {
+	if got := stringParam(map[string]any{"namespace": "default"}, "container"); got != "" {
+		t.Fatalf("expected missing optional param to be empty, got %q", got)
+	}
+	if got := stringParam(map[string]any{"container": nil}, "container"); got != "" {
+		t.Fatalf("expected nil optional param to be empty, got %q", got)
+	}
+}
+
+func TestKubectlExecShellCommandOmitsEmptyContainer(t *testing.T) {
+	command := kubectlExecShellCommand(connectors.TargetView{
+		Config: map[string]any{"kubectl_command": "kubectl"},
+	}, "default", "api-123", "")
+	if strings.Contains(command, " -c ") {
+		t.Fatalf("empty container should not add -c: %s", command)
+	}
+	if strings.Contains(command, "<nil>") {
+		t.Fatalf("command should not include nil marker: %s", command)
+	}
+	if !strings.Contains(command, "exec -it -n 'default' 'api-123' -- sh -lc") {
+		t.Fatalf("unexpected kubectl exec command: %s", command)
+	}
+}

--- a/backend/internal/connectors/kubernetes/kubernetes.go
+++ b/backend/internal/connectors/kubernetes/kubernetes.go
@@ -1,0 +1,1128 @@
+// Package kubernetesconnector defines the Kubernetes connector contract.
+package kubernetesconnector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+const (
+	Kind    = "kubernetes"
+	Label   = "Kubernetes"
+	Version = "0.2"
+
+	ActionVersion        = "cluster_version"
+	ActionListNamespaces = "list_namespaces"
+	ActionListWorkloads  = "list_workloads"
+	ActionListPods       = "list_pods"
+	ActionListServices   = "list_services"
+	ActionListIngress    = "list_ingress"
+	ActionListNodes      = "list_nodes"
+	ActionListEvents     = "list_events"
+	ActionDescribe       = "describe_resource"
+	ActionLogs           = "get_logs"
+	ActionRolloutRestart = "rollout_restart"
+
+	defaultKubectlCommand = "kubectl"
+	defaultLogTail        = 200
+	maxLogTail            = 2000
+	maxKubectlBytes       = 1024 << 10
+	maxLogBytes           = 512 << 10
+	maxReasonBytes        = 2000
+)
+
+var (
+	ErrUnsupportedAction = errors.New("unsupported kubernetes connector action")
+	ErrMissingTransport  = errors.New("kubernetes connector command transport is unavailable")
+	ErrInvalidConfig     = errors.New("kubernetes connector target config is invalid")
+	ErrScopeDenied       = errors.New("kubernetes namespace is outside this credential profile scope")
+
+	kubeNamePattern = regexp.MustCompile(`^[A-Za-z0-9._:-]+$`)
+)
+
+// Connector describes Kubernetes as a read-heavy connector over bounded kubectl
+// templates. The MVP intentionally uses an SSH command transport and does not
+// import kubeconfig/token material into AIPermission.
+type Connector struct{}
+
+func New() Connector {
+	return Connector{}
+}
+
+func (Connector) Kind() string {
+	return Kind
+}
+
+func (Connector) Label() string {
+	return Label
+}
+
+func (Connector) Version() string {
+	return Version
+}
+
+func (Connector) TargetSchema() connectors.Schema {
+	return connectors.Schema{Fields: []connectors.Field{
+		{
+			Name:        "connection_mode",
+			Label:       "Connection mode",
+			Type:        connectors.FieldSelect,
+			Required:    true,
+			Default:     "over_ssh",
+			Description: "Run bounded kubectl templates through an SSH connector profile.",
+			Options: []connectors.FieldOption{
+				{Value: "over_ssh", Label: "Over SSH"},
+			},
+		},
+		{
+			Name:        "transport_target_ref",
+			Label:       "SSH transport profile",
+			Type:        connectors.FieldString,
+			Required:    true,
+			Description: "SSH connector target/profile ref used to run kubectl.",
+		},
+		{
+			Name:        "kubectl_command",
+			Label:       "kubectl command",
+			Type:        connectors.FieldString,
+			Default:     defaultKubectlCommand,
+			Description: "kubectl command on the remote host. Keep this as kubectl unless the host uses a wrapper path.",
+		},
+		{
+			Name:        "context",
+			Label:       "Context",
+			Type:        connectors.FieldString,
+			Description: "Optional kubectl context name.",
+		},
+		{
+			Name:        "default_namespace",
+			Label:       "Default namespace",
+			Type:        connectors.FieldString,
+			Description: "Optional default namespace for actions that need one.",
+		},
+	}}
+}
+
+func (Connector) CredentialSchemas() []connectors.CredentialSchema {
+	return []connectors.CredentialSchema{
+		{
+			Kind:        "namespace_scope",
+			Label:       "Namespace scope",
+			Description: "Restrict this profile to all namespaces or to selected namespaces.",
+			Schema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "scope_mode",
+					Label:       "Scope",
+					Type:        connectors.FieldSelect,
+					Required:    true,
+					Default:     "all",
+					Description: "Use selected when this token should only see and operate on specific namespaces.",
+					Options: []connectors.FieldOption{
+						{Value: "all", Label: "All namespaces"},
+						{Value: "selected", Label: "Selected namespaces"},
+					},
+				},
+				{
+					Name:        "namespaces",
+					Label:       "Namespaces",
+					Type:        connectors.FieldMultiline,
+					Description: "One namespace per line. Required when scope is selected.",
+				},
+			}},
+		},
+	}
+}
+
+func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (connectors.ConnectorHelp, error) {
+	title := "Kubernetes target"
+	if strings.TrimSpace(target.Name) != "" {
+		title = "Kubernetes target: " + target.Name
+	}
+	return connectors.ConnectorHelp{
+		Title:       title,
+		Summary:     "Inspect Kubernetes namespaces, workloads, pods, services, events, nodes, and bounded logs through kubectl templates and AIPermission approval rules.",
+		Connector:   Label,
+		ConnectorID: Kind,
+		Usage: []string{
+			"Use list_namespaces first when the namespace is unknown.",
+			"Use list_workloads and list_pods to identify unhealthy deployments or pods.",
+			"Use list_events to find scheduling, image pull, probe, and crash loop clues.",
+			"Use get_logs with a bounded tail value for recent pod logs.",
+			"Use rollout_restart only when the operator intends a deployment restart.",
+		},
+		Warnings: []string{
+			"Kubernetes actions run through a selected SSH transport profile. The connector does not expose raw kubectl, apply, delete, pod exec, or Secret value browsing.",
+			"Logs and resource JSON may contain sensitive application data. Redaction is best-effort; avoid requesting sensitive logs unless approved.",
+			"Credential profile namespace scope can restrict AI access to a selected set of namespaces.",
+		},
+	}, nil
+}
+
+func (Connector) GetActionList(context.Context, connectors.TargetView, connectors.CredentialProfileView) ([]connectors.ActionDefinition, error) {
+	return []connectors.ActionDefinition{
+		{Name: ActionVersion, Label: "Cluster version", Description: "Read Kubernetes client/server version metadata.", Category: "metadata", Risk: connectors.RiskRead, InputSchema: connectors.Schema{}, OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 64 << 10}},
+		{Name: ActionListNamespaces, Label: "List namespaces", Description: "List Kubernetes namespaces visible to this profile.", Category: "browser", Risk: connectors.RiskRead, InputSchema: connectors.Schema{}, OutputHint: connectors.OutputHint{Format: "json", MaxRows: 500}},
+		{Name: ActionListWorkloads, Label: "List workloads", Description: "List deployments, statefulsets, and daemonsets.", Category: "browser", Risk: connectors.RiskRead, InputSchema: namespaceInputSchema(), OutputHint: connectors.OutputHint{Format: "json", MaxRows: 1000}},
+		{Name: ActionListPods, Label: "List pods", Description: "List pods with status, readiness, restarts, node, and age metadata.", Category: "browser", Risk: connectors.RiskRead, InputSchema: namespaceInputSchema(), OutputHint: connectors.OutputHint{Format: "json", MaxRows: 2000}},
+		{Name: ActionListServices, Label: "List services", Description: "List services and exposed ports.", Category: "browser", Risk: connectors.RiskRead, InputSchema: namespaceInputSchema(), OutputHint: connectors.OutputHint{Format: "json", MaxRows: 1000}},
+		{Name: ActionListIngress, Label: "List ingress", Description: "List ingress hosts and paths where available.", Category: "browser", Risk: connectors.RiskRead, InputSchema: namespaceInputSchema(), OutputHint: connectors.OutputHint{Format: "json", MaxRows: 1000}},
+		{Name: ActionListNodes, Label: "List nodes", Description: "List cluster nodes, versions, roles, and readiness.", Category: "browser", Risk: connectors.RiskRead, InputSchema: connectors.Schema{}, OutputHint: connectors.OutputHint{Format: "json", MaxRows: 500}},
+		{Name: ActionListEvents, Label: "List events", Description: "List warning-first Kubernetes events.", Category: "browser", Risk: connectors.RiskRead, InputSchema: connectors.Schema{Fields: []connectors.Field{{Name: "namespace", Label: "Namespace", Type: connectors.FieldString, Description: "Optional namespace. Empty lists across allowed namespaces."}, {Name: "limit", Label: "Limit", Type: connectors.FieldNumber, Default: 200}}}, OutputHint: connectors.OutputHint{Format: "json", MaxRows: 1000}},
+		{Name: ActionDescribe, Label: "Describe resource", Description: "Read JSON metadata for one Kubernetes resource.", Category: "browser", Risk: connectors.RiskRead, InputSchema: connectors.Schema{Fields: []connectors.Field{{Name: "resource_type", Label: "Resource type", Type: connectors.FieldSelect, Required: true, Options: []connectors.FieldOption{{Value: "pod", Label: "Pod"}, {Value: "deployment", Label: "Deployment"}, {Value: "statefulset", Label: "StatefulSet"}, {Value: "daemonset", Label: "DaemonSet"}, {Value: "service", Label: "Service"}, {Value: "ingress", Label: "Ingress"}, {Value: "node", Label: "Node"}}}, {Name: "name", Label: "Name", Type: connectors.FieldString, Required: true}, {Name: "namespace", Label: "Namespace", Type: connectors.FieldString, Description: "Required for namespaced resources unless target default namespace is set."}}}, OutputHint: connectors.OutputHint{Format: "json", MaxBytes: maxKubectlBytes}},
+		{Name: ActionLogs, Label: "Pod logs", Description: "Read a bounded tail of pod logs.", Category: "browser", Risk: connectors.RiskRead, InputSchema: connectors.Schema{Fields: []connectors.Field{{Name: "namespace", Label: "Namespace", Type: connectors.FieldString, Required: true}, {Name: "pod", Label: "Pod", Type: connectors.FieldString, Required: true}, {Name: "container", Label: "Container", Type: connectors.FieldString, Description: "Optional container name."}, {Name: "tail", Label: "Tail lines", Type: connectors.FieldNumber, Default: defaultLogTail}}}, OutputHint: connectors.OutputHint{Format: "text", MaxBytes: maxLogBytes}},
+		{Name: ActionRolloutRestart, Label: "Rollout restart", Description: "Restart one Kubernetes deployment.", Category: "lifecycle", Risk: connectors.RiskWrite, InputSchema: connectors.Schema{Fields: []connectors.Field{{Name: "namespace", Label: "Namespace", Type: connectors.FieldString, Required: true}, {Name: "deployment", Label: "Deployment", Type: connectors.FieldString, Required: true}}}, OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000}},
+	}, nil
+}
+
+func namespaceInputSchema() connectors.Schema {
+	return connectors.Schema{Fields: []connectors.Field{{Name: "namespace", Label: "Namespace", Type: connectors.FieldString, Description: "Optional namespace. Empty lists across allowed namespaces."}}}
+}
+
+func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) (connectors.PreparedAction, error) {
+	if len(req.Reason) > maxReasonBytes {
+		return connectors.PreparedAction{}, fmt.Errorf("reason is too large")
+	}
+	input := copyMap(req.Input)
+	risk := connectors.RiskRead
+	title := ""
+	summary := ""
+	switch req.ActionName {
+	case ActionVersion:
+		title = "Read Kubernetes version"
+		summary = "Read client/server version metadata."
+	case ActionListNamespaces:
+		title = "List Kubernetes namespaces"
+		summary = "List namespaces visible to this profile."
+	case ActionListWorkloads:
+		input["namespace"] = normalizeOptionalName(input, "namespace")
+		title = "List Kubernetes workloads"
+		summary = namespaceSummary(input)
+	case ActionListPods:
+		input["namespace"] = normalizeOptionalName(input, "namespace")
+		title = "List Kubernetes pods"
+		summary = namespaceSummary(input)
+	case ActionListServices:
+		input["namespace"] = normalizeOptionalName(input, "namespace")
+		title = "List Kubernetes services"
+		summary = namespaceSummary(input)
+	case ActionListIngress:
+		input["namespace"] = normalizeOptionalName(input, "namespace")
+		title = "List Kubernetes ingress"
+		summary = namespaceSummary(input)
+	case ActionListNodes:
+		title = "List Kubernetes nodes"
+		summary = "List cluster nodes."
+	case ActionListEvents:
+		input["namespace"] = normalizeOptionalName(input, "namespace")
+		input["limit"] = normalizeInt(input, "limit", 200, 1, 1000)
+		title = "List Kubernetes events"
+		summary = namespaceSummary(input)
+	case ActionDescribe:
+		resourceType := normalizeResourceType(input)
+		if resourceType == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("resource_type is required")
+		}
+		name := normalizeRequiredName(input, "name")
+		if name == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("name is required")
+		}
+		input["resource_type"] = resourceType
+		input["name"] = name
+		input["namespace"] = normalizeOptionalName(input, "namespace")
+		title = "Describe Kubernetes resource"
+		summary = resourceSummary(resourceType, stringValue(input, "namespace"), name)
+	case ActionLogs:
+		namespace := normalizeRequiredName(input, "namespace")
+		pod := normalizeRequiredName(input, "pod")
+		if namespace == "" || pod == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("namespace and pod are required")
+		}
+		input["namespace"] = namespace
+		input["pod"] = pod
+		input["container"] = normalizeOptionalName(input, "container")
+		input["tail"] = normalizeInt(input, "tail", defaultLogTail, 1, maxLogTail)
+		title = "Read Kubernetes pod logs"
+		summary = fmt.Sprintf("%s/%s tail=%d", namespace, pod, input["tail"])
+	case ActionRolloutRestart:
+		risk = connectors.RiskWrite
+		namespace := normalizeRequiredName(input, "namespace")
+		deployment := normalizeRequiredName(input, "deployment")
+		if namespace == "" || deployment == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("namespace and deployment are required")
+		}
+		input["namespace"] = namespace
+		input["deployment"] = deployment
+		title = "Rollout restart Kubernetes deployment"
+		summary = fmt.Sprintf("%s/%s", namespace, deployment)
+	default:
+		return connectors.PreparedAction{}, ErrUnsupportedAction
+	}
+	return connectors.PreparedAction{
+		ConnectorKind: Kind,
+		TargetRef:     req.Target.Ref,
+		ProfileID:     req.Profile.ID,
+		ActionName:    req.ActionName,
+		Risk:          risk,
+		Title:         title,
+		Summary:       summary,
+		Preview:       input,
+		Payload:       input,
+		ContextMaterial: map[string]any{
+			"target":          req.Target.Name,
+			"profile":         req.Profile.Label,
+			"connection_mode": connectionMode(req.Target),
+			"scope_mode":      scopeMode(req.Profile),
+		},
+	}, nil
+}
+
+func (Connector) ExecuteAction(ctx context.Context, runtime connectors.RuntimeContext, action connectors.PreparedAction) (connectors.ActionResult, error) {
+	client, err := newKubeClient(runtime)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	switch action.ActionName {
+	case ActionVersion:
+		return executeVersion(ctx, client)
+	case ActionListNamespaces:
+		return executeListNamespaces(ctx, client)
+	case ActionListWorkloads:
+		return executeListWorkloads(ctx, client, action.Payload)
+	case ActionListPods:
+		return executeListPods(ctx, client, action.Payload)
+	case ActionListServices:
+		return executeListServices(ctx, client, action.Payload)
+	case ActionListIngress:
+		return executeListIngress(ctx, client, action.Payload)
+	case ActionListNodes:
+		return executeListNodes(ctx, client)
+	case ActionListEvents:
+		return executeListEvents(ctx, client, action.Payload)
+	case ActionDescribe:
+		return executeDescribe(ctx, client, action.Payload)
+	case ActionLogs:
+		return executeLogs(ctx, client, action.Payload)
+	case ActionRolloutRestart:
+		return executeRolloutRestart(ctx, client, action.Payload)
+	default:
+		return connectors.ActionResult{}, ErrUnsupportedAction
+	}
+}
+
+func (Connector) TestConnection(ctx context.Context, runtime connectors.RuntimeContext) (connectors.TestResult, error) {
+	client, err := newKubeClient(runtime)
+	if err != nil {
+		return connectors.TestResult{Status: connectors.TestUnknownError, Message: err.Error()}, nil
+	}
+	result, err := client.run(ctx, client.baseCommand()+" get namespaces -o json", 20)
+	if err != nil {
+		return connectors.TestResult{Status: connectors.TestFailedNetwork, Message: err.Error()}, nil
+	}
+	if result.ExitCode != 0 {
+		return connectors.TestResult{Status: connectors.TestFailedPermission, Message: kubeCommandError("kubectl get namespaces", result).Error()}, nil
+	}
+	return connectors.TestResult{
+		Status:  connectors.TestOK,
+		Message: "Kubernetes connection ok.",
+		Details: map[string]any{
+			"duration_ms": result.DurationMS,
+			"mode":        connectionMode(runtime.Target),
+		},
+	}, nil
+}
+
+type kubeClient struct {
+	runtime   connectors.RuntimeContext
+	transport connectors.CommandTransport
+	command   string
+	context   string
+	scope     kubeScope
+}
+
+func newKubeClient(runtime connectors.RuntimeContext) (*kubeClient, error) {
+	transport, _ := runtime.Capability(connectors.CommandTransportCapabilityName).(connectors.CommandTransport)
+	if transport == nil {
+		return nil, ErrMissingTransport
+	}
+	command := strings.TrimSpace(stringValue(runtime.Target.Config, "kubectl_command"))
+	if command == "" {
+		command = defaultKubectlCommand
+	}
+	return &kubeClient{
+		runtime:   runtime,
+		transport: transport,
+		command:   command,
+		context:   strings.TrimSpace(stringValue(runtime.Target.Config, "context")),
+		scope:     kubeScopeFromProfile(runtime.Profile),
+	}, nil
+}
+
+func (client *kubeClient) baseCommand() string {
+	base := client.command
+	if client.context != "" {
+		base += " --context " + shellQuote(client.context)
+	}
+	return base
+}
+
+func (client *kubeClient) run(ctx context.Context, command string, timeoutSeconds int) (connectors.CommandRunResult, error) {
+	return client.transport.RunConnectorCommand(ctx, connectors.CommandRunRequest{
+		Mode:               connectionMode(client.runtime.Target),
+		TransportTargetRef: strings.TrimSpace(stringValue(client.runtime.Target.Config, "transport_target_ref")),
+		Command:            command,
+		TimeoutSeconds:     timeoutSeconds,
+	})
+}
+
+func executeVersion(ctx context.Context, client *kubeClient) (connectors.ActionResult, error) {
+	result, err := client.run(ctx, client.baseCommand()+" version -o json", 20)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	if result.ExitCode != 0 {
+		return connectors.ActionResult{}, kubeCommandError("kubectl version", result)
+	}
+	var output any
+	if err := json.Unmarshal([]byte(result.Stdout), &output); err != nil {
+		output = map[string]any{"raw": truncateString(result.Stdout, maxKubectlBytes)}
+	}
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"version": output, "duration_ms": result.DurationMS}, DisplayText: truncateString(result.Stdout, 4000)}, nil
+}
+
+func executeListNamespaces(ctx context.Context, client *kubeClient) (connectors.ActionResult, error) {
+	items, err := client.runKubeList(ctx, client.baseCommand()+" get namespaces -o json", 20)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	namespaces := make([]NamespaceSummary, 0, len(items))
+	for _, item := range items {
+		summary := namespaceSummaryFromItem(item)
+		if client.scope.namespaceAllowed(summary.Name) {
+			namespaces = append(namespaces, summary)
+		}
+	}
+	sort.SliceStable(namespaces, func(i, j int) bool { return namespaces[i].Name < namespaces[j].Name })
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"namespaces": namespaces, "count": len(namespaces), "scope_mode": client.scope.mode}, DisplayText: fmt.Sprintf("Listed %d Kubernetes namespace(s).", len(namespaces))}, nil
+}
+
+func executeListWorkloads(ctx context.Context, client *kubeClient, input map[string]any) (connectors.ActionResult, error) {
+	items, err := client.runNamespacedKubeList(ctx, "deployments,statefulsets,daemonsets", stringValue(input, "namespace"), 25)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	workloads := make([]WorkloadSummary, 0, len(items))
+	for _, item := range items {
+		workloads = append(workloads, workloadSummaryFromItem(item))
+	}
+	sort.SliceStable(workloads, func(i, j int) bool {
+		if workloads[i].Namespace == workloads[j].Namespace {
+			return workloads[i].Name < workloads[j].Name
+		}
+		return workloads[i].Namespace < workloads[j].Namespace
+	})
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"workloads": workloads, "count": len(workloads)}, DisplayText: workloadsDisplay(workloads)}, nil
+}
+
+func executeListPods(ctx context.Context, client *kubeClient, input map[string]any) (connectors.ActionResult, error) {
+	items, err := client.runNamespacedKubeList(ctx, "pods", stringValue(input, "namespace"), 25)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	pods := make([]PodSummary, 0, len(items))
+	for _, item := range items {
+		pods = append(pods, podSummaryFromItem(item))
+	}
+	sort.SliceStable(pods, func(i, j int) bool {
+		if pods[i].Namespace == pods[j].Namespace {
+			return pods[i].Name < pods[j].Name
+		}
+		return pods[i].Namespace < pods[j].Namespace
+	})
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"pods": pods, "count": len(pods)}, DisplayText: podsDisplay(pods)}, nil
+}
+
+func executeListServices(ctx context.Context, client *kubeClient, input map[string]any) (connectors.ActionResult, error) {
+	items, err := client.runNamespacedKubeList(ctx, "services", stringValue(input, "namespace"), 25)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	services := make([]ServiceSummary, 0, len(items))
+	for _, item := range items {
+		services = append(services, serviceSummaryFromItem(item))
+	}
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"services": services, "count": len(services)}, DisplayText: fmt.Sprintf("Listed %d Kubernetes service(s).", len(services))}, nil
+}
+
+func executeListIngress(ctx context.Context, client *kubeClient, input map[string]any) (connectors.ActionResult, error) {
+	items, err := client.runNamespacedKubeList(ctx, "ingress", stringValue(input, "namespace"), 25)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	ingresses := make([]IngressSummary, 0, len(items))
+	for _, item := range items {
+		ingresses = append(ingresses, ingressSummaryFromItem(item))
+	}
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"ingress": ingresses, "count": len(ingresses)}, DisplayText: fmt.Sprintf("Listed %d Kubernetes ingress resource(s).", len(ingresses))}, nil
+}
+
+func executeListNodes(ctx context.Context, client *kubeClient) (connectors.ActionResult, error) {
+	items, err := client.runKubeList(ctx, client.baseCommand()+" get nodes -o json", 25)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	nodes := make([]NodeSummary, 0, len(items))
+	for _, item := range items {
+		nodes = append(nodes, nodeSummaryFromItem(item))
+	}
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"nodes": nodes, "count": len(nodes)}, DisplayText: fmt.Sprintf("Listed %d Kubernetes node(s).", len(nodes))}, nil
+}
+
+func executeListEvents(ctx context.Context, client *kubeClient, input map[string]any) (connectors.ActionResult, error) {
+	limit := normalizeInt(input, "limit", 200, 1, 1000)
+	items, err := client.runNamespacedKubeList(ctx, "events", stringValue(input, "namespace"), 25)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	events := make([]EventSummary, 0, len(items))
+	for _, item := range items {
+		events = append(events, eventSummaryFromItem(item))
+	}
+	sort.SliceStable(events, func(i, j int) bool {
+		if events[i].Type == "Warning" && events[j].Type != "Warning" {
+			return true
+		}
+		if events[j].Type == "Warning" && events[i].Type != "Warning" {
+			return false
+		}
+		return events[i].LastTimestamp > events[j].LastTimestamp
+	})
+	if len(events) > limit {
+		events = events[:limit]
+	}
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"events": events, "count": len(events)}, DisplayText: fmt.Sprintf("Listed %d Kubernetes event(s).", len(events))}, nil
+}
+
+func executeDescribe(ctx context.Context, client *kubeClient, input map[string]any) (connectors.ActionResult, error) {
+	resourceType := normalizeResourceType(input)
+	name := normalizeRequiredName(input, "name")
+	namespace := namespaceOrDefault(client.runtime.Target, stringValue(input, "namespace"))
+	if resourceType != "node" {
+		if namespace == "" {
+			return connectors.ActionResult{}, fmt.Errorf("namespace is required for %s", resourceType)
+		}
+		if err := client.scope.ensureNamespace(namespace); err != nil {
+			return connectors.ActionResult{}, err
+		}
+	}
+	command := fmt.Sprintf("%s get %s %s -o json", client.baseCommand(), resourceType, shellQuote(name))
+	if resourceType != "node" {
+		command = fmt.Sprintf("%s get %s %s -n %s -o json", client.baseCommand(), resourceType, shellQuote(name), shellQuote(namespace))
+	}
+	result, err := client.run(ctx, command, 25)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	if result.ExitCode != 0 {
+		return connectors.ActionResult{}, kubeCommandError("kubectl get "+resourceType, result)
+	}
+	var resource map[string]any
+	if err := json.Unmarshal([]byte(result.Stdout), &resource); err != nil {
+		return connectors.ActionResult{}, fmt.Errorf("parse kubectl resource JSON: %w", err)
+	}
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"resource": resource, "summary": genericResourceSummary(resource)}, DisplayText: fmt.Sprintf("Read Kubernetes %s %s.", resourceType, resourceSummary(resourceType, namespace, name))}, nil
+}
+
+func executeLogs(ctx context.Context, client *kubeClient, input map[string]any) (connectors.ActionResult, error) {
+	namespace := normalizeRequiredName(input, "namespace")
+	pod := normalizeRequiredName(input, "pod")
+	container := normalizeOptionalName(input, "container")
+	if namespace == "" || pod == "" {
+		return connectors.ActionResult{}, fmt.Errorf("namespace and pod are required")
+	}
+	if err := client.scope.ensureNamespace(namespace); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	tail := normalizeInt(input, "tail", defaultLogTail, 1, maxLogTail)
+	command := fmt.Sprintf("%s logs -n %s %s --tail %d --timestamps=true", client.baseCommand(), shellQuote(namespace), shellQuote(pod), tail)
+	if container != "" {
+		command += " -c " + shellQuote(container)
+	}
+	command += " 2>&1"
+	result, err := client.run(ctx, command, 35)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	if result.ExitCode != 0 {
+		return connectors.ActionResult{}, kubeCommandError("kubectl logs", result)
+	}
+	logs := truncateString(result.Stdout, maxLogBytes)
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"namespace": namespace, "pod": pod, "container": container, "tail": tail, "logs": logs, "duration_ms": result.DurationMS}, DisplayText: logs}, nil
+}
+
+func executeRolloutRestart(ctx context.Context, client *kubeClient, input map[string]any) (connectors.ActionResult, error) {
+	namespace := normalizeRequiredName(input, "namespace")
+	deployment := normalizeRequiredName(input, "deployment")
+	if namespace == "" || deployment == "" {
+		return connectors.ActionResult{}, fmt.Errorf("namespace and deployment are required")
+	}
+	if err := client.scope.ensureNamespace(namespace); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	command := fmt.Sprintf("%s rollout restart deployment/%s -n %s 2>&1", client.baseCommand(), shellQuote(deployment), shellQuote(namespace))
+	result, err := client.run(ctx, command, 30)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	if result.ExitCode != 0 {
+		return connectors.ActionResult{}, kubeCommandError("kubectl rollout restart", result)
+	}
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: map[string]any{"namespace": namespace, "deployment": deployment, "response": strings.TrimSpace(result.Stdout), "duration_ms": result.DurationMS}, DisplayText: strings.TrimSpace(result.Stdout)}, nil
+}
+
+func (client *kubeClient) runKubeList(ctx context.Context, command string, timeoutSeconds int) ([]map[string]any, error) {
+	result, err := client.run(ctx, command, timeoutSeconds)
+	if err != nil {
+		return nil, err
+	}
+	if result.ExitCode != 0 {
+		return nil, kubeCommandError("kubectl get", result)
+	}
+	if len(result.Stdout) > maxKubectlBytes {
+		return nil, fmt.Errorf("kubectl output is larger than %d bytes", maxKubectlBytes)
+	}
+	var list struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &list); err != nil {
+		return nil, fmt.Errorf("parse kubectl JSON list: %w", err)
+	}
+	return list.Items, nil
+}
+
+func (client *kubeClient) runNamespacedKubeList(ctx context.Context, resource string, namespace string, timeoutSeconds int) ([]map[string]any, error) {
+	namespaces, clusterWide, err := client.namespacesForQuery(namespace)
+	if err != nil {
+		return nil, err
+	}
+	if clusterWide {
+		return client.runKubeList(ctx, fmt.Sprintf("%s get %s -A -o json", client.baseCommand(), resource), timeoutSeconds)
+	}
+	var all []map[string]any
+	for _, ns := range namespaces {
+		items, err := client.runKubeList(ctx, fmt.Sprintf("%s get %s -n %s -o json", client.baseCommand(), resource, shellQuote(ns)), timeoutSeconds)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, items...)
+	}
+	return all, nil
+}
+
+// ProfileAllowsNamespace reports whether a public credential profile can access
+// one namespace. Runtime adapters use this for connector-owned live-console
+// surfaces such as a pod shell.
+func ProfileAllowsNamespace(profile connectors.CredentialProfileView, namespace string) bool {
+	return kubeScopeFromProfile(profile).namespaceAllowed(strings.TrimSpace(namespace))
+}
+
+func (client *kubeClient) namespacesForQuery(namespace string) ([]string, bool, error) {
+	namespace = namespaceOrDefault(client.runtime.Target, namespace)
+	if namespace != "" {
+		if err := client.scope.ensureNamespace(namespace); err != nil {
+			return nil, false, err
+		}
+		return []string{namespace}, false, nil
+	}
+	if client.scope.mode == "selected" {
+		if len(client.scope.namespaces) == 0 {
+			return nil, false, fmt.Errorf("%w: selected scope has no namespaces", ErrInvalidConfig)
+		}
+		return append([]string(nil), client.scope.namespaces...), false, nil
+	}
+	return nil, true, nil
+}
+
+type kubeScope struct {
+	mode       string
+	namespaces []string
+	allowed    map[string]bool
+}
+
+func kubeScopeFromProfile(profile connectors.CredentialProfileView) kubeScope {
+	mode := strings.TrimSpace(stringValue(profile.Public, "scope_mode"))
+	if mode == "" {
+		mode = "all"
+	}
+	namespaces := splitLines(stringValue(profile.Public, "namespaces"))
+	scope := kubeScope{mode: mode, namespaces: namespaces, allowed: map[string]bool{}}
+	for _, namespace := range namespaces {
+		scope.allowed[namespace] = true
+	}
+	return scope
+}
+
+func (scope kubeScope) namespaceAllowed(namespace string) bool {
+	if scope.mode != "selected" {
+		return true
+	}
+	return scope.allowed[namespace]
+}
+
+func (scope kubeScope) ensureNamespace(namespace string) error {
+	if namespace == "" || !validKubeName(namespace) {
+		return fmt.Errorf("invalid namespace")
+	}
+	if !scope.namespaceAllowed(namespace) {
+		return fmt.Errorf("%w: %s", ErrScopeDenied, namespace)
+	}
+	return nil
+}
+
+type NamespaceSummary struct {
+	Name      string `json:"name"`
+	Status    string `json:"status,omitempty"`
+	Age       string `json:"age,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+type WorkloadSummary struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Ready     string `json:"ready,omitempty"`
+	Replicas  int    `json:"replicas"`
+	Available int    `json:"available"`
+	Image     string `json:"image,omitempty"`
+	Age       string `json:"age,omitempty"`
+}
+
+type PodSummary struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Phase     string `json:"phase,omitempty"`
+	Ready     string `json:"ready,omitempty"`
+	Restarts  int    `json:"restarts"`
+	Node      string `json:"node,omitempty"`
+	Age       string `json:"age,omitempty"`
+}
+
+type ServiceSummary struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Type      string `json:"type,omitempty"`
+	ClusterIP string `json:"cluster_ip,omitempty"`
+	Ports     string `json:"ports,omitempty"`
+	Age       string `json:"age,omitempty"`
+}
+
+type IngressSummary struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Class     string `json:"class,omitempty"`
+	Hosts     string `json:"hosts,omitempty"`
+	Age       string `json:"age,omitempty"`
+}
+
+type NodeSummary struct {
+	Name    string `json:"name"`
+	Ready   string `json:"ready,omitempty"`
+	Roles   string `json:"roles,omitempty"`
+	Version string `json:"version,omitempty"`
+	Age     string `json:"age,omitempty"`
+}
+
+type EventSummary struct {
+	Namespace     string `json:"namespace"`
+	Type          string `json:"type,omitempty"`
+	Reason        string `json:"reason,omitempty"`
+	Object        string `json:"object,omitempty"`
+	Message       string `json:"message,omitempty"`
+	LastTimestamp string `json:"last_timestamp,omitempty"`
+	Count         int    `json:"count,omitempty"`
+}
+
+func namespaceSummaryFromItem(item map[string]any) NamespaceSummary {
+	metadata := mapValue(item, "metadata")
+	status := mapValue(item, "status")
+	return NamespaceSummary{Name: stringValue(metadata, "name"), Status: stringValue(status, "phase"), CreatedAt: stringValue(metadata, "creationTimestamp"), Age: ageText(stringValue(metadata, "creationTimestamp"))}
+}
+
+func workloadSummaryFromItem(item map[string]any) WorkloadSummary {
+	metadata := mapValue(item, "metadata")
+	spec := mapValue(item, "spec")
+	status := mapValue(item, "status")
+	return WorkloadSummary{
+		Kind:      stringValue(item, "kind"),
+		Namespace: stringValue(metadata, "namespace"),
+		Name:      stringValue(metadata, "name"),
+		Ready:     fmt.Sprintf("%d/%d", intValue(status, "readyReplicas"), intValue(spec, "replicas")),
+		Replicas:  intValue(spec, "replicas"),
+		Available: intValue(status, "availableReplicas"),
+		Image:     firstContainerImage(item),
+		Age:       ageText(stringValue(metadata, "creationTimestamp")),
+	}
+}
+
+func podSummaryFromItem(item map[string]any) PodSummary {
+	metadata := mapValue(item, "metadata")
+	status := mapValue(item, "status")
+	ready, restarts := podReadyRestarts(status)
+	return PodSummary{Namespace: stringValue(metadata, "namespace"), Name: stringValue(metadata, "name"), Phase: stringValue(status, "phase"), Ready: ready, Restarts: restarts, Node: stringValue(mapValue(item, "spec"), "nodeName"), Age: ageText(stringValue(metadata, "creationTimestamp"))}
+}
+
+func serviceSummaryFromItem(item map[string]any) ServiceSummary {
+	metadata := mapValue(item, "metadata")
+	spec := mapValue(item, "spec")
+	return ServiceSummary{Namespace: stringValue(metadata, "namespace"), Name: stringValue(metadata, "name"), Type: stringValue(spec, "type"), ClusterIP: stringValue(spec, "clusterIP"), Ports: servicePorts(spec), Age: ageText(stringValue(metadata, "creationTimestamp"))}
+}
+
+func ingressSummaryFromItem(item map[string]any) IngressSummary {
+	metadata := mapValue(item, "metadata")
+	spec := mapValue(item, "spec")
+	return IngressSummary{Namespace: stringValue(metadata, "namespace"), Name: stringValue(metadata, "name"), Class: stringValue(spec, "ingressClassName"), Hosts: ingressHosts(spec), Age: ageText(stringValue(metadata, "creationTimestamp"))}
+}
+
+func nodeSummaryFromItem(item map[string]any) NodeSummary {
+	metadata := mapValue(item, "metadata")
+	status := mapValue(item, "status")
+	info := mapValue(status, "nodeInfo")
+	return NodeSummary{Name: stringValue(metadata, "name"), Ready: nodeReady(status), Roles: nodeRoles(metadata), Version: stringValue(info, "kubeletVersion"), Age: ageText(stringValue(metadata, "creationTimestamp"))}
+}
+
+func eventSummaryFromItem(item map[string]any) EventSummary {
+	metadata := mapValue(item, "metadata")
+	involved := mapValue(item, "involvedObject")
+	last := stringValue(item, "lastTimestamp")
+	if last == "" {
+		last = stringValue(item, "eventTime")
+	}
+	return EventSummary{Namespace: stringValue(metadata, "namespace"), Type: stringValue(item, "type"), Reason: stringValue(item, "reason"), Object: strings.Trim(strings.Join([]string{stringValue(involved, "kind"), stringValue(involved, "name")}, "/"), "/"), Message: truncateString(stringValue(item, "message"), 2000), LastTimestamp: last, Count: intValue(item, "count")}
+}
+
+func genericResourceSummary(resource map[string]any) map[string]any {
+	metadata := mapValue(resource, "metadata")
+	return map[string]any{"kind": stringValue(resource, "kind"), "namespace": stringValue(metadata, "namespace"), "name": stringValue(metadata, "name"), "created_at": stringValue(metadata, "creationTimestamp")}
+}
+
+func firstContainerImage(item map[string]any) string {
+	template := mapValue(mapValue(mapValue(item, "spec"), "template"), "spec")
+	containers := sliceValue(template, "containers")
+	if len(containers) == 0 {
+		return ""
+	}
+	return stringValue(containers[0], "image")
+}
+
+func podReadyRestarts(status map[string]any) (string, int) {
+	statuses := sliceValue(status, "containerStatuses")
+	ready := 0
+	restarts := 0
+	for _, container := range statuses {
+		if boolValue(container, "ready") {
+			ready++
+		}
+		restarts += intValue(container, "restartCount")
+	}
+	return fmt.Sprintf("%d/%d", ready, len(statuses)), restarts
+}
+
+func servicePorts(spec map[string]any) string {
+	var parts []string
+	for _, port := range sliceValue(spec, "ports") {
+		text := fmt.Sprintf("%d/%s", intValue(port, "port"), strings.ToUpper(stringValue(port, "protocol")))
+		if nodePort := intValue(port, "nodePort"); nodePort > 0 {
+			text += fmt.Sprintf(":%d", nodePort)
+		}
+		parts = append(parts, text)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func ingressHosts(spec map[string]any) string {
+	var hosts []string
+	for _, rule := range sliceValue(spec, "rules") {
+		if host := stringValue(rule, "host"); host != "" {
+			hosts = append(hosts, host)
+		}
+	}
+	return strings.Join(hosts, ", ")
+}
+
+func nodeReady(status map[string]any) string {
+	for _, condition := range sliceValue(status, "conditions") {
+		if stringValue(condition, "type") == "Ready" {
+			return stringValue(condition, "status")
+		}
+	}
+	return ""
+}
+
+func nodeRoles(metadata map[string]any) string {
+	labels := mapValue(metadata, "labels")
+	var roles []string
+	for key := range labels {
+		if strings.HasPrefix(key, "node-role.kubernetes.io/") {
+			role := strings.TrimPrefix(key, "node-role.kubernetes.io/")
+			if role == "" {
+				role = "control-plane"
+			}
+			roles = append(roles, role)
+		}
+	}
+	sort.Strings(roles)
+	if len(roles) == 0 {
+		return "worker"
+	}
+	return strings.Join(roles, ",")
+}
+
+func workloadsDisplay(workloads []WorkloadSummary) string {
+	if len(workloads) == 0 {
+		return "No Kubernetes workloads found."
+	}
+	lines := make([]string, 0, len(workloads))
+	for _, workload := range workloads {
+		lines = append(lines, fmt.Sprintf("%s/%s/%s ready=%s image=%s", workload.Namespace, workload.Kind, workload.Name, workload.Ready, workload.Image))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func podsDisplay(pods []PodSummary) string {
+	if len(pods) == 0 {
+		return "No Kubernetes pods found."
+	}
+	lines := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		lines = append(lines, fmt.Sprintf("%s/%s phase=%s ready=%s restarts=%d", pod.Namespace, pod.Name, pod.Phase, pod.Ready, pod.Restarts))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func kubeCommandError(command string, result connectors.CommandRunResult) error {
+	text := strings.TrimSpace(result.Stderr)
+	if text == "" {
+		text = strings.TrimSpace(result.Stdout)
+	}
+	if text == "" {
+		text = fmt.Sprintf("exit code %d", result.ExitCode)
+	}
+	return fmt.Errorf("%s failed: %s", command, truncateString(text, 2000))
+}
+
+func connectionMode(target connectors.TargetView) string {
+	mode := strings.TrimSpace(stringValue(target.Config, "connection_mode"))
+	if mode == "" {
+		return "over_ssh"
+	}
+	return mode
+}
+
+func scopeMode(profile connectors.CredentialProfileView) string {
+	mode := strings.TrimSpace(stringValue(profile.Public, "scope_mode"))
+	if mode == "" {
+		return "all"
+	}
+	return mode
+}
+
+func namespaceOrDefault(target connectors.TargetView, namespace string) string {
+	namespace = strings.TrimSpace(namespace)
+	if namespace != "" {
+		return namespace
+	}
+	return strings.TrimSpace(stringValue(target.Config, "default_namespace"))
+}
+
+func normalizeResourceType(input map[string]any) string {
+	value := strings.ToLower(strings.TrimSpace(stringValue(input, "resource_type")))
+	switch value {
+	case "pod", "deployment", "statefulset", "daemonset", "service", "ingress", "node":
+		return value
+	default:
+		return ""
+	}
+}
+
+func normalizeRequiredName(input map[string]any, key string) string {
+	value := strings.TrimSpace(stringValue(input, key))
+	if !validKubeName(value) {
+		return ""
+	}
+	return value
+}
+
+func normalizeOptionalName(input map[string]any, key string) string {
+	value := strings.TrimSpace(stringValue(input, key))
+	if value == "" {
+		return ""
+	}
+	if !validKubeName(value) {
+		return ""
+	}
+	return value
+}
+
+func validKubeName(value string) bool {
+	return value != "" && kubeNamePattern.MatchString(value)
+}
+
+func resourceSummary(resourceType string, namespace string, name string) string {
+	if namespace == "" {
+		return resourceType + "/" + name
+	}
+	return namespace + "/" + resourceType + "/" + name
+}
+
+func namespaceSummary(input map[string]any) string {
+	if namespace := stringValue(input, "namespace"); namespace != "" {
+		return "namespace " + namespace
+	}
+	return "allowed namespaces"
+}
+
+func mapValue(value any, key string) map[string]any {
+	source, ok := value.(map[string]any)
+	if !ok || source == nil {
+		return map[string]any{}
+	}
+	child, ok := source[key].(map[string]any)
+	if !ok || child == nil {
+		return map[string]any{}
+	}
+	return child
+}
+
+func sliceValue(source map[string]any, key string) []map[string]any {
+	values, ok := source[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(values))
+	for _, value := range values {
+		if item, ok := value.(map[string]any); ok {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func stringValue(source any, key string) string {
+	mapped, ok := source.(map[string]any)
+	if !ok || mapped == nil {
+		return ""
+	}
+	value, ok := mapped[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func intValue(source map[string]any, key string) int {
+	value, ok := source[key]
+	if !ok || value == nil {
+		return 0
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case json.Number:
+		parsed, _ := strconv.Atoi(string(typed))
+		return parsed
+	default:
+		parsed, _ := strconv.Atoi(strings.TrimSpace(fmt.Sprint(typed)))
+		return parsed
+	}
+}
+
+func boolValue(source map[string]any, key string) bool {
+	value, ok := source[key]
+	if !ok || value == nil {
+		return false
+	}
+	typed, _ := value.(bool)
+	return typed
+}
+
+func normalizeInt(input map[string]any, key string, fallback int, min int, max int) int {
+	value, ok := input[key]
+	if !ok || value == nil {
+		return fallback
+	}
+	var parsed int
+	switch typed := value.(type) {
+	case int:
+		parsed = typed
+	case int64:
+		parsed = int(typed)
+	case float64:
+		parsed = int(typed)
+	case json.Number:
+		parsed, _ = strconv.Atoi(string(typed))
+	default:
+		parsed, _ = strconv.Atoi(strings.TrimSpace(fmt.Sprint(typed)))
+	}
+	if parsed < min {
+		return fallback
+	}
+	if parsed > max {
+		return max
+	}
+	return parsed
+}
+
+func copyMap(input map[string]any) map[string]any {
+	output := make(map[string]any, len(input))
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}
+
+func splitLines(value string) []string {
+	var result []string
+	for _, line := range strings.Split(value, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && validKubeName(trimmed) {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func ageText(createdAt string) string {
+	return createdAt
+}
+
+func truncateString(value string, maxBytes int) string {
+	if maxBytes < 1 || len(value) <= maxBytes {
+		return value
+	}
+	return value[:maxBytes] + "\n... truncated ..."
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/backend/internal/connectors/kubernetes/kubernetes_test.go
+++ b/backend/internal/connectors/kubernetes/kubernetes_test.go
@@ -1,0 +1,149 @@
+package kubernetesconnector
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+func TestPrepareActionRejectsEmptyLogTarget(t *testing.T) {
+	_, err := New().PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     kubeTarget(),
+		Profile:    kubeProfile("selected"),
+		ActionName: ActionLogs,
+		Input:      map[string]any{"namespace": "production", "pod": " "},
+	})
+	if err == nil {
+		t.Fatal("expected empty pod error")
+	}
+}
+
+func TestListPodsUsesSelectedNamespaces(t *testing.T) {
+	transport := &fakeCommandTransport{
+		results: map[string]connectors.CommandRunResult{
+			"kubectl get pods -n 'production' -o json": {Stdout: `{"items":[{"metadata":{"namespace":"production","name":"api","creationTimestamp":"2026-01-01T00:00:00Z"},"status":{"phase":"Running","containerStatuses":[{"ready":true,"restartCount":1}]},"spec":{"nodeName":"node-1"}}]}`},
+		},
+	}
+	result, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       kubeTarget(),
+		Profile:      kubeProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}, connectors.PreparedAction{ActionName: ActionListPods, Payload: map[string]any{}})
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	output, _ := result.Output.(map[string]any)
+	pods, _ := output["pods"].([]PodSummary)
+	if len(pods) != 1 || pods[0].Namespace != "production" || pods[0].Ready != "1/1" || pods[0].Restarts != 1 {
+		t.Fatalf("unexpected pods: %#v", pods)
+	}
+}
+
+func TestLogsRejectsOutOfScopeNamespace(t *testing.T) {
+	_, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       kubeTarget(),
+		Profile:      kubeProfile("selected"),
+		Capabilities: fakeCapabilities{transport: &fakeCommandTransport{}},
+	}, connectors.PreparedAction{ActionName: ActionLogs, Payload: map[string]any{"namespace": "staging", "pod": "api"}})
+	if err == nil || !strings.Contains(err.Error(), ErrScopeDenied.Error()) {
+		t.Fatalf("expected scope denied, got %v", err)
+	}
+}
+
+func TestRolloutRestartRunsBoundedKubectlTemplate(t *testing.T) {
+	transport := &fakeCommandTransport{
+		results: map[string]connectors.CommandRunResult{
+			"kubectl rollout restart deployment/'api' -n 'production' 2>&1": {Stdout: "deployment.apps/api restarted\n", ExitCode: 0, DurationMS: 9},
+		},
+	}
+	result, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       kubeTarget(),
+		Profile:      kubeProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}, connectors.PreparedAction{ActionName: ActionRolloutRestart, Payload: map[string]any{"namespace": "production", "deployment": "api"}})
+	if err != nil {
+		t.Fatalf("rollout restart: %v", err)
+	}
+	if result.Status != connectors.ResultCompleted || !strings.Contains(result.DisplayText, "restarted") {
+		t.Fatalf("unexpected restart result: %#v", result)
+	}
+}
+
+func TestDescribeReturnsResourceSummary(t *testing.T) {
+	transport := &fakeCommandTransport{
+		results: map[string]connectors.CommandRunResult{
+			"kubectl get deployment 'api' -n 'production' -o json": {Stdout: `{"kind":"Deployment","metadata":{"namespace":"production","name":"api","creationTimestamp":"2026-01-01T00:00:00Z"}}`},
+		},
+	}
+	result, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{
+		Target:       kubeTarget(),
+		Profile:      kubeProfile("selected"),
+		Capabilities: fakeCapabilities{transport: transport},
+	}, connectors.PreparedAction{ActionName: ActionDescribe, Payload: map[string]any{"resource_type": "deployment", "namespace": "production", "name": "api"}})
+	if err != nil {
+		t.Fatalf("describe: %v", err)
+	}
+	if !strings.Contains(toJSON(t, result.Output), "Deployment") {
+		t.Fatalf("unexpected describe output: %#v", result.Output)
+	}
+}
+
+func kubeTarget() connectors.TargetView {
+	return connectors.TargetView{
+		ID:            1,
+		Ref:           "kubernetes:1:10",
+		ConnectorKind: Kind,
+		Name:          "cluster",
+		Config:        map[string]any{"connection_mode": "over_ssh", "transport_target_ref": "ssh:2:20", "kubectl_command": "kubectl"},
+	}
+}
+
+func kubeProfile(scopeMode string) connectors.CredentialProfileView {
+	return connectors.CredentialProfileView{
+		ID:            10,
+		TargetID:      1,
+		ConnectorKind: Kind,
+		Kind:          "namespace_scope",
+		Label:         "production",
+		Public:        map[string]any{"scope_mode": scopeMode, "namespaces": "production"},
+	}
+}
+
+type fakeCapabilities struct {
+	transport connectors.CommandTransport
+}
+
+func (capabilities fakeCapabilities) RuntimeCapability(name string) connectors.RuntimeCapability {
+	if name == connectors.CommandTransportCapabilityName {
+		return capabilities.transport
+	}
+	return nil
+}
+
+type fakeCommandTransport struct {
+	results map[string]connectors.CommandRunResult
+}
+
+func (transport *fakeCommandTransport) ConnectorRuntimeCapability() string {
+	return connectors.CommandTransportCapabilityName
+}
+
+func (transport *fakeCommandTransport) RunConnectorCommand(_ context.Context, request connectors.CommandRunRequest) (connectors.CommandRunResult, error) {
+	result, ok := transport.results[request.Command]
+	if !ok {
+		return connectors.CommandRunResult{ExitCode: 127, Stderr: "unexpected command: " + request.Command}, nil
+	}
+	return result, nil
+}
+
+func toJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+	return string(data)
+}

--- a/backend/internal/console/console_sessions_test.go
+++ b/backend/internal/console/console_sessions_test.go
@@ -302,6 +302,24 @@ func TestManualInputCapturesOutputWhenBracketPromptReturns(t *testing.T) {
 	}
 }
 
+func TestManualInputCapturesOutputWhenPathPromptReturns(t *testing.T) {
+	database, manager, session := newManualHistoryTestSession(t)
+	stdin := &recordingWriteCloser{}
+	session.stdin = stdin
+	session.rawTranscript = "/ # "
+	manager.sessions[session.id] = session
+
+	if err := manager.Input(context.Background(), session.id, "pwd\n"); err != nil {
+		t.Fatalf("input: %v", err)
+	}
+	session.appendOutput("pwd\r\n/\r\n/ # ")
+	waitForManualHistoryStatus(t, database, "completed")
+	row := readManualHistoryRow(t, database)
+	if row.command != "pwd" || row.stdout != "/" || row.trackingReason != "exit_code_unavailable" {
+		t.Fatalf("expected captured Kubernetes path prompt output, got %#v", row)
+	}
+}
+
 func TestManualInputCapturesAptUpdateOutput(t *testing.T) {
 	database, manager, session := newManualHistoryTestSession(t)
 	stdin := &recordingWriteCloser{}
@@ -651,6 +669,19 @@ func TestManualPromptPrefixSupportsBracketPathPrompts(t *testing.T) {
 	}
 	if !manualTranscriptEndsWithPrompt("[~] # ", "[~] #") {
 		t.Fatalf("bare bracket prompt should count as returned prompt")
+	}
+}
+
+func TestManualPromptPrefixSupportsKubernetesPathPrompts(t *testing.T) {
+	transcript := "/ # ls"
+	if prompt := lastManualShellPrompt(transcript); prompt != "/ #" {
+		t.Fatalf("expected Kubernetes path prompt prefix from echo line, got %q", prompt)
+	}
+	if manualTranscriptEndsWithPrompt(transcript, "/ #") {
+		t.Fatalf("command echo line must not count as returned path prompt")
+	}
+	if !manualTranscriptEndsWithPrompt("/app $ ", "/app $") {
+		t.Fatalf("bare path prompt should count as returned prompt")
 	}
 }
 

--- a/backend/internal/console/manual_history.go
+++ b/backend/internal/console/manual_history.go
@@ -621,6 +621,9 @@ func (s *managedConsoleSession) manualOutputCompletionLocked() *manualOutputComp
 	if !manualSegmentHasPrompt(segment) {
 		return nil
 	}
+	if manualActiveIsHistoryRecall(&active) && strings.TrimSpace(active.ResumePrompt) != "" && !manualTranscriptEndsWithPrompt(segment, active.ResumePrompt) {
+		return nil
+	}
 	stdout, outputTruncated := manualCapturedOutput(segment, active.Command)
 	truncated = truncated || outputTruncated
 	status := "completed"

--- a/backend/internal/console/output.go
+++ b/backend/internal/console/output.go
@@ -9,8 +9,8 @@ import (
 
 var ansiSequencePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\a]*(\a|\x1b\\)`)
 var aptNoisePattern = regexp.MustCompile(`^\d+% \[|^Reading package lists\.\.\. \d+%$|^Building dependency tree\.\.\. \d+%$|^Reading state information\.\.\. \d+%$|^Scanning (processes|candidates|linux images)\.\.\. \[|^Scanning (processes|candidates|linux images)\.\.\.$`)
-var shellPromptPattern = regexp.MustCompile(`^(?:[^@\s]+@[^:\s]+:.*|\[[^\]\r\n]{1,128}\]\s*)[#$]\s*.*$`)
-var bareShellPromptPattern = regexp.MustCompile(`^(?:[^@\s]+@[^:\s]+:.*|\[[^\]\r\n]{1,128}\]\s*)[#$]\s*$`)
+var shellPromptPattern = regexp.MustCompile(`^(?:[^@\s]+@[^:\s]+:.*|\[[^\]\r\n]{1,128}\]\s*|(?:~|/)[^#$\r\n]{0,128}\s*)[#$]\s*.*$`)
+var bareShellPromptPattern = regexp.MustCompile(`^(?:[^@\s]+@[^:\s]+:.*|\[[^\]\r\n]{1,128}\]\s*|(?:~|/)[^#$\r\n]{0,128}\s*)[#$]\s*$`)
 
 func PlainOutput(value string) string {
 	if value == "" {

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -2,8 +2,8 @@
 
 The MCP surface is connector-first. AIPermission does not expose separate
 product-specific MCP wrappers for SSH, database, cache, queue, or container
-products. SSH, Postgres, Redis, RabbitMQ, Docker, and future integrations are
-reached through the same connector target/action pipeline.
+products. SSH, Postgres, Redis, RabbitMQ, Docker, Kubernetes, and future
+integrations are reached through the same connector target/action pipeline.
 
 Recommended package use:
 
@@ -52,6 +52,7 @@ postgres:7:2
 redis:8:3
 rabbitmq:9:4
 docker:10:5
+kubernetes:11:6
 ```
 
 The profile chooses which stored credential is used. The connector action still
@@ -59,8 +60,8 @@ runs locally through the gateway; AIPermission does not host a remote connector
 service.
 
 Clients should discover targets and actions at runtime. Do not hardcode SSH,
-Postgres, Redis, RabbitMQ, or Docker as special MCP modes; future connector
-kinds use the same tools and `target_ref` shape.
+Postgres, Redis, RabbitMQ, Docker, or Kubernetes as special MCP modes; future
+connector kinds use the same tools and `target_ref` shape.
 
 ## list_connector_targets
 
@@ -154,6 +155,12 @@ only list or operate on that container through Docker actions; image, network,
 volume reads, `container_exec`, and live container console sessions are bounded
 to the selected container scope where practical. Arbitrary host-level Docker
 commands, prune, removal, and raw Docker command execution are not exposed.
+
+Kubernetes actions include cluster version metadata, namespace/workload/pod/
+service/ingress/node/event listing, resource JSON describes, bounded pod log
+tails, and explicit `rollout_restart` for deployments. Kubernetes profiles can
+scope access by namespace visibility. Raw `kubectl`, manifest apply/edit/delete,
+pod deletion, scaling, and Secret value browsing are not exposed.
 
 ## call_connector_action
 

--- a/docs/mvp/scope.md
+++ b/docs/mvp/scope.md
@@ -11,12 +11,13 @@ Main target:
 The MVP is not a DevOps platform. It does not own production operations. It gives a developer a controlled, token-scoped, auditable execution channel for debugging, maintenance, incident triage, and temporary AI-assisted automation.
 
 The MVP does not introduce first-class management modules for every external
-system. It introduces one connector pipeline. SSH, Postgres, Redis, RabbitMQ, Docker, and future
-integrations are connector kinds that provide their own actions while sharing
-the same target/profile/action permission model. If an allowed SSH target has
-the needed CLI tools and access, the AI can operate at command level through
-the SSH connector `exec` action. If a structured connector such as Postgres is
-selected, the AI uses that connector's smaller purpose-built action surface.
+system. It introduces one connector pipeline. SSH, Postgres, Redis, RabbitMQ,
+Docker, Kubernetes, and future integrations are connector kinds that provide
+their own actions while sharing the same target/profile/action permission model.
+If an allowed SSH target has the needed CLI tools and access, the AI can operate
+at command level through the SSH connector `exec` action. If a structured
+connector such as Postgres is selected, the AI uses that connector's smaller
+purpose-built action surface.
 
 The gateway itself is local-only. It is not designed to run on a remote server for browser/MCP clients, to be shared on a LAN, or to act as a central team control plane.
 
@@ -37,8 +38,9 @@ The gateway itself is local-only. It is not designed to run on a remote server f
   SFTP transfer, and host-key approval
 - built-in Postgres connector with schema/table inspection and bounded
   read-only query actions
-- built-in Redis, RabbitMQ, and Docker connectors for scoped cache, queue, and
-  container operations through the shared connector pipeline
+- built-in Redis, RabbitMQ, Docker, and Kubernetes connectors for scoped cache,
+  queue, container runtime, and cluster visibility through the shared connector
+  pipeline
 - API token creation and revocation
 - token-to-target/profile/action permissions
 - execution rules: `always_run`, `approval_required`, `blocked`

--- a/docs/setup/docker-runtime.md
+++ b/docs/setup/docker-runtime.md
@@ -21,7 +21,7 @@ Pin a specific release image with `AIPERMISSION_VERSION` without the leading
 `v`:
 
 ```txt
-AIPERMISSION_VERSION=0.2.9 docker compose -f docker-compose.release.yml up -d
+AIPERMISSION_VERSION=0.2.10 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, keep shell scripts checked out with LF line endings. Git should do

--- a/docs/skills/aipermission-docs/SKILL.md
+++ b/docs/skills/aipermission-docs/SKILL.md
@@ -133,7 +133,7 @@ Use the established aipermission naming:
 - `gateway` is the local backend that owns credentials, policy, execution, approvals, and audit.
 - `MCP client` means Cursor, Windsurf, or another AI tool integration.
 - `API token` means the gateway access token used by MCP/API clients.
-- `connector target` means a saved SSH, Postgres, Redis, RabbitMQ, Docker, or future integration target.
+- `connector target` means a saved SSH, Postgres, Redis, RabbitMQ, Docker, Kubernetes, or future integration target.
 - `server` is acceptable only when specifically describing an SSH connector target.
 - `database` means a configured Postgres connector target/profile.
 - `execution rule` means `always_run`, `approval_required`, or `blocked`.

--- a/docs/whatis-aipermission.md
+++ b/docs/whatis-aipermission.md
@@ -259,7 +259,7 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-SSH, Postgres, Redis, RabbitMQ, Docker, and future integrations are exposed as
+SSH, Postgres, Redis, RabbitMQ, Docker, Kubernetes, and future integrations are exposed as
 connector actions instead of separate product-specific MCP tools.
 
 ## Connector Action Flow

--- a/frontend/src/components/app-shell.jsx
+++ b/frontend/src/components/app-shell.jsx
@@ -251,7 +251,7 @@ export function Shell({ theme, setTheme }) {
     const session = await apiPost("/api/console/sessions", {
       runtime_id: server.id,
       name: options.name || `${server.name} shell`,
-      close_existing: true,
+      close_existing: options.closeExisting !== false,
       params: options.params || undefined,
     });
     upsertConsoleSession(session);

--- a/frontend/src/components/console/pty-console.jsx
+++ b/frontend/src/components/console/pty-console.jsx
@@ -22,12 +22,16 @@ export function PtyConsole({ session, onInput, onResize, theme = "dark" }) {
     terminal.loadAddon(fit);
     terminal.open(containerRef.current);
     terminal.focus();
-    fit.fit();
-    onResize(terminal.cols, terminal.rows);
-
-    const resizeObserver = new ResizeObserver(() => {
+    const fitAndResize = () => {
       fit.fit();
       onResize(terminal.cols, terminal.rows);
+    };
+    fitAndResize();
+    const frame = requestAnimationFrame(fitAndResize);
+    const settleTimer = window.setTimeout(fitAndResize, 80);
+
+    const resizeObserver = new ResizeObserver(() => {
+      fitAndResize();
     });
     resizeObserver.observe(containerRef.current);
 
@@ -42,6 +46,8 @@ export function PtyConsole({ session, onInput, onResize, theme = "dark" }) {
     return () => {
       disposable.dispose();
       containerRef.current?.removeEventListener("pointerdown", focusHandler);
+      cancelAnimationFrame(frame);
+      window.clearTimeout(settleTimer);
       resizeObserver.disconnect();
       terminal.dispose();
     };

--- a/frontend/src/connectors/templates/docker/console.jsx
+++ b/frontend/src/connectors/templates/docker/console.jsx
@@ -8,7 +8,7 @@ import { Input } from "../../../components/ui/form";
 import { TerminalBlock } from "../../../components/ui/terminal-block";
 import { apiPost } from "../../../lib/api";
 
-export function DockerConnectorConsoleTemplate({ children, target, approvals, theme, session, selectedSessionLive, selectedRuntimeTarget, onNewLiveSession, onEndLiveSession, onRefreshActivity }) {
+export function DockerConnectorConsoleTemplate({ children, target, approvals, theme, session, selectedSessionLive, selectedRuntimeTarget, onNewLiveSession, onSelectLiveSessionName, onEndLiveSession, onRefreshActivity }) {
   const [resourceView, setResourceView] = useState("containers");
   const [containers, setContainers] = useState([]);
   const [resources, setResources] = useState({ images: [], networks: [], volumes: [] });
@@ -19,6 +19,7 @@ export function DockerConnectorConsoleTemplate({ children, target, approvals, th
   const [viewMode, setViewMode] = useState("logs");
   const [result, setResult] = useState(null);
   const [resultSearch, setResultSearch] = useState("");
+  const [pendingConsoleName, setPendingConsoleName] = useState("");
   const [state, setState] = useState({ state: "idle", error: "", message: "" });
   const [confirmDialog, setConfirmDialog] = useState({ open: false, title: "", description: "", details: [], actionName: "", pending: false });
   const panelClass = theme === "light" ? "bg-white text-stone-900" : "bg-[#1e1e1e] text-stone-100";
@@ -64,6 +65,12 @@ export function DockerConnectorConsoleTemplate({ children, target, approvals, th
     if (resourceView === "containers") return;
     void refreshResource(resourceView);
   }, [resourceView, target.ref]);
+
+  useEffect(() => {
+    if (pendingConsoleName && selectedContainerConsoleLive) {
+      setPendingConsoleName("");
+    }
+  }, [pendingConsoleName, selectedContainerConsoleLive]);
 
   async function runDockerAction({ actionName, input = {}, reason, busy = "running", showResult = true }) {
     setState({ state: busy, error: "", message: "" });
@@ -129,6 +136,8 @@ export function DockerConnectorConsoleTemplate({ children, target, approvals, th
 
   function openContainerConsole(container = selectedContainer) {
     if (!container) return;
+    const containerRef = container.name || container.id;
+    if (containerRef) onSelectLiveSessionName?.(dockerConsoleSessionName(target, containerRef));
     setViewMode("console");
     setResult(null);
     setResultSearch("");
@@ -136,10 +145,18 @@ export function DockerConnectorConsoleTemplate({ children, target, approvals, th
 
   async function startContainerConsole() {
     if (!selectedContainerRef) return;
-    await onNewLiveSession?.({
-      name: expectedConsoleSessionName,
-      params: { container: selectedContainerRef },
-    });
+    setPendingConsoleName(expectedConsoleSessionName);
+    onSelectLiveSessionName?.(expectedConsoleSessionName);
+    try {
+      await onNewLiveSession?.({
+        name: expectedConsoleSessionName,
+        params: { container: selectedContainerRef },
+        closeExisting: false,
+      });
+    } catch (error) {
+      setPendingConsoleName("");
+      throw error;
+    }
   }
 
   function selectContainer(container) {
@@ -237,8 +254,8 @@ export function DockerConnectorConsoleTemplate({ children, target, approvals, th
 
   return (
     <div className={`grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
-      <div className="grid min-h-0 gap-4 overflow-hidden p-4 lg:grid-cols-[360px_minmax(0,1fr)]">
-        <section className={`grid min-h-0 grid-rows-[auto_auto_auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+      <div className="grid h-full min-h-0 gap-4 overflow-hidden p-4 lg:grid-cols-[360px_minmax(0,1fr)]">
+        <section className={`grid h-full min-h-0 grid-rows-[auto_auto_auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
           <div className={`border-b p-3 ${borderClass}`}>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
@@ -295,60 +312,62 @@ export function DockerConnectorConsoleTemplate({ children, target, approvals, th
           </div>
         </section>
 
-        <section className={`grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
-          <div className={`border-b p-3 ${borderClass}`}>
-            <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
-              <div className="min-w-0">
-                <div className="flex min-w-0 items-center gap-2">
-                  <p className="truncate text-sm font-semibold">{selectedResource ? resourcePrimary(resourceView, selectedResource) : `Select ${resourceSingular(resourceView)}`}</p>
-                  {state.state !== "idle" ? (
-                    <span className={`inline-flex shrink-0 items-center gap-1 text-xs ${mutedClass}`}>
-                      <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                      Loading
-                    </span>
-                  ) : null}
+        <section className={`grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+          <div>
+            <div className={`border-b p-3 ${borderClass}`}>
+              <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <p className="truncate text-sm font-semibold">{selectedResource ? resourcePrimary(resourceView, selectedResource) : `Select ${resourceSingular(resourceView)}`}</p>
+                    {state.state !== "idle" ? (
+                      <span className={`inline-flex shrink-0 items-center gap-1 text-xs ${mutedClass}`}>
+                        <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                        Loading
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className={`truncate text-xs ${mutedClass}`}>{selectedResource ? resourceSecondary(resourceView, selectedResource) : resourcePlaceholder(resourceView)}</p>
                 </div>
-                <p className={`truncate text-xs ${mutedClass}`}>{selectedResource ? resourceSecondary(resourceView, selectedResource) : resourcePlaceholder(resourceView)}</p>
+                {resourceView === "containers" && selectedContainer ? (
+                  <div className="flex flex-wrap items-center justify-end gap-2">
+                    <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={showingInspect ? () => readLogs() : () => inspectContainer()} disabled={state.state !== "idle"} title={showingInspect ? "Show container logs" : "Inspect container"}>
+                      {showingInspect ? <RefreshCcw className="h-3.5 w-3.5" /> : <FileJson className="h-3.5 w-3.5" />}
+                      {showingInspect ? "Logs" : "Inspect"}
+                    </Button>
+                    {!showingInspect && viewMode !== "console" ? (
+                      <>
+                        <label className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
+                          Tail
+                          <Input className={`h-8 w-24 ${inputClass}`} type="number" min="1" max="2000" value={tail} onChange={(event) => setTail(event.target.value)} />
+                        </label>
+                        <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => readLogs()} disabled={state.state !== "idle"} title="Refresh logs">
+                          <RefreshCcw className="h-3.5 w-3.5" />
+                        </Button>
+                      </>
+                    ) : null}
+                    <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openContainerConsole()} disabled={state.state !== "idle"} title="Open live console inside this container">
+                      <TerminalSquare className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openLifecycle("start_container")} disabled={state.state !== "idle"} title="Start container">
+                      <Play className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openLifecycle("stop_container")} disabled={state.state !== "idle"} title="Stop container">
+                      <Square className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openLifecycle("restart_container")} disabled={state.state !== "idle"} title="Restart container">
+                      <RotateCcw className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ) : null}
               </div>
-              {resourceView === "containers" && selectedContainer ? (
-                <div className="flex flex-wrap items-center justify-end gap-2">
-                  <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={showingInspect ? () => readLogs() : () => inspectContainer()} disabled={state.state !== "idle"} title={showingInspect ? "Show container logs" : "Inspect container"}>
-                    {showingInspect ? <RefreshCcw className="h-3.5 w-3.5" /> : <FileJson className="h-3.5 w-3.5" />}
-                    {showingInspect ? "Logs" : "Inspect"}
-                  </Button>
-                  {!showingInspect && viewMode !== "console" ? (
-                    <>
-                      <label className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
-                        Tail
-                        <Input className={`h-8 w-24 ${inputClass}`} type="number" min="1" max="2000" value={tail} onChange={(event) => setTail(event.target.value)} />
-                      </label>
-                      <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => readLogs()} disabled={state.state !== "idle"} title="Refresh logs">
-                        <RefreshCcw className="h-3.5 w-3.5" />
-                      </Button>
-                    </>
-                  ) : null}
-                  <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openContainerConsole()} disabled={state.state !== "idle"} title="Open live console inside this container">
-                    <TerminalSquare className="h-3.5 w-3.5" />
-                  </Button>
-                  <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openLifecycle("start_container")} disabled={state.state !== "idle"} title="Start container">
-                    <Play className="h-3.5 w-3.5" />
-                  </Button>
-                  <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openLifecycle("stop_container")} disabled={state.state !== "idle"} title="Stop container">
-                    <Square className="h-3.5 w-3.5" />
-                  </Button>
-                  <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openLifecycle("restart_container")} disabled={state.state !== "idle"} title="Restart container">
-                    <RotateCcw className="h-3.5 w-3.5" />
-                  </Button>
-                </div>
-              ) : null}
             </div>
+            {state.error ? (
+              <div className={`border-b px-3 py-2 text-right text-xs text-red-500 ${borderClass}`}>
+                <span className="break-words">{state.error}</span>
+              </div>
+            ) : null}
           </div>
-          {state.error ? (
-            <div className={`border-b px-3 py-2 text-right text-xs text-red-500 ${borderClass}`}>
-              <span className="break-words">{state.error}</span>
-            </div>
-          ) : null}
-          <div className="grid min-h-0 overflow-hidden p-3">
+          <div className="grid h-full min-h-0 grid-rows-[minmax(0,1fr)] overflow-hidden p-3">
             {!selectedResource ? (
               <div className={`grid place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>{resourcePlaceholder(resourceView)}</div>
             ) : resourceView !== "containers" ? (
@@ -361,6 +380,7 @@ export function DockerConnectorConsoleTemplate({ children, target, approvals, th
                 selectedRuntimeTarget={selectedRuntimeTarget}
                 session={session}
                 sessionLive={selectedContainerConsoleLive}
+                pending={pendingConsoleName === expectedConsoleSessionName}
                 theme={theme}
                 mutedClass={mutedClass}
                 borderClass={borderClass}
@@ -417,7 +437,7 @@ export function DockerConnectorConsoleTemplate({ children, target, approvals, th
   );
 }
 
-function DockerContainerConsolePanel({ children, target, container, containerRef, selectedRuntimeTarget, session, sessionLive, theme, mutedClass, borderClass, onStart, onEnd }) {
+function DockerContainerConsolePanel({ children, target, container, containerRef, selectedRuntimeTarget, session, sessionLive, pending, theme, mutedClass, borderClass, onStart, onEnd }) {
   const light = theme === "light";
   if (!container) {
     return (
@@ -439,11 +459,22 @@ function DockerContainerConsolePanel({ children, target, container, containerRef
             End
           </Button>
         </div>
-        <div className="min-h-0 overflow-hidden">{children}</div>
+        <div className="h-full min-h-0 overflow-hidden">{children}</div>
       </div>
     );
   }
   const lastSessionForOtherContainer = session?.id && session?.name !== dockerConsoleSessionName(target, containerRef);
+  if (pending) {
+    return (
+      <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center ${borderClass}`}>
+        <div className="grid max-w-md gap-3">
+          <LoaderCircle className="mx-auto h-6 w-6 animate-spin text-emerald-500" />
+          <h3 className={`text-base font-semibold ${light ? "text-stone-950" : "text-white"}`}>Connecting container console</h3>
+          <p className={`text-sm leading-6 ${mutedClass}`}>Opening an interactive shell inside <span className="font-mono">{containerRef}</span>.</p>
+        </div>
+      </div>
+    );
+  }
   return (
     <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center ${borderClass}`}>
       <div className="grid max-w-md gap-4">

--- a/frontend/src/connectors/templates/kubernetes/console.jsx
+++ b/frontend/src/connectors/templates/kubernetes/console.jsx
@@ -1,0 +1,724 @@
+import { FileJson, LoaderCircle, RefreshCcw, RotateCcw, Search, TerminalSquare, TriangleAlert, XCircle } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "../../../components/ui/badge";
+import { Button } from "../../../components/ui/button";
+import { CopyButton } from "../../../components/ui/copy-button";
+import { Dialog } from "../../../components/ui/dialog";
+import { Input, Select } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+import { TerminalBlock } from "../../../components/ui/terminal-block";
+import { apiPost } from "../../../lib/api";
+
+const resourceTabs = Object.freeze([
+  { key: "workloads", label: "Workloads", action: "list_workloads", output: "workloads" },
+  { key: "pods", label: "Pods", action: "list_pods", output: "pods" },
+  { key: "services", label: "Services", action: "list_services", output: "services" },
+  { key: "ingress", label: "Ingress", action: "list_ingress", output: "ingress" },
+  { key: "nodes", label: "Nodes", action: "list_nodes", output: "nodes" },
+  { key: "events", label: "Events", action: "list_events", output: "events" },
+]);
+
+export function KubernetesConnectorConsoleTemplate({ children, target, approvals, theme, session, selectedSessionLive, selectedRuntimeTarget, onNewLiveSession, onSelectLiveSessionName, onEndLiveSession, onRefreshActivity }) {
+  const [tab, setTab] = useState("workloads");
+  const [namespace, setNamespace] = useState("");
+  const [namespaces, setNamespaces] = useState([]);
+  const [filter, setFilter] = useState("");
+  const [resources, setResources] = useState({});
+  const [selectedKey, setSelectedKey] = useState("");
+  const [detail, setDetail] = useState(null);
+  const [logs, setLogs] = useState("");
+  const [resultSearch, setResultSearch] = useState("");
+  const [viewMode, setViewMode] = useState("details");
+  const [pendingConsoleName, setPendingConsoleName] = useState("");
+  const [state, setState] = useState({ state: "idle", error: "", message: "" });
+  const [confirmRestart, setConfirmRestart] = useState({ open: false, pending: false, workload: null });
+  const panelClass = theme === "light" ? "bg-white text-stone-900" : "bg-[#1e1e1e] text-stone-100";
+  const mutedClass = theme === "light" ? "text-stone-500" : "text-stone-400";
+  const borderClass = theme === "light" ? "border-stone-200" : "border-stone-700";
+  const subtlePanelClass = theme === "light" ? "bg-stone-50" : "bg-[#252526]";
+  const inputClass = theme === "light" ? "border-stone-300 bg-white text-stone-900 placeholder:text-stone-400" : "border-stone-700 bg-[#1a1a1a] text-stone-100 placeholder:text-stone-500";
+  const rowHoverClass = theme === "light" ? "hover:bg-stone-50" : "hover:bg-stone-800/60";
+  const activeRowClass = theme === "light" ? "border-emerald-200 bg-emerald-50 text-emerald-950" : "border-emerald-700 bg-emerald-950/40 text-emerald-100";
+  const activeItems = useMemo(() => (approvals?.data || []).filter((item) => item.target_ref === target.ref), [approvals?.data, target.ref]);
+  const latestAction = activeItems[0] || null;
+  const activeTab = resourceTabs.find((item) => item.key === tab) || resourceTabs[0];
+  const activeResources = resources[tab] || [];
+  const selectedResource = activeResources.find((item) => resourceKey(tab, item) === selectedKey) || null;
+  const expectedConsoleSessionName = selectedResource && tab === "pods" ? kubernetesConsoleSessionName(target, selectedResource) : "";
+  const selectedPodConsoleLive = Boolean(selectedSessionLive && session?.name === expectedConsoleSessionName);
+  const filteredResources = useMemo(() => {
+    const query = filter.trim().toLowerCase();
+    if (!query) return activeResources;
+    return activeResources.filter((item) => resourceSearchValues(tab, item).some((value) => String(value || "").toLowerCase().includes(query)));
+  }, [activeResources, filter, tab]);
+
+  useEffect(() => {
+    setNamespace("");
+    setNamespaces([]);
+    setResources({});
+    setSelectedKey("");
+    setDetail(null);
+    setLogs("");
+    setResultSearch("");
+    setViewMode("details");
+    setFilter("");
+    setTab("workloads");
+  }, [target.ref]);
+
+  useEffect(() => {
+    void refreshNamespaces();
+    void refreshResource("workloads");
+  }, [target.ref]);
+
+  useEffect(() => {
+    if (pendingConsoleName && selectedPodConsoleLive) {
+      setPendingConsoleName("");
+    }
+  }, [pendingConsoleName, selectedPodConsoleLive]);
+
+  async function runKubeAction({ actionName, input = {}, reason, busy = "running" }) {
+    setState({ state: busy, error: "", message: "" });
+    try {
+      const item = await apiPost("/api/connector-actions/local-run", {
+        target_ref: target.ref,
+        action_name: actionName,
+        input,
+        reason,
+      });
+      setState({ state: "idle", error: "", message: item.display_text || "" });
+      await onRefreshActivity?.();
+      return item;
+    } catch (error) {
+      setState({ state: "error", error: error.message || "Kubernetes action failed.", message: "" });
+      throw error;
+    }
+  }
+
+  async function refreshNamespaces() {
+    const item = await runKubeAction({ actionName: "list_namespaces", reason: "manual Kubernetes browser namespace list", busy: "loading" });
+    const next = Array.isArray(item.output?.namespaces) ? item.output.namespaces : [];
+    setNamespaces(next);
+  }
+
+  async function refreshResource(nextTab = tab) {
+    const config = resourceTabs.find((item) => item.key === nextTab) || resourceTabs[0];
+    const input = {};
+    if (!["nodes"].includes(config.key) && namespace) {
+      input.namespace = namespace;
+    }
+    if (config.key === "events") {
+      input.limit = 250;
+    }
+    const item = await runKubeAction({
+      actionName: config.action,
+      input,
+      reason: `manual Kubernetes browser ${config.key} list`,
+      busy: "loading",
+    });
+    const next = Array.isArray(item.output?.[config.output]) ? item.output[config.output] : [];
+    setResources((current) => ({ ...current, [config.key]: next }));
+    setSelectedKey((current) => (current && next.some((entry) => resourceKey(config.key, entry) === current) ? current : ""));
+    if (!next.some((entry) => resourceKey(config.key, entry) === selectedKey)) {
+      setDetail(null);
+      setLogs("");
+    }
+  }
+
+  async function selectResource(resource) {
+    const key = resourceKey(tab, resource);
+    const nextViewMode = tab === "pods" && viewMode === "console" ? "console" : "details";
+    if (selectedKey === key) {
+      setSelectedKey("");
+      setDetail(null);
+      setLogs("");
+      setResultSearch("");
+      setViewMode("details");
+      return;
+    }
+    setSelectedKey(key);
+    setLogs("");
+    setResultSearch("");
+    setViewMode(nextViewMode);
+    if (nextViewMode === "console") {
+      onSelectLiveSessionName?.(kubernetesConsoleSessionName(target, resource));
+    }
+    if (tab === "events") {
+      setDetail({ output: { resource } });
+      return;
+    }
+    if (tab === "nodes") {
+      await describeResource({ resource_type: "node", name: resource.name });
+      return;
+    }
+    if (tab === "workloads") {
+      await describeResource({ resource_type: resourceTypeForWorkload(resource), namespace: resource.namespace, name: resource.name });
+      return;
+    }
+    if (tab === "pods") {
+      await describeResource({ resource_type: "pod", namespace: resource.namespace, name: resource.name });
+      if (nextViewMode === "console") return;
+      try {
+        await readLogs(resource);
+      } catch {
+        // Keep the pod detail visible even when logs are unavailable.
+      }
+      return;
+    }
+    if (tab === "services") {
+      await describeResource({ resource_type: "service", namespace: resource.namespace, name: resource.name });
+      return;
+    }
+    if (tab === "ingress") {
+      await describeResource({ resource_type: "ingress", namespace: resource.namespace, name: resource.name });
+    }
+  }
+
+  async function describeResource(input) {
+    const item = await runKubeAction({ actionName: "describe_resource", input, reason: "manual Kubernetes browser resource detail", busy: "reading" });
+    setDetail(item);
+  }
+
+  async function readLogs(resource = selectedResource) {
+    if (!resource || tab !== "pods") return;
+    const item = await runKubeAction({
+      actionName: "get_logs",
+      input: { namespace: resource.namespace, pod: resource.name, tail: 300 },
+      reason: "manual Kubernetes browser pod logs",
+      busy: "reading",
+    });
+    setLogs(item.output?.logs || item.display_text || "");
+    setViewMode("details");
+  }
+
+  function openPodConsole(resource = selectedResource) {
+    if (!resource || tab !== "pods") return;
+    onSelectLiveSessionName?.(kubernetesConsoleSessionName(target, resource));
+    setViewMode("console");
+    setResultSearch("");
+  }
+
+  async function startPodConsole(resource = selectedResource) {
+    if (!resource || tab !== "pods") return;
+    const sessionName = kubernetesConsoleSessionName(target, resource);
+    setPendingConsoleName(sessionName);
+    onSelectLiveSessionName?.(sessionName);
+    try {
+      await onNewLiveSession?.({
+        name: sessionName,
+        params: { namespace: resource.namespace, pod: resource.name },
+        closeExisting: false,
+      });
+    } catch (error) {
+      setPendingConsoleName("");
+      throw error;
+    }
+  }
+
+  function openRestart(workload = selectedResource) {
+    if (!workload || tab !== "workloads" || workload.kind !== "Deployment") return;
+    setConfirmRestart({ open: true, pending: false, workload });
+  }
+
+  async function confirmRolloutRestart() {
+    const workload = confirmRestart.workload;
+    if (!workload) return;
+    setConfirmRestart((current) => ({ ...current, pending: true }));
+    try {
+      await runKubeAction({
+        actionName: "rollout_restart",
+        input: { namespace: workload.namespace, deployment: workload.name },
+        reason: "manual Kubernetes browser rollout restart",
+        busy: "writing",
+      });
+      setConfirmRestart({ open: false, pending: false, workload: null });
+      await refreshResource("workloads");
+    } catch {
+      setConfirmRestart((current) => ({ ...current, pending: false }));
+    }
+  }
+
+  function switchTab(nextTab) {
+    if (tab === nextTab) return;
+    setTab(nextTab);
+    setSelectedKey("");
+    setDetail(null);
+    setLogs("");
+    setResultSearch("");
+    setViewMode("details");
+    setFilter("");
+    void refreshResource(nextTab);
+  }
+
+  return (
+    <div className={`grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
+      <div className="grid h-full min-h-0 gap-4 overflow-hidden p-4 lg:grid-cols-[380px_minmax(0,1fr)]">
+        <section className={`grid h-full min-h-0 grid-rows-[auto_auto_auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+          <div className={`border-b p-3 ${borderClass}`}>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold">Kubernetes resources</p>
+                <p className={`text-xs ${mutedClass}`}>{filteredResources.length} shown · {activeResources.length} loaded</p>
+              </div>
+              <div className="flex items-center gap-2">
+                {latestAction ? <Badge tone={latestAction.status === "failed" ? "bad" : latestAction.status === "completed" ? "good" : "warn"}>{latestAction.action_name}</Badge> : null}
+                <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Refresh" onClick={() => refreshResource(tab)} disabled={state.state !== "idle"}>
+                  <RefreshCcw className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          </div>
+          <div className={`grid grid-cols-3 gap-1 border-b p-2 ${borderClass}`}>
+            {resourceTabs.map((item) => (
+              <button
+                type="button"
+                key={item.key}
+                className={`rounded-md px-2 py-1.5 text-xs font-semibold transition ${tab === item.key ? "bg-emerald-600 text-white" : theme === "light" ? "text-stone-600 hover:bg-stone-100" : "text-stone-300 hover:bg-stone-800"}`}
+                onClick={() => switchTab(item.key)}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+          <div className={`grid gap-2 border-b p-3 ${borderClass}`}>
+            <Select value={namespace} onChange={(event) => { setNamespace(event.target.value); setSelectedKey(""); setDetail(null); setLogs(""); }}>
+              <option value="">All allowed namespaces</option>
+              {namespaces.map((item) => (
+                <option value={item.name} key={item.name}>
+                  {item.name}
+                </option>
+              ))}
+            </Select>
+            <div className="relative">
+              <Search className={`pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 ${mutedClass}`} />
+              <Input className={`pl-9 ${inputClass}`} value={filter} onChange={(event) => setFilter(event.target.value)} placeholder={`Filter ${activeTab.label.toLowerCase()}`} />
+            </div>
+          </div>
+          <div className="min-h-0 overflow-auto">
+            {filteredResources.map((resource) => (
+              <button
+                key={resourceKey(tab, resource)}
+                type="button"
+                className={`grid w-full gap-1 border-b px-3 py-3 text-left text-sm transition ${borderClass} ${rowHoverClass} ${selectedKey === resourceKey(tab, resource) ? activeRowClass : ""}`}
+                onClick={() => selectResource(resource)}
+              >
+                <span className="flex min-w-0 items-center justify-between gap-3">
+                  <span className="truncate font-semibold" title={resourceTitle(tab, resource)}>{resourceTitle(tab, resource)}</span>
+                  {resourceStatus(tab, resource) ? <Badge tone={resourceTone(tab, resource)}>{resourceStatus(tab, resource)}</Badge> : null}
+                </span>
+                <span className={`truncate text-xs ${mutedClass}`}>{resourceSubtitle(tab, resource)}</span>
+                <span className={`truncate text-xs ${mutedClass}`}>{resourceTertiary(tab, resource)}</span>
+              </button>
+            ))}
+            {filteredResources.length === 0 ? <Notice>{state.state === "loading" ? "Loading Kubernetes resources..." : "No resources found for this filter."}</Notice> : null}
+          </div>
+        </section>
+
+        <section className={`grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass}`}>
+          <div className={`flex flex-wrap items-center justify-between gap-3 border-b p-3 ${borderClass} ${subtlePanelClass}`}>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold">{selectedResource ? resourceTitle(tab, selectedResource) : activeTab.label}</p>
+              <p className={`truncate text-xs ${mutedClass}`}>{selectedResource ? resourceSubtitle(tab, selectedResource) : "Select a resource to inspect details, logs, events, or raw JSON."}</p>
+              <KubernetesHeaderStatus state={state} mutedClass={mutedClass} />
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {selectedResource && tab === "pods" ? (
+                <>
+                  <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={() => readLogs(selectedResource)} disabled={state.state !== "idle"}>
+                    Logs
+                  </Button>
+                  <Button type="button" variant="outline" className="h-8 w-8 px-0" onClick={() => openPodConsole(selectedResource)} disabled={state.state !== "idle"} title="Open live console inside this pod">
+                    <TerminalSquare className="h-3.5 w-3.5" />
+                  </Button>
+                </>
+              ) : null}
+              {selectedResource && tab === "workloads" && selectedResource.kind === "Deployment" ? (
+                <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={() => openRestart(selectedResource)} disabled={state.state !== "idle"}>
+                  <RotateCcw className="h-3.5 w-3.5" />
+                  Restart
+                </Button>
+              ) : null}
+            </div>
+          </div>
+          <div className="grid h-full min-h-0 grid-rows-[minmax(0,1fr)] overflow-hidden p-3">
+            {tab === "pods" && viewMode === "console" ? (
+              <KubernetesPodConsolePanel
+                target={target}
+                pod={selectedResource}
+                selectedRuntimeTarget={selectedRuntimeTarget}
+                session={session}
+                sessionLive={selectedPodConsoleLive}
+                pending={pendingConsoleName === expectedConsoleSessionName || (state.state !== "idle" && !selectedPodConsoleLive)}
+                theme={theme}
+                mutedClass={mutedClass}
+                borderClass={borderClass}
+                onStart={() => startPodConsole(selectedResource)}
+                onEnd={onEndLiveSession}
+              >
+                {children}
+              </KubernetesPodConsolePanel>
+            ) : (
+              <KubernetesResourceDetail
+                tab={tab}
+                resource={selectedResource}
+                detail={detail}
+                logs={logs}
+                search={resultSearch}
+                onSearch={setResultSearch}
+                inputClass={inputClass}
+                mutedClass={mutedClass}
+              />
+            )}
+          </div>
+        </section>
+      </div>
+      <KubernetesFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
+      <Dialog open={confirmRestart.open} onClose={() => setConfirmRestart({ open: false, pending: false, workload: null })} title="Rollout restart deployment" maxWidth="max-w-lg">
+        <div className="grid gap-4">
+          <Notice tone="warn">
+            <TriangleAlert className="mr-2 inline h-4 w-4" />
+            This restarts pods for the selected deployment. Keep this action in Prompt mode unless the workflow is trusted.
+          </Notice>
+          <div className={`rounded-md border p-3 text-sm ${borderClass}`}>
+            <p><span className={mutedClass}>Namespace:</span> {confirmRestart.workload?.namespace}</p>
+            <p><span className={mutedClass}>Deployment:</span> {confirmRestart.workload?.name}</p>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => setConfirmRestart({ open: false, pending: false, workload: null })} disabled={confirmRestart.pending}>Cancel</Button>
+            <Button type="button" onClick={confirmRolloutRestart} disabled={confirmRestart.pending}>
+              {confirmRestart.pending ? "Restarting..." : "Rollout restart"}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    </div>
+  );
+}
+
+function KubernetesResourceDetail({ tab, resource, detail, logs, search, onSearch, inputClass, mutedClass }) {
+  if (!resource) {
+    return (
+      <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${mutedClass}`}>
+        Select a Kubernetes resource to inspect metadata, logs, and raw JSON.
+      </div>
+    );
+  }
+  const rawResource = detail?.output?.resource || detail?.output || resource;
+  const rawValue = JSON.stringify(rawResource || {}, null, 2);
+  const topTitle = kubernetesTopTitle(tab);
+  const topSubtitle = kubernetesTopSubtitle(tab, resource);
+  const topCopyValue = tab === "pods" ? logs : kubernetesMetadataText(tab, resource);
+  const showLogSurface = tab === "pods";
+  return (
+    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,600px)_auto_minmax(0,1fr)] overflow-hidden">
+      <KubernetesResultHeader title={topTitle} subtitle={topSubtitle} copyValue={topCopyValue} search={search} onSearch={onSearch} inputClass={inputClass} searchPlaceholder={tab === "pods" ? "Search logs" : "Search metadata"} />
+      {showLogSurface ? (
+        <TerminalBlock
+          className="h-full min-h-0 max-h-full overflow-auto whitespace-pre text-xs"
+          surface="log"
+          style={{ whiteSpace: "pre", overflowWrap: "normal", wordBreak: "normal" }}
+        >
+          <HighlightedText text={logs || "Click Logs to load bounded pod logs for this pod."} query={search} />
+        </TerminalBlock>
+      ) : (
+        <div className="min-h-0 overflow-auto rounded-md border border-stone-700 bg-[#1a1a1a] p-3">
+          <KubernetesSummaryCards tab={tab} resource={resource} mutedClass={mutedClass} />
+          {tab === "nodes" ? (
+            <p className="mt-3 rounded-md border border-amber-700/50 bg-amber-950/30 p-3 text-xs text-amber-100">
+              Kubernetes nodes do not expose pod-style logs through kubectl logs. Use metadata, conditions, and events for node investigation.
+            </p>
+          ) : null}
+          {tab === "events" && resource.message ? (
+            <TerminalBlock className="mt-3 min-h-32 text-xs" surface="dark">
+              <HighlightedText text={resource.message} query={search} />
+            </TerminalBlock>
+          ) : null}
+        </div>
+      )}
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <FileJson className="h-3.5 w-3.5 text-stone-500" />
+          <p className="truncate text-xs font-semibold uppercase tracking-wide text-stone-500">Kubernetes raw data</p>
+        </div>
+        <div className="flex min-w-0 items-center justify-end gap-2">
+          <Input className={`h-8 w-56 text-xs ${inputClass || ""}`} value={search} onChange={(event) => onSearch?.(event.target.value)} placeholder="Search raw data" />
+          <CopyButton value={rawValue} variant="outline" className="h-8 px-2 text-xs" />
+        </div>
+      </div>
+      <div className="mt-2 grid h-full min-h-0 overflow-hidden">
+        <TerminalBlock className="h-full min-h-0 whitespace-pre-wrap break-words text-xs [overflow-wrap:anywhere]" surface="dark">
+          <HighlightedText text={rawValue} query={search} />
+        </TerminalBlock>
+      </div>
+    </div>
+  );
+}
+
+function KubernetesPodConsolePanel({ children, target, pod, selectedRuntimeTarget, session, sessionLive, pending, theme, mutedClass, borderClass, onStart, onEnd }) {
+  const light = theme === "light";
+  if (!pod) {
+    return (
+      <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center text-sm ${borderClass} ${mutedClass}`}>
+        Select a pod, then open a live console inside it.
+      </div>
+    );
+  }
+  const podRef = `${pod.namespace}/${pod.name}`;
+  if (sessionLive) {
+    return (
+      <div className={`grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass}`}>
+        <div className={`flex min-w-0 items-center justify-between gap-3 border-b px-3 py-2 ${borderClass}`}>
+          <div className="min-w-0">
+            <p className="truncate text-xs font-semibold uppercase tracking-wide text-stone-500">Pod console</p>
+            <p className="truncate font-mono text-xs">{podRef}</p>
+          </div>
+          <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={onEnd} title="Close this pod console session">
+            <XCircle className="h-3.5 w-3.5" />
+            End
+          </Button>
+        </div>
+        <div className="h-full min-h-0 overflow-hidden">{children}</div>
+      </div>
+    );
+  }
+  const expectedName = kubernetesConsoleSessionName(target, pod);
+  if (pending) {
+    return (
+      <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center ${borderClass}`}>
+        <div className="grid max-w-md gap-3">
+          <LoaderCircle className="mx-auto h-6 w-6 animate-spin text-emerald-500" />
+          <h3 className={`text-base font-semibold ${light ? "text-stone-950" : "text-white"}`}>Connecting pod console</h3>
+          <p className={`text-sm leading-6 ${mutedClass}`}>Opening an interactive shell inside <span className="font-mono">{podRef}</span>.</p>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className={`grid h-full min-h-0 place-items-center rounded-lg border border-dashed p-8 text-center ${borderClass}`}>
+      <div className="grid max-w-md gap-4">
+        <div className={`mx-auto flex h-12 w-12 items-center justify-center rounded-full border ${light ? "border-stone-200 bg-stone-100" : "border-stone-600 bg-stone-800"}`}>
+          <TerminalSquare className={`h-6 w-6 ${light ? "text-stone-600" : "text-stone-300"}`} />
+        </div>
+        <div className="grid gap-2">
+          <h3 className={`text-base font-semibold ${light ? "text-stone-950" : "text-white"}`}>No active pod console</h3>
+          <p className={`text-sm leading-6 ${mutedClass}`}>
+            Start an interactive shell inside <span className="font-mono">{podRef}</span>. It uses the same live terminal as SSH and Docker consoles.
+          </p>
+          {!selectedRuntimeTarget ? <p className="text-xs text-red-500">This Kubernetes profile does not have a live runtime surface yet. Save the connector once, then retry.</p> : null}
+        </div>
+        <Button type="button" className="mx-auto" onClick={onStart} disabled={!selectedRuntimeTarget}>
+          <RefreshCcw className="h-4 w-4" />
+          Start Pod Console
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function kubernetesConsoleSessionName(target, pod) {
+  return `kubernetes:${target?.ref || "target"}:${pod?.namespace || "namespace"}:${pod?.name || "pod"}`;
+}
+
+function KubernetesHeaderStatus({ state, mutedClass }) {
+  if (state.state !== "idle" && state.state !== "error") {
+    return (
+      <p className="mt-1 flex min-h-4 items-center gap-1 truncate text-[11px] text-amber-500">
+        <LoaderCircle className="h-3 w-3 shrink-0 animate-spin" />
+        <span className="truncate">{state.state}</span>
+      </p>
+    );
+  }
+  if (state.state === "error" && state.error) {
+    return <p className="mt-1 min-h-4 truncate text-[11px] text-red-500">{state.error}</p>;
+  }
+  return <p className={`mt-1 min-h-4 text-[11px] ${mutedClass}`}>&nbsp;</p>;
+}
+
+function KubernetesResultHeader({ title, subtitle, copyValue, search, onSearch, inputClass, searchPlaceholder }) {
+  return (
+    <div className="mb-2 flex items-center justify-between gap-3">
+      <div className="min-w-0">
+        <p className="truncate text-xs font-semibold uppercase tracking-wide text-stone-500">{title}</p>
+        {subtitle ? <p className="truncate text-xs text-stone-500">{subtitle}</p> : null}
+      </div>
+      <div className="flex min-w-0 items-center justify-end gap-2">
+        <Input className={`h-8 w-56 text-xs ${inputClass || ""}`} value={search} onChange={(event) => onSearch?.(event.target.value)} placeholder={searchPlaceholder || "Search"} />
+        {copyValue ? <CopyButton value={copyValue} variant="outline" className="h-8 px-2 text-xs" /> : null}
+      </div>
+    </div>
+  );
+}
+
+function HighlightedText({ text, query }) {
+  const value = String(text || "");
+  const needle = String(query || "");
+  if (!needle.trim()) return value;
+  const lowerValue = value.toLowerCase();
+  const lowerNeedle = needle.toLowerCase();
+  const parts = [];
+  let index = 0;
+  let matchIndex = lowerValue.indexOf(lowerNeedle, index);
+  let key = 0;
+  while (matchIndex !== -1) {
+    if (matchIndex > index) parts.push(value.slice(index, matchIndex));
+    parts.push(
+      <mark key={`m-${key++}`} className="rounded bg-yellow-300 px-0.5 text-stone-950">
+        {value.slice(matchIndex, matchIndex + needle.length)}
+      </mark>
+    );
+    index = matchIndex + needle.length;
+    matchIndex = lowerValue.indexOf(lowerNeedle, index);
+  }
+  if (index < value.length) parts.push(value.slice(index));
+  return parts;
+}
+
+function kubernetesTopTitle(tab) {
+  if (tab === "pods") return "Pod logs";
+  if (tab === "nodes") return "Node metadata";
+  if (tab === "events") return "Event details";
+  return "Resource metadata";
+}
+
+function kubernetesTopSubtitle(tab, resource) {
+  if (!resource) return "";
+  if (tab === "pods") return `${resource.namespace}/${resource.name}`;
+  if (tab === "nodes") return "Node logs are not available through kubectl logs.";
+  if (tab === "events") return `${resource.namespace || "-"} · ${resource.object || "-"}`;
+  return resourceSubtitle(tab, resource);
+}
+
+function kubernetesMetadataText(tab, resource) {
+  return summaryRows(tab, resource)
+    .map((row) => `${row.label}: ${row.value || "-"}`)
+    .join("\n");
+}
+
+function KubernetesSummaryCards({ tab, resource, detail, mutedClass }) {
+  if (!resource) {
+    return <p className={`text-sm ${mutedClass}`}>No resource selected.</p>;
+  }
+  const rows = summaryRows(tab, resource, detail);
+  return (
+    <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+      {rows.map((row) => (
+        <div key={row.label} className="rounded-md border border-stone-700/40 p-2">
+          <p className={`text-[11px] uppercase ${mutedClass}`}>{row.label}</p>
+          <p className="truncate text-sm font-semibold" title={String(row.value || "-")}>{row.value || "-"}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function KubernetesFooter({ target, borderClass, mutedClass }) {
+  return (
+    <div className={`flex min-h-9 items-center justify-between border-t px-4 py-2 text-xs ${borderClass} ${mutedClass}`}>
+      <span>Kubernetes transport</span>
+      <span className="font-mono">{target.config?.transport_target_ref || "no transport"}</span>
+    </div>
+  );
+}
+
+function summaryRows(tab, resource) {
+  if (tab === "workloads") return [
+    { label: "Kind", value: resource.kind },
+    { label: "Namespace", value: resource.namespace },
+    { label: "Ready", value: resource.ready },
+    { label: "Image", value: resource.image },
+  ];
+  if (tab === "pods") return [
+    { label: "Namespace", value: resource.namespace },
+    { label: "Phase", value: resource.phase },
+    { label: "Ready", value: resource.ready },
+    { label: "Restarts", value: resource.restarts },
+  ];
+  if (tab === "services") return [
+    { label: "Namespace", value: resource.namespace },
+    { label: "Type", value: resource.type },
+    { label: "Cluster IP", value: resource.cluster_ip },
+    { label: "Ports", value: resource.ports },
+  ];
+  if (tab === "ingress") return [
+    { label: "Namespace", value: resource.namespace },
+    { label: "Class", value: resource.class },
+    { label: "Hosts", value: resource.hosts },
+    { label: "Age", value: resource.age },
+  ];
+  if (tab === "nodes") return [
+    { label: "Name", value: resource.name },
+    { label: "Ready", value: resource.ready },
+    { label: "Roles", value: resource.roles },
+    { label: "Version", value: resource.version },
+  ];
+  return [
+    { label: "Type", value: resource.type },
+    { label: "Reason", value: resource.reason },
+    { label: "Object", value: resource.object },
+    { label: "Count", value: resource.count },
+  ];
+}
+
+function resourceKey(tab, item) {
+  if (!item) return "";
+  if (tab === "nodes") return item.name || "";
+  return `${item.namespace || ""}/${item.kind || tab}/${item.name || item.reason || item.message || ""}`;
+}
+
+function resourceTitle(tab, item) {
+  if (!item) return "";
+  if (tab === "events") return `${item.type || "Event"} ${item.reason || ""}`.trim();
+  if (tab === "workloads") return `${item.namespace}/${item.kind}/${item.name}`;
+  if (tab === "pods") return item.node || item.name;
+  if (tab === "nodes") return item.name;
+  return `${item.namespace}/${item.name}`;
+}
+
+function resourceSubtitle(tab, item) {
+  if (!item) return "";
+  if (tab === "workloads") return `ready ${item.ready || "-"} · image ${item.image || "-"}`;
+  if (tab === "pods") return `${item.namespace}/${item.name}`;
+  if (tab === "services") return `${item.type || "-"} · ${item.cluster_ip || "-"} · ${item.ports || "no ports"}`;
+  if (tab === "ingress") return `${item.hosts || "no hosts"} · ${item.class || "no class"}`;
+  if (tab === "nodes") return `ready ${item.ready || "-"} · ${item.roles || "-"} · ${item.version || "-"}`;
+  return `${item.namespace || "-"} · ${item.object || "-"} · ${item.message || ""}`;
+}
+
+function resourceTertiary(tab, item) {
+  if (!item) return "";
+  if (tab === "pods") return `ready ${item.ready || "-"} · restarts ${item.restarts || 0} · ${item.phase || "-"}`;
+  if (tab === "workloads") return `${item.namespace || "-"} · age ${item.age || "-"}`;
+  if (tab === "services") return `age ${item.age || "-"} · external ${item.external_ip || "-"}`;
+  if (tab === "ingress") return `namespace ${item.namespace || "-"} · age ${item.age || "-"}`;
+  if (tab === "nodes") return `age ${item.age || "-"} · status ${item.ready || "-"}`;
+  return item.message || "";
+}
+
+function resourceStatus(tab, item) {
+  if (!item) return "";
+  if (tab === "pods") return item.phase || "";
+  if (tab === "workloads") return item.ready || "";
+  if (tab === "services") return item.type || "";
+  if (tab === "nodes") return item.ready || "";
+  if (tab === "events") return item.type || "";
+  return "";
+}
+
+function resourceTone(tab, item) {
+  const value = String(resourceStatus(tab, item)).toLowerCase();
+  if (tab === "events" && value === "warning") return "warn";
+  if (value.includes("running") || value.includes("ready") || value.match(/^\d+\/\d+$/)) return "good";
+  if (value.includes("pending") || value.includes("unknown")) return "warn";
+  if (value.includes("failed") || value.includes("error") || value.includes("crash")) return "bad";
+  return "neutral";
+}
+
+function resourceSearchValues(tab, item) {
+  return [resourceTitle(tab, item), resourceSubtitle(tab, item), resourceTertiary(tab, item), item.namespace, item.name, item.kind, item.reason, item.message, item.hosts, item.image, item.node];
+}
+
+function resourceTypeForWorkload(resource) {
+  const kind = String(resource?.kind || "").toLowerCase();
+  if (kind === "statefulset") return "statefulset";
+  if (kind === "daemonset") return "daemonset";
+  return "deployment";
+}

--- a/frontend/src/connectors/templates/kubernetes/credential-form.jsx
+++ b/frontend/src/connectors/templates/kubernetes/credential-form.jsx
@@ -1,0 +1,65 @@
+import { Server, Plus } from "lucide-react";
+import { Button } from "../../../components/ui/button";
+import { Field, Input, Select, Textarea } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+
+export function KubernetesCredentialFormTemplate({ targets, form, formMode = "create", state, onChange, onSubmit }) {
+  const kubernetesTargets = targets.filter((target) => target.connector_kind === "kubernetes");
+  const editing = formMode === "edit";
+  return (
+    <form className="grid gap-4" onSubmit={onSubmit}>
+      {kubernetesTargets.length === 0 ? (
+        <Notice tone="warn">Create a Kubernetes connector target before adding a namespace scope.</Notice>
+      ) : (
+        <Notice tone="good">
+          {editing ? "Update this Kubernetes namespace scope. Token permissions bound to this profile will use the new scope immediately." : "Create a namespace scope, then bind tokens to this profile from Console or Tokens."}
+        </Notice>
+      )}
+      <Field>
+        Connector target
+        <Select value={form.target_id} onChange={(event) => onChange({ ...form, target_id: event.target.value })} disabled={editing} required>
+          <option value="" disabled>
+            Select Kubernetes target
+          </option>
+          {kubernetesTargets.map((target) => (
+            <option value={target.id} key={target.id}>
+              {target.name} · {target.config?.transport_target_ref || "no transport"}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange({ ...form, profile_label: event.target.value })} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange({ ...form, risk_label: event.target.value })} />
+        </Field>
+      </div>
+      <Field>
+        Namespace scope
+        <Select value={form.scope_mode} onChange={(event) => onChange({ ...form, scope_mode: event.target.value })}>
+          <option value="all">All namespaces</option>
+          <option value="selected">Selected namespaces</option>
+        </Select>
+      </Field>
+      {form.scope_mode === "selected" ? (
+        <Field>
+          Namespaces
+          <Textarea rows={6} value={form.namespaces} onChange={(event) => onChange({ ...form, namespaces: event.target.value })} placeholder={"production\nmonitoring\nbackend"} />
+        </Field>
+      ) : null}
+      {state.state === "error" ? <Notice tone="bad">{state.error}</Notice> : null}
+      <Button type="submit" disabled={state.state === "saving" || kubernetesTargets.length === 0}>
+        <Plus className="h-4 w-4" />
+        {state.state === "saving" ? "Saving..." : editing ? "Save namespace scope" : "Create namespace scope"}
+      </Button>
+      <Notice>
+        <Server className="mr-2 inline h-4 w-4" />
+        Namespace scopes contain public allowlists only. Kubernetes auth still comes from the selected remote kubectl environment.
+      </Notice>
+    </form>
+  );
+}

--- a/frontend/src/connectors/templates/kubernetes/form.jsx
+++ b/frontend/src/connectors/templates/kubernetes/form.jsx
@@ -1,0 +1,81 @@
+import { Field, Input, Select, Textarea } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+
+export function KubernetesConnectorFormTemplate({ form, targets = [], onChange }) {
+  const sshProfiles = sshProfileOptions(targets);
+  return (
+    <>
+      <Notice tone="good">
+        Kubernetes uses bounded kubectl templates over an SSH connector profile. Start with read-only actions and keep rollout restart in Prompt mode.
+      </Notice>
+      <Field>
+        Connector name
+        <Input value={form.name} onChange={(event) => onChange("name", event.target.value)} required />
+      </Field>
+      <Field>
+        SSH transport profile
+        <Select value={form.transport_target_ref} onChange={(event) => onChange("transport_target_ref", event.target.value)} required>
+          <option value="" disabled>
+            Select SSH profile
+          </option>
+          {sshProfiles.map((profile) => (
+            <option value={profile.ref} key={profile.ref}>
+              {profile.label}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Field>
+          kubectl command
+          <Input value={form.kubectl_command} onChange={(event) => onChange("kubectl_command", event.target.value)} required />
+        </Field>
+        <Field>
+          Context
+          <Input value={form.context} onChange={(event) => onChange("context", event.target.value)} placeholder="optional" />
+        </Field>
+        <Field>
+          Default namespace
+          <Input value={form.default_namespace} onChange={(event) => onChange("default_namespace", event.target.value)} placeholder="optional" />
+        </Field>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange("profile_label", event.target.value)} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange("risk_label", event.target.value)} />
+        </Field>
+      </div>
+      <Field>
+        Namespace scope
+        <Select value={form.scope_mode} onChange={(event) => onChange("scope_mode", event.target.value)}>
+          <option value="all">All namespaces</option>
+          <option value="selected">Selected namespaces</option>
+        </Select>
+      </Field>
+      {form.scope_mode === "selected" ? (
+        <Field>
+          Namespaces
+          <Textarea rows={5} value={form.namespaces} onChange={(event) => onChange("namespaces", event.target.value)} placeholder={"production\nmonitoring"} />
+        </Field>
+      ) : null}
+      <Notice>
+        AIPermission does not import kubeconfig or service-account tokens in this MVP. The selected SSH profile must reach a host where kubectl is already configured.
+      </Notice>
+    </>
+  );
+}
+
+function sshProfileOptions(targets) {
+  return (targets || [])
+    .filter((target) => target.connector_kind === "ssh")
+    .flatMap((target) =>
+      (target.profiles || []).map((profile) => ({
+        ref: profile.ref || `${target.connector_kind}:${target.id}:${profile.id}`,
+        label: `${target.name} / ${profile.label} · ${target.config?.host || "host"}:${target.config?.port || 22}`,
+      }))
+    );
+}

--- a/frontend/src/connectors/templates/kubernetes/index.jsx
+++ b/frontend/src/connectors/templates/kubernetes/index.jsx
@@ -1,0 +1,15 @@
+import { KubernetesConnectorConsoleTemplate } from "./console";
+import { KubernetesCredentialFormTemplate } from "./credential-form";
+import { KubernetesConnectorFormTemplate } from "./form";
+import { KubernetesConnectorRowActionsTemplate } from "./list-item";
+import { KubernetesConnectorOperationsTemplate } from "./operations";
+import * as model from "./model";
+
+export default Object.freeze({
+  Console: KubernetesConnectorConsoleTemplate,
+  CredentialForm: KubernetesCredentialFormTemplate,
+  Form: KubernetesConnectorFormTemplate,
+  model,
+  Operations: KubernetesConnectorOperationsTemplate,
+  RowActions: KubernetesConnectorRowActionsTemplate,
+});

--- a/frontend/src/connectors/templates/kubernetes/list-item.jsx
+++ b/frontend/src/connectors/templates/kubernetes/list-item.jsx
@@ -1,0 +1,3 @@
+export function KubernetesConnectorRowActionsTemplate() {
+  return null;
+}

--- a/frontend/src/connectors/templates/kubernetes/metadata.json
+++ b/frontend/src/connectors/templates/kubernetes/metadata.json
@@ -1,0 +1,8 @@
+{
+  "kind": "kubernetes",
+  "label": "Kubernetes",
+  "summary": "Read-heavy Kubernetes cluster browser with bounded logs and prompt-only rollout restart.",
+  "version": "0.2",
+  "icon": "server",
+  "badge_tone": "neutral"
+}

--- a/frontend/src/connectors/templates/kubernetes/model.js
+++ b/frontend/src/connectors/templates/kubernetes/model.js
@@ -1,0 +1,290 @@
+import { apiDelete, apiPost, apiPut } from "../../../lib/api";
+import { createTargetWithProfile, updateTargetWithProfile } from "../target-profile-save";
+
+const emptyKubernetesCredentialForm = { target_id: "", profile_label: "all-namespaces", scope_mode: "all", namespaces: "", risk_label: "cluster visibility" };
+
+export function emptyForm() {
+  return {
+    connector_kind: "kubernetes",
+    name: "kubernetes",
+    connection_mode: "over_ssh",
+    transport_target_ref: "",
+    kubectl_command: "kubectl",
+    context: "",
+    default_namespace: "",
+    profile_label: "all-namespaces",
+    scope_mode: "all",
+    namespaces: "",
+    risk_label: "cluster visibility",
+  };
+}
+
+export function formFromTarget({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : {});
+  return {
+    connector_kind: "kubernetes",
+    profile_id: selectedProfile.id ? String(selectedProfile.id) : "",
+    name: target.name || "",
+    connection_mode: target.config?.connection_mode || "over_ssh",
+    transport_target_ref: target.config?.transport_target_ref || "",
+    kubectl_command: target.config?.kubectl_command || "kubectl",
+    context: target.config?.context || "",
+    default_namespace: target.config?.default_namespace || "",
+    profile_label: selectedProfile.label || "all-namespaces",
+    scope_mode: selectedProfile.public?.scope_mode || "all",
+    namespaces: selectedProfile.public?.namespaces || "",
+    risk_label: selectedProfile.risk_label || "cluster visibility",
+  };
+}
+
+export function activeCredential() {
+  return null;
+}
+
+export function syncForm({ form }) {
+  if (form.connector_kind !== "kubernetes") return form;
+  return { ...form, connection_mode: "over_ssh", kubectl_command: form.kubectl_command || "kubectl" };
+}
+
+export function submitDisabled({ state, form }) {
+  return state.state === "saving" || !form.transport_target_ref;
+}
+
+export function submitLabel({ state, mode }) {
+  if (state.state === "saving") return "Saving...";
+  return mode === "edit" ? "Save changes" : "Create connector";
+}
+
+export async function save({ mode, form, target }) {
+  if (mode === "edit") {
+    await updateTarget({ form, target });
+    return;
+  }
+  await createTarget({ form });
+}
+
+export async function deleteTarget({ target }) {
+  await apiDelete(`/api/connector-targets/${target.id}`);
+}
+
+export function emptyCredentialState({ targets = [] } = {}) {
+  const firstTarget = targets.find((target) => target.connector_kind === "kubernetes");
+  return {
+    form: {
+      ...emptyKubernetesCredentialForm,
+      target_id: String(firstTarget?.id || ""),
+    },
+  };
+}
+
+export function credentialStateFromRow({ row }) {
+  return {
+    form: {
+      target_id: String(row.target_id || ""),
+      profile_label: row.name,
+      scope_mode: row.profile?.public?.scope_mode || "all",
+      namespaces: row.profile?.public?.namespaces || "",
+      risk_label: row.profile?.risk_label || "",
+    },
+  };
+}
+
+export function credentialFormProps({ targets, formState, setFormState, formMode, state, onSubmit }) {
+  return {
+    form: formState.form,
+    formMode,
+    targets,
+    state,
+    onChange: (form) => setFormState({ form }),
+    onSubmit: (event) => onSubmit(event, formMode === "edit" ? "update" : "create"),
+  };
+}
+
+export async function saveCredential({ operation, row, formState }) {
+  const form = formState.form;
+  const payload = {
+    kind: "namespace_scope",
+    label: form.profile_label,
+    public: {
+      scope_mode: form.scope_mode || "all",
+      namespaces: form.namespaces || "",
+    },
+    secret: {},
+    risk_label: form.risk_label,
+  };
+  if (operation === "create") {
+    await apiPost(`/api/connector-targets/${form.target_id}/profiles`, payload);
+    return { message: "Kubernetes namespace scope created." };
+  }
+  if (operation === "update") {
+    if (!row) throw new Error("Kubernetes namespace scope is not loaded.");
+    await apiPut(`/api/connector-targets/${form.target_id}/profiles/${row.id}`, payload);
+    return { message: "Kubernetes namespace scope updated." };
+  }
+  throw new Error("Unsupported Kubernetes credential operation.");
+}
+
+export async function deleteCredential({ row }) {
+  await apiDelete(`/api/connector-targets/${row.target_id}/profiles/${row.id}`);
+}
+
+export function credentialRows({ targets }) {
+  return targets.flatMap((target) =>
+    (target.profiles || [])
+      .filter((profile) => target.connector_kind === "kubernetes")
+      .map((profile) => ({
+        row_id: `${target.connector_kind}:${target.id}:${profile.id}`,
+        connector_kind: target.connector_kind,
+        resource_kind: "credential_profile",
+        connector_label: "Kubernetes",
+        id: profile.id,
+        target_id: target.id,
+        name: profile.label,
+        kind: profile.kind,
+        profile,
+        target_label: target.name,
+        target_detail: targetEndpoint({ target }),
+        metadata: credentialMetadata(profile),
+        delete_disabled: "",
+      }))
+  );
+}
+
+export async function test({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!selectedProfile) throw new Error("Kubernetes profile is not loaded.");
+  const data = await apiPost(`/api/connector-targets/${target.id}/profiles/${selectedProfile.id}/test`, {});
+  return { ok: data.ok, error: data.message || null, data };
+}
+
+export function canEdit() {
+  return true;
+}
+
+export function canDelete() {
+  return true;
+}
+
+export function credentialHint() {
+  return null;
+}
+
+export function targetEndpoint({ target }) {
+  const profile = target.config?.transport_target_ref || "no transport";
+  const context = target.config?.context ? ` · context ${target.config.context}` : "";
+  const namespace = target.config?.default_namespace ? ` · ns ${target.config.default_namespace}` : "";
+  return `${target.config?.kubectl_command || "kubectl"} · ${profile}${context}${namespace}`;
+}
+
+export function targetDisplayName({ target }) {
+  if (!target) return "Kubernetes target";
+  return target.target_name || target.name || "Kubernetes target";
+}
+
+export function targetSubtitle({ target }) {
+  return targetEndpoint({ target });
+}
+
+export function targetProfileLabel({ target }) {
+  return target?.profile_label || "namespace scope";
+}
+
+export function usesLiveConsole() {
+  return true;
+}
+
+export function liveConsoleRuntimeTarget({ target }) {
+  return {
+    id: target.runtime_id,
+    name: targetDisplayName({ target }),
+    host: target.config?.transport_target_ref || "",
+    port: 0,
+    username: target.profile_label || "",
+    description: "Kubernetes pod console",
+    connector_ref: target.ref,
+    connector_kind: target.connector_kind,
+    target_id: target.target_id,
+    profile_id: target.profile_id,
+    target,
+  };
+}
+
+export function deleteDialog({ target }) {
+  return {
+    title: target ? `Delete ${target.name}` : "Delete connector",
+    description: "Remove this Kubernetes connector target, namespace scopes, and token action permissions from aipermission.",
+    details: [
+      { label: "Connector", value: target?.name },
+      { label: "Reference", value: target ? `${target.connector_kind}:${target.id}` : "" },
+    ],
+    notice: "This removes the connector target and its local permission metadata. It does not change the Kubernetes cluster.",
+    actions: [
+      { label: "Cancel", action: "close", variant: "outline" },
+      { label: "Delete connector", pendingLabel: "Deleting...", removeKey: false },
+    ],
+  };
+}
+
+async function createTarget({ form }) {
+  await createTargetWithProfile({
+    targetPayload: {
+      connector_kind: "kubernetes",
+      name: form.name,
+      config: kubernetesTargetConfigFromForm(form),
+    },
+    profilePayload: kubernetesProfilePayloadFromForm(form),
+  });
+}
+
+async function updateTarget({ form, target }) {
+  const profile = target?.profiles?.find((item) => Number(item.id) === Number(form.profile_id)) || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!target || !profile) throw new Error("Kubernetes connector profile is not loaded.");
+  await updateTargetWithProfile({
+    targetID: target.id,
+    profileID: profile.id,
+    targetPayload: {
+      name: form.name,
+      config: kubernetesTargetConfigFromForm(form),
+    },
+    profilePayload: kubernetesProfilePayloadFromForm(form, profile.kind || "namespace_scope"),
+  });
+}
+
+function kubernetesTargetConfigFromForm(form) {
+  return {
+    connection_mode: "over_ssh",
+    transport_target_ref: form.transport_target_ref || "",
+    kubectl_command: form.kubectl_command || "kubectl",
+    context: form.context || "",
+    default_namespace: form.default_namespace || "",
+  };
+}
+
+function kubernetesProfilePayloadFromForm(form, kind = "namespace_scope") {
+  return {
+    kind,
+    label: form.profile_label,
+    public: {
+      scope_mode: form.scope_mode || "all",
+      namespaces: form.namespaces || "",
+    },
+    secret: {},
+    risk_label: form.risk_label || "cluster visibility",
+  };
+}
+
+function credentialMetadata(profile) {
+  const scope = profile.public?.scope_mode === "selected" ? "selected namespaces" : "all namespaces";
+  const namespaces = splitLines(profile.public?.namespaces || "");
+  const items = [`scope: ${scope}`];
+  if (namespaces.length > 0) items.push(`namespaces: ${namespaces.slice(0, 3).join(", ")}${namespaces.length > 3 ? ` +${namespaces.length - 3}` : ""}`);
+  if (profile.risk_label) items.push(`risk: ${profile.risk_label}`);
+  return items;
+}
+
+function splitLines(value) {
+  return String(value || "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}

--- a/frontend/src/connectors/templates/kubernetes/operations.jsx
+++ b/frontend/src/connectors/templates/kubernetes/operations.jsx
@@ -1,0 +1,3 @@
+export function KubernetesConnectorOperationsTemplate() {
+  return null;
+}

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -236,7 +236,9 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.9"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.10"/);
+  assert.match(releaseSource, /Kubernetes connector/);
+  assert.match(releaseSource, /Kubernetes is now a built-in connector/);
   assert.match(releaseSource, /Docker inventory and images/);
   assert.match(releaseSource, /Docker connector actions now include scoped image/);
   assert.match(releaseSource, /Maintenance and backup providers/);

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,35 @@
-export const appVersion = "0.2.9";
+export const appVersion = "0.2.10";
 
 export const changelogEntries = [
+  {
+    version: "0.2.10",
+    label: "Kubernetes connector",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Kubernetes is now a built-in connector that runs bounded kubectl templates through an SSH transport profile.",
+          "Kubernetes Console adds resource tabs for workloads, pods, services, ingress, nodes, and events with namespace filtering.",
+          "Kubernetes MCP actions cover cluster version, resource lists, resource describe, bounded pod log tails, and explicit rollout restart.",
+          "Pod console sessions reuse the same live terminal component as SSH and Docker console for one selected pod/container.",
+        ],
+      },
+      {
+        title: "Fixed",
+        items: [
+          "Manual command history now completes for Kubernetes/BusyBox-style prompts such as / # and /app $.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "Kubernetes does not expose raw kubectl, manifest apply/edit/delete, pod deletion, scaling, or Secret value browsing.",
+          "Kubernetes profiles scope access by namespace visibility, and pod logs remain bounded by requested tail limits.",
+          "rollout_restart is the only Kubernetes write action in this release and still follows token/action permissions and approval policy.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.9",
     label: "Docker inventory and images",

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -22,7 +22,7 @@ import { MessagesDialog } from "../components/console/messages-dialog";
 import { NoLiveSession } from "../components/console/no-live-session";
 import { PtyConsole } from "../components/console/pty-console";
 import { TokenPermissionPanel } from "../components/console/token-permission-panel";
-import { emptySession, isUnreadMessage, latestSessionForRuntime } from "../components/console/helpers";
+import { emptySession, isLiveConsoleSession, isUnreadMessage, latestSessionForRuntime } from "../components/console/helpers";
 import { useConsolePageState } from "../components/console/use-console-page-state";
 import { ConnectorIcon } from "../connectors/templates/common";
 import { ConnectorTemplateNotFound, getConnectorModel, getConnectorTemplate } from "../connectors/templates/registry";
@@ -74,6 +74,7 @@ export function ConsolePage() {
   const [now, setNow] = useState(Date.now());
   const [structuredSessionsByTarget, setStructuredSessionsByTarget] = useState({});
   const [selectedProfileByTarget, setSelectedProfileByTarget] = useState({});
+  const [liveSessionNameByTarget, setLiveSessionNameByTarget] = useState({});
 
   const selectedTargetRef = searchParams.get("target");
   const sessions = consoleSessions.data || [];
@@ -105,8 +106,7 @@ export function ConsolePage() {
   const selectedStructuredSession = selectedTarget && !selectedTargetUsesLiveConsole ? structuredSessionsByTarget[selectedTarget.ref] || null : null;
   const {
     selectedRuntimeTarget,
-    selectedSession,
-    selectedSessionLive,
+    selectedSession: runtimeSelectedSession,
     unreadMessages,
     selectedUnreadMessages,
   } = useConsolePageState({
@@ -116,6 +116,12 @@ export function ConsolePage() {
     selectedRuntimeID,
     allowTargetFallback: false,
   });
+  const selectedLiveSessionName = selectedTarget?.ref ? liveSessionNameByTarget[selectedTarget.ref] || "" : "";
+  const selectedNamedLiveSession = selectedRuntimeTarget && selectedLiveSessionName
+    ? sessions.find((session) => Number(session.runtime_id) === Number(selectedRuntimeTarget.id) && session.name === selectedLiveSessionName)
+    : null;
+  const selectedSession = selectedNamedLiveSession || runtimeSelectedSession;
+  const selectedSessionLive = isLiveConsoleSession(selectedSession);
   const selectedTargetProfiles = useMemo(() => profilesForConnectorTarget(targetItems, selectedTarget), [targetItems, selectedTarget?.connector_kind, selectedTarget?.target_id]);
   const targetRows = useMemo(() => consoleTargetRows(targetItems, selectedTarget, selectedProfileByTarget), [targetItems, selectedTarget?.ref, selectedProfileByTarget]);
   const selectedTokenOptions = useMemo(() => {
@@ -146,8 +152,8 @@ export function ConsolePage() {
     .filter((permission) => permission?.expires_at)
     .map((permission) => permissionLifetimeLabel(permission, now));
   const showAlwaysRunWarning = Boolean(mcpRuntime?.data?.enabled && selectedTarget && alwaysRunTokenPermissions.length > 0);
-  const selectedRunningConnectorRequests = selectedTargetUsesLiveConsole && selectedTarget
-    ? connectorActionApprovals.data.filter((approval) => approval.status === "running" && approval.target_ref === selectedTarget.ref)
+  const selectedRunningConnectorRequests = selectedTargetUsesLiveConsole && selectedTarget?.connector_kind === "ssh"
+    ? connectorActionApprovals.data.filter((approval) => approval.status === "running" && approval.target_ref === selectedTarget.ref && approval.action_name === "exec")
     : [];
   const selectedRunningRequest = selectedRunningConnectorRequests[0] || null;
   const consoleBannerCount = (showAlwaysRunWarning ? 1 : 0) + (selectedRunningRequest ? 1 : 0) + (newSessionError ? 1 : 0);
@@ -377,6 +383,9 @@ export function ConsolePage() {
   async function startNewConsoleSession(runtimeTarget, options = {}) {
     if (!runtimeTarget) return;
     setNewSessionError("");
+    if (options.name && selectedTarget?.ref) {
+      setLiveSessionNameByTarget((current) => ({ ...current, [selectedTarget.ref]: options.name }));
+    }
     try {
       await newConsoleSession(runtimeTarget, options);
     } catch (error) {
@@ -401,6 +410,11 @@ export function ConsolePage() {
   function startStructuredConnectorSession() {
     if (!selectedTarget || selectedTargetUsesLiveConsole) return;
     setStructuredSessionsByTarget((current) => ({ ...current, [selectedTarget.ref]: newStructuredConsoleSession() }));
+  }
+
+  function selectLiveSessionName(name) {
+    if (!selectedTarget?.ref || !name) return;
+    setLiveSessionNameByTarget((current) => ({ ...current, [selectedTarget.ref]: name }));
   }
 
   function endStructuredConnectorSession() {
@@ -465,7 +479,7 @@ export function ConsolePage() {
       </aside>
 
       <section
-        className={`grid min-w-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border shadow-xl ${
+        className={`grid h-full min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border shadow-xl ${
           theme === "light" ? "border-stone-200 bg-white" : "border-stone-800 bg-[#1e1e1e]"
         }`}
       >
@@ -547,8 +561,8 @@ export function ConsolePage() {
         </header>
 
         <div
-          className={consoleBannerCount > 0 ? "grid min-h-0" : "min-h-0"}
-          style={consoleBannerCount > 0 ? { gridTemplateRows: `${Array(consoleBannerCount).fill("auto").join(" ")} minmax(0, 1fr)` } : undefined}
+          className="grid h-full min-h-0 overflow-hidden"
+          style={{ gridTemplateRows: consoleBannerCount > 0 ? `${Array(consoleBannerCount).fill("auto").join(" ")} minmax(0, 1fr)` : "minmax(0, 1fr)" }}
         >
           {showAlwaysRunWarning ? (
             <div className="sticky top-0 z-10 border-b border-red-800/50 bg-red-950 px-4 py-2 text-xs font-semibold text-red-50">
@@ -580,6 +594,7 @@ export function ConsolePage() {
               selectedRuntimeTarget={selectedRuntimeTarget}
               onNewStructuredSession={startStructuredConnectorSession}
               onNewLiveSession={(options = {}) => selectedRuntimeTarget && startNewConsoleSession(selectedRuntimeTarget, options)}
+              onSelectLiveSessionName={selectLiveSessionName}
               onEndLiveSession={() => selectedSession.id && closeConsoleSession(selectedSession.id)}
               onOpenActivity={() => setConnectorActivityOpen(true)}
               onRefreshActivity={loadConnectorActionApprovals}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,7 +2564,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.8",
+      "version": "0.2.10",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -9,8 +9,8 @@ credentials, or other connector secrets.
 The gateway is intentionally local-only. Run it on the developer machine and
 keep the URL on `localhost`; remote systems are connector targets, not places
 to host the gateway for LAN or internet users. SSH, Postgres, Redis, RabbitMQ,
-and Docker are built-in connectors that use the same target/profile/action
-permission model as future connectors.
+Docker, and Kubernetes are built-in connectors that use the same
+target/profile/action permission model as future connectors.
 
 ![AIPermission demo: AI operates through approval-based connector access](https://raw.githubusercontent.com/aipermission/aipermission/main/docs/assets/demo/aipermission-demo.gif)
 
@@ -62,7 +62,7 @@ The generated MCP config contains a bearer token. Keep it private. For project-l
 - `get_connector_action_request`
 
 All integration work goes through connector targets. SSH, Postgres, Redis,
-RabbitMQ, Docker, and future connectors share the same model: target,
+RabbitMQ, Docker, Kubernetes, and future connectors share the same model: target,
 credential profile, connector action, token action permission, approval,
 history, and audit.
 
@@ -95,6 +95,14 @@ container names/IDs, or name patterns. `container_exec` and live container
 console sessions are scoped to one visible container; arbitrary host-level
 Docker commands, prune, removal, and raw Docker command execution are not
 exposed.
+
+For Kubernetes, call `get_connector_actions(target_ref)` to discover bounded
+actions such as `cluster_version`, `list_namespaces`, `list_workloads`,
+`list_pods`, `list_services`, `list_ingress`, `list_nodes`, `list_events`,
+`describe_resource`, `get_logs`, and `rollout_restart`. Kubernetes actions run
+through an SSH transport profile and can be scoped by namespace visibility. Raw
+`kubectl`, manifest apply/edit/delete, pod deletion, scaling, and Secret value
+browsing are not exposed.
 
 Connector responses can include `approval_pending` or `running`. Poll
 `get_connector_action_request(request_id)` until the request reaches a terminal

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Highlights

- Add Kubernetes as a built-in connector over SSH transport with namespace-scoped resource browsing.
- Add Kubernetes Console tabs, bounded pod logs, live pod console sessions, and explicit rollout restart.
- Fix manual console history for Kubernetes/BusyBox-style path prompts.

## Changes

### Added

- Kubernetes connector actions for cluster version, namespaces, workloads, pods, services, ingress, nodes, events, describe, logs, and rollout restart.
- Kubernetes Console template with namespace selector, resource tabs, resource detail, bounded logs, and pod console.

### Fixed

- Manual command tracking now completes on prompts such as `/ #` and `/app $`.
- Docker action adapter ignores missing optional parameters instead of serializing nil values.

### Maintenance

- Bump app, MCP package, in-app changelog, README, and connector docs to 0.2.10.

## Security

- Kubernetes does not expose raw kubectl, manifest apply/edit/delete, pod deletion, scaling, or Secret value browsing.
- rollout_restart is the only Kubernetes write action in this release and still follows token/action permissions and approval policy.

## Validation

- node scripts/secret-scan.js
- make test
- make build
- make audit
- go test -race ./...
- go vet ./...
- govulncheck ./...
- docker compose config --quiet
- docker compose up -d --build --force-recreate
- packages/mcp: npm test, npm run build, npm audit --omit=dev --audit-level=moderate, npm pack --dry-run
- packages/npm-placeholder: npm pack --dry-run

## Notes

- MCP package still needs npm publish after the GitHub release is created.