### PR TITLE
Release 0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-06-29
+
+### Added
+
+- Added S3 as a built-in connector with Direct and Over SSH connection modes.
+- Added S3-compatible bucket browsing, object metadata reads, bounded object
+  download/upload, object rename, and explicit delete actions.
+- Added an S3 Console browser template for object search, metadata inspection,
+  download, upload, rename, and delete flows.
+
+### Changed
+
+- Moved live-console recovery action selection into connector frontend
+  templates, so recovery UI is connector-defined instead of SSH-specific.
+- Moved connector-provisioned credential metadata ownership behind connector
+  contracts, so managed profile details no longer live in generic API handlers.
+- Removed a stale Docker-shaped target-operation request DTO from generic
+  connector target handlers.
+
+### Fixed
+
+- Direct connector TCP dials now prefer IPv4 before IPv6 fallback when both are
+  available, avoiding Docker-hosted gateway timeouts on providers whose IPv6
+  endpoint is unreachable from the container network.
+
+### Tests
+
+- Added S3 connector tests for SigV4 request signing, path escaping, upload
+  preview redaction, list filtering, and overwrite protection.
+- Added direct connector dial ordering coverage for dual-stack DNS responses.
+- Added backend and frontend boundary checks that guard against connector
+  details leaking back into generic API handlers or generic Console code.
+
+### Security
+
+- S3 credentials are stored only as connector credential profile secrets, and
+  object content upload/download actions are bounded by connector size limits.
+
 ## [0.2.10] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ AIPermission is intentionally designed as a local developer gateway.
 
 - The gateway runs on the developer's own machine.
 - Remote systems are connector targets reached from that local gateway.
-- SSH, Postgres, Redis, RabbitMQ, Docker, and Kubernetes are built-in connector
+- SSH, Postgres, Redis, RabbitMQ, S3, Docker, and Kubernetes are built-in connector
   types, not separate product modes.
 - The web UI, REST API, and MCP API are not designed to be shared on a LAN.
 - The project does not support running the gateway as a remote hosted service.
@@ -118,7 +118,7 @@ Implemented:
 - Go backend with SQLite storage
 - React web UI
 - connector target/profile/action pipeline for SSH, Postgres, Redis, RabbitMQ,
-  Docker, and future local
+  S3, Docker, and future local
   integrations
 - generic connector network transport so protocol connectors can use Direct or
   reviewed Over SSH TCP paths without importing SSH-specific code
@@ -137,6 +137,9 @@ Implemented:
 - built-in RabbitMQ connector with Direct and Over SSH connection modes, queue
   browsing, vhost metadata, binding inspection, bounded message peeking, and
   explicit message publishing
+- built-in S3 connector with Direct and Over SSH connection modes,
+  S3-compatible bucket browsing, object metadata, bounded object
+  upload/download, rename, and delete actions
 - built-in Docker connector over an SSH transport profile, with scoped
   container/image/network/volume inventory, redacted inspect metadata, bounded
   logs, scoped container exec, live container console, and explicit
@@ -161,7 +164,7 @@ Implemented:
 - persistent web console with live PTY streaming
 - UI bulk SSH command execution across selected connector targets with per-target history rows
 - MCP bridge with connector action tools for SSH, Postgres, Redis, RabbitMQ,
-  Docker, and future local integrations
+  S3, Docker, and future local integrations
 - approval dialog with Run / Decline / note
 - approval-context snapshots that stale old pending connector actions after
   permission, connector target, credential profile, connector metadata, or
@@ -352,7 +355,7 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-The MCP surface is connector-first. SSH, Postgres, Redis, RabbitMQ, Docker,
+The MCP surface is connector-first. SSH, Postgres, Redis, RabbitMQ, S3, Docker,
 Kubernetes, and future integrations use the same target/profile/action permission
 pipeline. `list_connector_targets` is
 permission-scoped, not a live health check. Current reachability is learned when
@@ -371,6 +374,13 @@ as `overview`, `list_vhosts`, `list_queues`, `get_queue`, `list_bindings`, and
 `peek_messages`, and `publish_message`. Treat message payload previews and
 message publishing as sensitive queue access; previews use bounded
 count/truncation limits and `ack_requeue_true`.
+
+For S3, call `get_connector_actions(target_ref)` to discover actions such as
+`bucket_info`, `list_objects`, `get_object_metadata`, `download_object`,
+`upload_object`, `rename_object`, and `delete_object`. Object content may
+contain secrets; downloads and uploads are bounded connector actions and large
+transfer-center style object movement is intentionally out of scope for the
+initial S3 connector.
 
 For Docker, call `get_connector_actions(target_ref)` to discover bounded
 actions such as `docker_version`, `list_containers`, `list_images`,

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ To pin a specific release image, set `AIPERMISSION_VERSION` without the leading
 `v`:
 
 ```bash
-AIPERMISSION_VERSION=0.2.10 docker compose -f docker-compose.release.yml up -d
+AIPERMISSION_VERSION=0.2.11 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, clone the repository with Git's default text handling or make sure

--- a/backend/internal/api/connector_boundary_test.go
+++ b/backend/internal/api/connector_boundary_test.go
@@ -80,3 +80,42 @@ func TestSSHSpecificAPIReferencesStayInsideConnectorAdapters(t *testing.T) {
 		t.Fatalf("walk api dir: %v", err)
 	}
 }
+
+func TestProvisionedCredentialMetadataStaysInsideConnectors(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime caller unavailable")
+	}
+	apiDir := filepath.Dir(filename)
+	disallowed := []string{
+		"managed_by_aipermission",
+		"managed_role_name",
+		"managed_admin_profile_id",
+		"managed_admin_profile_ref",
+		"managed_preset",
+		"managed_scope",
+	}
+	err := filepath.WalkDir(apiDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		name := filepath.Base(path)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		source := string(content)
+		for _, pattern := range disallowed {
+			if strings.Contains(source, pattern) {
+				t.Fatalf("%s must keep provisioned credential metadata behind connector contracts, found %q", name, pattern)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk api dir: %v", err)
+	}
+}

--- a/backend/internal/api/connector_network_transport.go
+++ b/backend/internal/api/connector_network_transport.go
@@ -42,8 +42,7 @@ func (transport connectorNetworkTransport) DialConnectorTCP(ctx context.Context,
 	defer cancel()
 	switch mode {
 	case "direct":
-		var dialer net.Dialer
-		return dialer.DialContext(ctx, "tcp", address)
+		return dialDirectConnectorTCP(ctx, request.Host, request.Port)
 	case "over_ssh":
 		targetRef := strings.TrimSpace(request.TransportTargetRef)
 		if targetRef == "" {
@@ -72,6 +71,69 @@ func networkDialAddress(host string, port int) (string, error) {
 		return "", fmt.Errorf("port must be between 1 and 65535")
 	}
 	return net.JoinHostPort(resolveConnectorDialHost(host), strconv.Itoa(port)), nil
+}
+
+func dialDirectConnectorTCP(ctx context.Context, host string, port int) (net.Conn, error) {
+	host = resolveConnectorDialHost(strings.TrimSpace(host))
+	address := net.JoinHostPort(host, strconv.Itoa(port))
+	if ip := net.ParseIP(strings.Trim(host, "[]")); ip != nil {
+		return dialTCPAddress(ctx, ipNetwork(ip), address)
+	}
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err == nil && len(addrs) > 0 {
+		var lastErr error
+		for _, addr := range preferredDialAddresses(addrs, port) {
+			conn, err := dialTCPAddress(ctx, addr.network, addr.address)
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		if lastErr != nil {
+			return nil, lastErr
+		}
+	}
+	return dialTCPAddress(ctx, "tcp", address)
+}
+
+type preferredDialAddress struct {
+	network string
+	address string
+}
+
+func preferredDialAddresses(addrs []net.IPAddr, port int) []preferredDialAddress {
+	result := make([]preferredDialAddress, 0, len(addrs))
+	appendFamily := func(wantV4 bool) {
+		for _, addr := range addrs {
+			ip := addr.IP
+			if ip == nil {
+				continue
+			}
+			isV4 := ip.To4() != nil
+			if isV4 != wantV4 {
+				continue
+			}
+			result = append(result, preferredDialAddress{
+				network: ipNetwork(ip),
+				address: net.JoinHostPort(ip.String(), strconv.Itoa(port)),
+			})
+		}
+	}
+	appendFamily(true)
+	appendFamily(false)
+	return result
+}
+
+func ipNetwork(ip net.IP) string {
+	if ip.To4() != nil {
+		return "tcp4"
+	}
+	return "tcp6"
+}
+
+func dialTCPAddress(ctx context.Context, network string, address string) (net.Conn, error) {
+	var dialer net.Dialer
+	return dialer.DialContext(ctx, network, address)
 }
 
 func resolveConnectorDialHost(host string) string {

--- a/backend/internal/api/connector_network_transport_test.go
+++ b/backend/internal/api/connector_network_transport_test.go
@@ -1,6 +1,9 @@
 package api
 
-import "testing"
+import (
+	"net"
+	"testing"
+)
 
 func TestParseLinuxDefaultGatewayRoute(t *testing.T) {
 	gateway, ok := parseLinuxDefaultGatewayRoute(`Iface	Destination	Gateway	Flags	RefCnt	Use	Metric	Mask
@@ -19,5 +22,21 @@ func TestParseLinuxDefaultGatewayRouteRejectsMissingDefault(t *testing.T) {
 eth0	0008A8C0	00000000	0001	0	0	0	00FFFFFF
 `); ok || gateway != "" {
 		t.Fatalf("unexpected gateway %q ok=%v", gateway, ok)
+	}
+}
+
+func TestPreferredDialAddressesPreferIPv4(t *testing.T) {
+	addrs := preferredDialAddresses([]net.IPAddr{
+		{IP: net.ParseIP("2001:db8::10")},
+		{IP: net.ParseIP("192.0.2.10")},
+	}, 443)
+	if len(addrs) != 2 {
+		t.Fatalf("addresses = %#v", addrs)
+	}
+	if addrs[0].network != "tcp4" || addrs[0].address != "192.0.2.10:443" {
+		t.Fatalf("first address = %#v", addrs[0])
+	}
+	if addrs[1].network != "tcp6" || addrs[1].address != "[2001:db8::10]:443" {
+		t.Fatalf("second address = %#v", addrs[1])
 	}
 }

--- a/backend/internal/api/connector_profile_provision_handlers.go
+++ b/backend/internal/api/connector_profile_provision_handlers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/aipermission/aipermission/backend/internal/connectors"
@@ -151,20 +150,24 @@ func cleanupProvisionedCredentialProfileAfterFailure(
 }
 
 func (s connectorTargetHandlers) cleanupProvisionedCredentialProfileIfNeeded(ctx context.Context, runtime *databaseRuntime, target connectortargets.Target, profile connectortargets.CredentialProfile) error {
-	if !boolMapValue(profile.Public, "managed_by_aipermission") {
-		return nil
-	}
 	connector, ok := runtime.connectorRegistry().Get(target.ConnectorKind)
 	if !ok {
 		return connectortargets.ValidationError("unsupported connector kind")
 	}
+	lifecycle, ok := connector.(connectors.ProvisionedCredentialLifecycle)
+	if !ok {
+		return nil
+	}
+	adminProfileID, managed, err := lifecycle.ProvisionedCredentialAdminProfileID(connectortargets.CredentialProfileView(profile))
+	if err != nil {
+		return connectortargets.ValidationError(err.Error())
+	}
+	if !managed {
+		return nil
+	}
 	provisioner, ok := connector.(connectors.CredentialProvisioner)
 	if !ok {
 		return connectortargets.ValidationError("connector does not support managed credential cleanup")
-	}
-	adminProfileID := int64MapValue(profile.Public, "managed_admin_profile_id")
-	if adminProfileID < 1 || adminProfileID == profile.ID {
-		return connectortargets.ValidationError("managed credential profile is missing a valid admin profile reference")
 	}
 	store := connectortargets.NewStore(runtime.database)
 	adminProfile, err := store.GetCredentialProfile(ctx, target.ID, adminProfileID)
@@ -244,37 +247,4 @@ func handleConnectorProvisionError(w http.ResponseWriter, err error) {
 		return
 	}
 	writeError(w, http.StatusBadRequest, err.Error())
-}
-
-func boolMapValue(values map[string]any, name string) bool {
-	if values == nil {
-		return false
-	}
-	switch typed := values[name].(type) {
-	case bool:
-		return typed
-	case string:
-		return strings.EqualFold(strings.TrimSpace(typed), "true")
-	default:
-		return false
-	}
-}
-
-func int64MapValue(values map[string]any, name string) int64 {
-	if values == nil {
-		return 0
-	}
-	switch typed := values[name].(type) {
-	case int:
-		return int64(typed)
-	case int64:
-		return typed
-	case float64:
-		return int64(typed)
-	case string:
-		parsed, _ := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
-		return parsed
-	default:
-		return 0
-	}
 }

--- a/backend/internal/api/connector_target_handlers.go
+++ b/backend/internal/api/connector_target_handlers.go
@@ -815,12 +815,14 @@ func (s connectorTargetHandlers) updateConnectorCredentialProfile(w http.Respons
 		handleConnectorTargetError(w, err)
 		return
 	}
-	mergedPublic, err := preserveManagedCredentialPublic(existingProfile.Public, request.Public)
-	if err != nil {
-		handleConnectorTargetError(w, err)
-		return
+	if lifecycle, ok := connector.(connectors.ProvisionedCredentialLifecycle); ok {
+		mergedPublic, err := lifecycle.PreserveProvisionedCredentialPublic(connectortargets.CredentialProfileView(existingProfile), request.Public)
+		if err != nil {
+			handleConnectorTargetError(w, connectortargets.ValidationError(err.Error()))
+			return
+		}
+		request.Public = mergedPublic
 	}
-	request.Public = mergedPublic
 	preparedProfile, ok := s.prepareConnectorCredentialProfileInput(w, r, runtime, connector, updateProfileAdapterRequest(request), request.Secret != nil)
 	if !ok {
 		return
@@ -949,37 +951,6 @@ func (s connectorTargetHandlers) staleConnectorActionRequestsForTarget(ctx conte
 		}
 	}
 	return result.Affected, nil
-}
-
-func preserveManagedCredentialPublic(existing map[string]any, requested map[string]any) (map[string]any, error) {
-	if requested == nil {
-		requested = map[string]any{}
-	}
-	if !boolMapValue(existing, "managed_by_aipermission") {
-		return requested, nil
-	}
-	next := cloneMapAny(requested)
-	existingUsername := strings.TrimSpace(toString(existing["username"]))
-	requestedUsername := strings.TrimSpace(toString(next["username"]))
-	if requestedUsername != "" && existingUsername != "" && requestedUsername != existingUsername {
-		return nil, connectortargets.ValidationError("managed credential username cannot be changed; create a new managed profile instead")
-	}
-	if existingUsername != "" {
-		next["username"] = existingUsername
-	}
-	for _, key := range []string{
-		"managed_by_aipermission",
-		"managed_role_name",
-		"managed_admin_profile_id",
-		"managed_admin_profile_ref",
-		"managed_preset",
-		"managed_scope",
-	} {
-		if value, ok := existing[key]; ok {
-			next[key] = value
-		}
-	}
-	return next, nil
 }
 
 func (s connectorTargetHandlers) ensureConnectorRuntimeSurfacesForProfile(ctx context.Context, store *connectortargets.Store, target connectortargets.Target, profile connectortargets.CredentialProfile) error {

--- a/backend/internal/api/connector_target_handlers.go
+++ b/backend/internal/api/connector_target_handlers.go
@@ -64,12 +64,6 @@ type connectorTargetTestResponse struct {
 	DurationMS    int64          `json:"duration_ms"`
 }
 
-type connectorTargetOperationRequest struct {
-	ProfileID    int64  `json:"profile_id,omitempty"`
-	ContainerRef string `json:"container_ref,omitempty"`
-	Tail         int    `json:"tail,omitempty"`
-}
-
 type connectorTargetResponse struct {
 	ID            int64            `json:"id"`
 	Ref           string           `json:"ref,omitempty"`

--- a/backend/internal/connectors/builtin/registry.go
+++ b/backend/internal/connectors/builtin/registry.go
@@ -11,6 +11,7 @@ import (
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
 	rabbitmqconnector "github.com/aipermission/aipermission/backend/internal/connectors/rabbitmq"
 	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"
+	s3connector "github.com/aipermission/aipermission/backend/internal/connectors/s3"
 	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
 	_ "github.com/aipermission/aipermission/backend/internal/connectors/ssh/apiadapter"
 )
@@ -23,6 +24,7 @@ func RegisterAll(registry *connectors.Registry) error {
 		postgresconnector.New(),
 		rabbitmqconnector.New(),
 		redisconnector.New(),
+		s3connector.New(),
 		sshconnector.New(),
 	} {
 		if err := registry.Register(connector); err != nil {

--- a/backend/internal/connectors/builtin/registry_test.go
+++ b/backend/internal/connectors/builtin/registry_test.go
@@ -11,6 +11,7 @@ import (
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
 	rabbitmqconnector "github.com/aipermission/aipermission/backend/internal/connectors/rabbitmq"
 	redisconnector "github.com/aipermission/aipermission/backend/internal/connectors/redis"
+	s3connector "github.com/aipermission/aipermission/backend/internal/connectors/s3"
 	sshconnector "github.com/aipermission/aipermission/backend/internal/connectors/ssh"
 )
 
@@ -56,6 +57,13 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	if redis.Label() != redisconnector.Label {
 		t.Fatalf("redis label = %q", redis.Label())
 	}
+	s3, ok := registry.Get(s3connector.Kind)
+	if !ok {
+		t.Fatal("expected s3 connector")
+	}
+	if s3.Label() != s3connector.Label {
+		t.Fatalf("s3 label = %q", s3.Label())
+	}
 
 	connector, ok := registry.Get(sshconnector.Kind)
 	if !ok {
@@ -66,7 +74,7 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	}
 
 	infos := registry.List()
-	if len(infos) != 6 || infos[0].Kind != dockerconnector.Kind || infos[1].Kind != kubernetesconnector.Kind || infos[2].Kind != postgresconnector.Kind || infos[3].Kind != rabbitmqconnector.Kind || infos[4].Kind != redisconnector.Kind || infos[5].Kind != sshconnector.Kind {
+	if len(infos) != 7 || infos[0].Kind != dockerconnector.Kind || infos[1].Kind != kubernetesconnector.Kind || infos[2].Kind != postgresconnector.Kind || infos[3].Kind != rabbitmqconnector.Kind || infos[4].Kind != redisconnector.Kind || infos[5].Kind != s3connector.Kind || infos[6].Kind != sshconnector.Kind {
 		t.Fatalf("unexpected connector list: %#v", infos)
 	}
 }
@@ -238,6 +246,29 @@ func builtInDeterminismSamples(t *testing.T, kind string) (connectors.TargetView
 				rabbitmqconnector.ActionListBindings: {"vhost": "/", "queue": "jobs", "limit": 10},
 				rabbitmqconnector.ActionPeekMessages: {"vhost": "/", "queue": "jobs", "count": 2, "max_payload_bytes": 4096},
 				rabbitmqconnector.ActionPublish:      {"vhost": "/", "exchange": "amq.default", "routing_key": "jobs", "payload": `{"ok":true}`, "payload_encoding": "string", "properties": map[string]any{"content_type": "application/json"}},
+			}
+	case s3connector.Kind:
+		return connectors.TargetView{
+				ID:            7,
+				Ref:           "s3:7:70",
+				ConnectorKind: s3connector.Kind,
+				Name:          "object-store",
+				Config:        map[string]any{"connection_mode": "direct", "scheme": "https", "host": "s3.example.com", "port": 443, "region": "us-east-1", "bucket": "app-backups", "path_style": true},
+			}, connectors.CredentialProfileView{
+				ID:            70,
+				TargetID:      7,
+				ConnectorKind: s3connector.Kind,
+				Kind:          "access_key",
+				Label:         "backup",
+				Public:        map[string]any{"access_key_id": "AKIAEXAMPLE"},
+			}, map[string]map[string]any{
+				s3connector.ActionBucketInfo:        {},
+				s3connector.ActionListObjects:       {"prefix": "daily/", "search": "db", "limit": 10},
+				s3connector.ActionGetObjectMetadata: {"key": "daily/app.aipdb"},
+				s3connector.ActionDownloadObject:    {"key": "daily/app.aipdb", "max_bytes": 1024},
+				s3connector.ActionUploadObject:      {"key": "daily/app.txt", "content_text": "hello", "content_type": "text/plain", "overwrite": true},
+				s3connector.ActionRenameObject:      {"source_key": "daily/app.txt", "destination_key": "daily/app-renamed.txt", "overwrite": true},
+				s3connector.ActionDeleteObject:      {"key": "daily/app-renamed.txt"},
 			}
 	case sshconnector.Kind:
 		return connectors.TargetView{

--- a/backend/internal/connectors/connector.go
+++ b/backend/internal/connectors/connector.go
@@ -49,6 +49,14 @@ type CredentialProvisioner interface {
 	CleanupProvisionedCredentialProfile(ctx context.Context, runtime RuntimeContext, profile CredentialProfileView) (ActionResult, error)
 }
 
+// ProvisionedCredentialLifecycle is an optional connector contract for metadata
+// the connector needs to preserve or interpret for credentials it provisioned.
+// Core owns storage; the connector owns the meaning of the public metadata.
+type ProvisionedCredentialLifecycle interface {
+	PreserveProvisionedCredentialPublic(existing CredentialProfileView, requested map[string]any) (map[string]any, error)
+	ProvisionedCredentialAdminProfileID(profile CredentialProfileView) (adminProfileID int64, managed bool, err error)
+}
+
 // BackupRestorer is an optional connector contract for operator-driven backup
 // and restore flows. Core owns HTTP upload/download, confirmation, and audit;
 // the connector owns the external service dump/restore implementation.

--- a/backend/internal/connectors/postgres/postgres.go
+++ b/backend/internal/connectors/postgres/postgres.go
@@ -596,6 +596,48 @@ func (Connector) ProvisionCredentialProfile(ctx context.Context, runtime connect
 	}, nil
 }
 
+func (Connector) PreserveProvisionedCredentialPublic(existing connectors.CredentialProfileView, requested map[string]any) (map[string]any, error) {
+	if requested == nil {
+		requested = map[string]any{}
+	}
+	if !boolPublic(existing.Public, "managed_by_aipermission") {
+		return clonePublicMap(requested), nil
+	}
+	next := clonePublicMap(requested)
+	existingUsername := strings.TrimSpace(publicString(existing.Public, "username"))
+	requestedUsername := strings.TrimSpace(publicString(next, "username"))
+	if requestedUsername != "" && existingUsername != "" && requestedUsername != existingUsername {
+		return nil, fmt.Errorf("managed credential username cannot be changed; create a new managed profile instead")
+	}
+	if existingUsername != "" {
+		next["username"] = existingUsername
+	}
+	for _, key := range []string{
+		"managed_by_aipermission",
+		"managed_role_name",
+		"managed_admin_profile_id",
+		"managed_admin_profile_ref",
+		"managed_preset",
+		"managed_scope",
+	} {
+		if value, ok := existing.Public[key]; ok {
+			next[key] = value
+		}
+	}
+	return next, nil
+}
+
+func (Connector) ProvisionedCredentialAdminProfileID(profile connectors.CredentialProfileView) (int64, bool, error) {
+	if !boolPublic(profile.Public, "managed_by_aipermission") {
+		return 0, false, nil
+	}
+	adminProfileID := int64Public(profile.Public, "managed_admin_profile_id")
+	if adminProfileID < 1 || adminProfileID == profile.ID {
+		return 0, true, fmt.Errorf("managed credential profile is missing a valid admin profile reference")
+	}
+	return adminProfileID, true, nil
+}
+
 func (Connector) CleanupProvisionedCredentialProfile(ctx context.Context, runtime connectors.RuntimeContext, profile connectors.CredentialProfileView) (connectors.ActionResult, error) {
 	if runtime.Target.ConnectorKind != Kind {
 		return connectors.ActionResult{}, fmt.Errorf("target connector kind must be %s", Kind)
@@ -1384,6 +1426,46 @@ func publicString(public map[string]any, name string) string {
 		return ""
 	}
 	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func int64Public(public map[string]any, name string) int64 {
+	if public == nil {
+		return 0
+	}
+	value, ok := public[name]
+	if !ok || value == nil {
+		return 0
+	}
+	switch typed := value.(type) {
+	case int:
+		return int64(typed)
+	case int64:
+		return typed
+	case float64:
+		return int64(typed)
+	case json.Number:
+		parsed, err := strconv.ParseInt(string(typed), 10, 64)
+		if err == nil {
+			return parsed
+		}
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+		if err == nil {
+			return parsed
+		}
+	}
+	return 0
+}
+
+func clonePublicMap(values map[string]any) map[string]any {
+	if values == nil {
+		return map[string]any{}
+	}
+	copied := make(map[string]any, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
 }
 
 func payloadString(payload map[string]any, name string) string {

--- a/backend/internal/connectors/s3/s3.go
+++ b/backend/internal/connectors/s3/s3.go
@@ -1,0 +1,1338 @@
+// Package s3connector defines the S3-compatible storage connector contract.
+package s3connector
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+const (
+	Kind    = "s3"
+	Label   = "S3"
+	Version = "0.2"
+
+	ActionBucketInfo        = "bucket_info"
+	ActionListObjects       = "list_objects"
+	ActionGetObjectMetadata = "get_object_metadata"
+	ActionDownloadObject    = "download_object"
+	ActionUploadObject      = "upload_object"
+	ActionRenameObject      = "rename_object"
+	ActionDeleteObject      = "delete_object"
+
+	defaultS3Scheme    = "https"
+	defaultS3Host      = "s3.amazonaws.com"
+	defaultS3Port      = 443
+	defaultS3Region    = "us-east-1"
+	defaultS3ListLimit = 100
+	maxS3ListLimit     = 1000
+	maxS3SearchPages   = 20
+	defaultDownloadMax = 5 << 20
+	maxDownloadBytes   = 25 << 20
+	maxUploadBytes     = 16 << 20
+	maxS3ResponseBytes = 2 << 20
+	maxS3ReasonBytes   = 2000
+	s3HTTPTimeout      = 30 * time.Second
+	emptySHA256Hex     = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+var (
+	ErrUnsupportedAction = errors.New("unsupported s3 connector action")
+	ErrMissingTransport  = errors.New("s3 connector network transport is unavailable")
+	ErrMissingSecret     = errors.New("s3 connector credential is missing required secret")
+	ErrInvalidConfig     = errors.New("s3 connector target config is invalid")
+)
+
+// Connector describes S3-compatible object storage as a connector-shaped
+// target with bounded object browsing and explicit write/destructive actions.
+type Connector struct{}
+
+func New() Connector {
+	return Connector{}
+}
+
+func (Connector) Kind() string {
+	return Kind
+}
+
+func (Connector) Label() string {
+	return Label
+}
+
+func (Connector) Version() string {
+	return Version
+}
+
+func (Connector) TargetSchema() connectors.Schema {
+	return connectors.Schema{Fields: []connectors.Field{
+		{
+			Name:        "connection_mode",
+			Label:       "Connection mode",
+			Type:        connectors.FieldSelect,
+			Required:    true,
+			Default:     "direct",
+			Description: "Connect directly from the local gateway, or tunnel to an S3-compatible endpoint through an SSH connector profile.",
+			Options: []connectors.FieldOption{
+				{Value: "direct", Label: "Direct"},
+				{Value: "over_ssh", Label: "Over SSH"},
+			},
+		},
+		{
+			Name:        "scheme",
+			Label:       "Scheme",
+			Type:        connectors.FieldSelect,
+			Required:    true,
+			Default:     defaultS3Scheme,
+			Description: "Endpoint HTTP scheme.",
+			Options: []connectors.FieldOption{
+				{Value: "http", Label: "HTTP"},
+				{Value: "https", Label: "HTTPS"},
+			},
+		},
+		{
+			Name:        "host",
+			Label:       "Endpoint host",
+			Type:        connectors.FieldString,
+			Required:    true,
+			Default:     defaultS3Host,
+			Description: "S3-compatible endpoint host. For Over SSH this is resolved from the SSH server.",
+		},
+		{
+			Name:        "port",
+			Label:       "Endpoint port",
+			Type:        connectors.FieldNumber,
+			Required:    true,
+			Default:     defaultS3Port,
+			Description: "Endpoint TCP port.",
+		},
+		{
+			Name:        "region",
+			Label:       "Region",
+			Type:        connectors.FieldString,
+			Required:    true,
+			Default:     defaultS3Region,
+			Description: "AWS SigV4 region. Many S3-compatible services accept us-east-1.",
+		},
+		{
+			Name:        "bucket",
+			Label:       "Bucket",
+			Type:        connectors.FieldString,
+			Required:    true,
+			Description: "Bucket name to browse and manage.",
+		},
+		{
+			Name:        "path_style",
+			Label:       "Path-style addressing",
+			Type:        connectors.FieldBoolean,
+			Default:     true,
+			Description: "Use /bucket/key paths. Keep enabled for most S3-compatible providers such as MinIO.",
+		},
+		{
+			Name:        "transport_target_ref",
+			Label:       "SSH transport target",
+			Type:        connectors.FieldString,
+			Description: "Connector target ref used when connection_mode is over_ssh.",
+		},
+	}}
+}
+
+func (Connector) CredentialSchemas() []connectors.CredentialSchema {
+	return []connectors.CredentialSchema{
+		{
+			Kind:        "access_key",
+			Label:       "Access key",
+			Description: "S3 access key credentials stored through the encrypted vault layer.",
+			Schema: connectors.Schema{Fields: []connectors.Field{
+				{
+					Name:        "access_key_id",
+					Label:       "Access key ID",
+					Type:        connectors.FieldString,
+					Required:    true,
+					Description: "S3 access key ID.",
+				},
+				{
+					Name:        "secret_access_key",
+					Label:       "Secret access key",
+					Type:        connectors.FieldSecret,
+					Required:    true,
+					Secret:      true,
+					Description: "S3 secret access key.",
+				},
+				{
+					Name:        "session_token",
+					Label:       "Session token",
+					Type:        connectors.FieldSecret,
+					Secret:      true,
+					Description: "Optional temporary session token.",
+				},
+			}},
+		},
+	}
+}
+
+func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (connectors.ConnectorHelp, error) {
+	title := "S3 target"
+	if strings.TrimSpace(target.Name) != "" {
+		title = "S3 target: " + target.Name
+	}
+	return connectors.ConnectorHelp{
+		Title:       title,
+		Summary:     "Browse S3-compatible object storage and run bounded object actions through AIPermission approval rules.",
+		Connector:   Label,
+		ConnectorID: Kind,
+		Usage: []string{
+			"Use list_objects with a prefix or search filter before reading object details.",
+			"Use get_object_metadata to inspect one object without downloading content.",
+			"Use download_object only for bounded object reads; large transfer-center style downloads are a future feature.",
+			"Use upload_object and rename_object only for intentional writes.",
+			"Use delete_object carefully; it is destructive and should normally require approval.",
+		},
+		Warnings: []string{
+			"S3 objects may contain secrets or customer data. Redaction is best-effort; avoid reading object content unless explicitly approved.",
+			"download_object and upload_object are intentionally size-bounded in the connector action pipeline.",
+			"S3 credential profiles decide what the object storage service itself allows.",
+		},
+	}, nil
+}
+
+func (Connector) GetActionList(context.Context, connectors.TargetView, connectors.CredentialProfileView) ([]connectors.ActionDefinition, error) {
+	return []connectors.ActionDefinition{
+		{
+			Name:        ActionBucketInfo,
+			Label:       "Bucket info",
+			Description: "Check bucket access and read bounded bucket metadata.",
+			Category:    "metadata",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{},
+			OutputHint:  connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+		{
+			Name:        ActionListObjects,
+			Label:       "List objects",
+			Description: "List objects in the bucket with optional prefix/search filters.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "prefix", Label: "Prefix", Type: connectors.FieldString, Description: "Optional object key prefix."},
+				{Name: "search", Label: "Search", Type: connectors.FieldString, Description: "Optional case-insensitive key search applied after listing."},
+				{Name: "cursor", Label: "Cursor", Type: connectors.FieldString, Description: "Optional pagination cursor returned by a previous list."},
+				{Name: "limit", Label: "Limit", Type: connectors.FieldNumber, Default: defaultS3ListLimit},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxRows: maxS3ListLimit},
+		},
+		{
+			Name:        ActionGetObjectMetadata,
+			Label:       "Read object metadata",
+			Description: "Read headers and metadata for one object without downloading content.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 32 << 10},
+		},
+		{
+			Name:        ActionDownloadObject,
+			Label:       "Download object",
+			Description: "Download one bounded object and return base64 content.",
+			Category:    "browser",
+			Risk:        connectors.RiskRead,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
+				{Name: "max_bytes", Label: "Max bytes", Type: connectors.FieldNumber, Default: defaultDownloadMax},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: maxDownloadBytes},
+		},
+		{
+			Name:        ActionUploadObject,
+			Label:       "Upload object",
+			Description: "Upload one bounded object from text or base64 content.",
+			Category:    "write",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
+				{Name: "content_text", Label: "Text content", Type: connectors.FieldMultiline},
+				{Name: "content_base64", Label: "Base64 content", Type: connectors.FieldMultiline},
+				{Name: "content_type", Label: "Content type", Type: connectors.FieldString, Default: "application/octet-stream"},
+				{Name: "overwrite", Label: "Overwrite existing object", Type: connectors.FieldBoolean, Default: false},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+		{
+			Name:        ActionRenameObject,
+			Label:       "Rename object",
+			Description: "Copy one object to a new key and delete the original key.",
+			Category:    "write",
+			Risk:        connectors.RiskWrite,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "source_key", Label: "Source key", Type: connectors.FieldString, Required: true},
+				{Name: "destination_key", Label: "Destination key", Type: connectors.FieldString, Required: true},
+				{Name: "overwrite", Label: "Overwrite destination", Type: connectors.FieldBoolean, Default: false},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+		{
+			Name:        ActionDeleteObject,
+			Label:       "Delete object",
+			Description: "Delete one object from the bucket.",
+			Category:    "destructive",
+			Risk:        connectors.RiskDestructive,
+			InputSchema: connectors.Schema{Fields: []connectors.Field{
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
+			}},
+			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
+		},
+	}, nil
+}
+
+func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) (connectors.PreparedAction, error) {
+	input := copyMap(req.Input)
+	risk := connectors.RiskRead
+	title := ""
+	summary := ""
+	switch req.ActionName {
+	case ActionBucketInfo:
+		title = "Read S3 bucket info"
+		summary = fmt.Sprintf("Check bucket %q access.", s3Bucket(req.Target))
+	case ActionListObjects:
+		prefix := strings.TrimSpace(stringValue(input, "prefix"))
+		search := strings.TrimSpace(stringValue(input, "search"))
+		cursor := strings.TrimSpace(stringValue(input, "cursor"))
+		limit := normalizeInt(input, "limit", defaultS3ListLimit, 1, maxS3ListLimit)
+		input["prefix"] = prefix
+		input["search"] = search
+		input["cursor"] = cursor
+		input["limit"] = limit
+		title = "List S3 objects"
+		summary = fmt.Sprintf("List up to %d object(s) in bucket %q.", limit, s3Bucket(req.Target))
+	case ActionGetObjectMetadata:
+		key := normalizeObjectKey(input, "key")
+		if key == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("key is required")
+		}
+		input["key"] = key
+		title = "Read S3 object metadata"
+		summary = key
+	case ActionDownloadObject:
+		key := normalizeObjectKey(input, "key")
+		if key == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("key is required")
+		}
+		maxBytes := normalizeInt(input, "max_bytes", defaultDownloadMax, 1, maxDownloadBytes)
+		input["key"] = key
+		input["max_bytes"] = maxBytes
+		title = "Download S3 object"
+		summary = fmt.Sprintf("%s (max %d bytes)", key, maxBytes)
+	case ActionUploadObject:
+		risk = connectors.RiskWrite
+		key := normalizeObjectKey(input, "key")
+		if key == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("key is required")
+		}
+		contentText := stringValue(input, "content_text")
+		contentBase64 := strings.TrimSpace(stringValue(input, "content_base64"))
+		if contentText == "" && contentBase64 == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("content_text or content_base64 is required")
+		}
+		if contentText != "" && contentBase64 != "" {
+			return connectors.PreparedAction{}, fmt.Errorf("provide content_text or content_base64, not both")
+		}
+		contentBytes, err := uploadBytes(contentText, contentBase64)
+		if err != nil {
+			return connectors.PreparedAction{}, err
+		}
+		if len(contentBytes) > maxUploadBytes {
+			return connectors.PreparedAction{}, fmt.Errorf("object content is larger than %d bytes", maxUploadBytes)
+		}
+		contentType := strings.TrimSpace(stringValue(input, "content_type"))
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+		input["key"] = key
+		input["content_type"] = contentType
+		input["content_bytes"] = len(contentBytes)
+		input["overwrite"] = boolValue(input, "overwrite")
+		delete(input, "content_text")
+		delete(input, "content_base64")
+		if contentBase64 != "" {
+			input["content_base64"] = contentBase64
+		} else {
+			input["content_base64"] = base64.StdEncoding.EncodeToString(contentBytes)
+		}
+		title = "Upload S3 object"
+		summary = fmt.Sprintf("%s (%d bytes)", key, len(contentBytes))
+	case ActionRenameObject:
+		risk = connectors.RiskWrite
+		sourceKey := normalizeObjectKey(input, "source_key")
+		destinationKey := normalizeObjectKey(input, "destination_key")
+		if sourceKey == "" || destinationKey == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("source_key and destination_key are required")
+		}
+		if sourceKey == destinationKey {
+			return connectors.PreparedAction{}, fmt.Errorf("source_key and destination_key must differ")
+		}
+		input["source_key"] = sourceKey
+		input["destination_key"] = destinationKey
+		input["overwrite"] = boolValue(input, "overwrite")
+		title = "Rename S3 object"
+		summary = fmt.Sprintf("%s -> %s", sourceKey, destinationKey)
+	case ActionDeleteObject:
+		risk = connectors.RiskDestructive
+		key := normalizeObjectKey(input, "key")
+		if key == "" {
+			return connectors.PreparedAction{}, fmt.Errorf("key is required")
+		}
+		input["key"] = key
+		title = "Delete S3 object"
+		summary = key
+	default:
+		return connectors.PreparedAction{}, ErrUnsupportedAction
+	}
+	if len(req.Reason) > maxS3ReasonBytes {
+		return connectors.PreparedAction{}, fmt.Errorf("reason is too large")
+	}
+	preview := copyMap(input)
+	if _, ok := preview["content_base64"]; ok {
+		preview["content_base64"] = fmt.Sprintf("[base64 content: %v bytes]", input["content_bytes"])
+	}
+	return connectors.PreparedAction{
+		ConnectorKind: Kind,
+		TargetRef:     req.Target.Ref,
+		ProfileID:     req.Profile.ID,
+		ActionName:    req.ActionName,
+		Risk:          risk,
+		Title:         title,
+		Summary:       summary,
+		Preview:       preview,
+		Payload:       input,
+		ContextMaterial: map[string]any{
+			"target":          req.Target.Name,
+			"profile":         req.Profile.Label,
+			"bucket":          s3Bucket(req.Target),
+			"connection_mode": connectionMode(req.Target),
+		},
+	}, nil
+}
+
+func (Connector) ExecuteAction(ctx context.Context, runtime connectors.RuntimeContext, action connectors.PreparedAction) (connectors.ActionResult, error) {
+	client, err := newS3Client(ctx, runtime)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	switch action.ActionName {
+	case ActionBucketInfo:
+		return executeBucketInfo(ctx, client)
+	case ActionListObjects:
+		return executeListObjects(ctx, client, action.Payload)
+	case ActionGetObjectMetadata:
+		return executeGetObjectMetadata(ctx, client, action.Payload)
+	case ActionDownloadObject:
+		return executeDownloadObject(ctx, client, action.Payload)
+	case ActionUploadObject:
+		return executeUploadObject(ctx, client, action.Payload)
+	case ActionRenameObject:
+		return executeRenameObject(ctx, client, action.Payload)
+	case ActionDeleteObject:
+		return executeDeleteObject(ctx, client, action.Payload)
+	default:
+		return connectors.ActionResult{}, ErrUnsupportedAction
+	}
+}
+
+func (Connector) TestConnection(ctx context.Context, runtime connectors.RuntimeContext) (connectors.TestResult, error) {
+	client, err := newS3Client(ctx, runtime)
+	if err != nil {
+		return connectors.TestResult{Status: classifyS3TestError(err), Message: err.Error()}, nil
+	}
+	headers, err := client.HeadBucket(ctx)
+	if err != nil {
+		return connectors.TestResult{Status: classifyS3TestError(err), Message: err.Error()}, nil
+	}
+	return connectors.TestResult{
+		Status:  connectors.TestOK,
+		Message: "S3 bucket connection ok.",
+		Details: map[string]any{
+			"bucket":     client.bucket,
+			"region":     client.region,
+			"request_id": firstHeader(headers, "X-Amz-Request-Id", "X-Amz-Id-2"),
+		},
+	}, nil
+}
+
+func executeBucketInfo(ctx context.Context, client *s3Client) (connectors.ActionResult, error) {
+	headers, err := client.HeadBucket(ctx)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	output := map[string]any{
+		"bucket":   client.bucket,
+		"region":   client.region,
+		"endpoint": client.endpointDisplay(),
+		"headers":  safeHeaders(headers),
+	}
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      output,
+		DisplayText: fmt.Sprintf("Bucket %s is reachable at %s.", client.bucket, client.endpointDisplay()),
+	}, nil
+}
+
+func executeListObjects(ctx context.Context, client *s3Client, input map[string]any) (connectors.ActionResult, error) {
+	prefix := strings.TrimSpace(stringValue(input, "prefix"))
+	search := strings.ToLower(strings.TrimSpace(stringValue(input, "search")))
+	cursor := strings.TrimSpace(stringValue(input, "cursor"))
+	limit := normalizeInt(input, "limit", defaultS3ListLimit, 1, maxS3ListLimit)
+
+	objects := make([]map[string]any, 0, limit)
+	directories := make([]map[string]any, 0)
+	nextCursor := cursor
+	isTruncated := false
+	scanned := 0
+	scanLimited := false
+	pageLimit := limit
+	delimiter := search == ""
+	if search != "" {
+		pageLimit = maxS3ListLimit
+	}
+
+	for page := 0; page < maxS3SearchPages; page++ {
+		result, err := client.ListObjects(ctx, prefix, nextCursor, pageLimit, delimiter)
+		if err != nil {
+			return connectors.ActionResult{}, err
+		}
+		scanned += len(result.Contents)
+		isTruncated = result.IsTruncated
+		if search == "" {
+			for _, directory := range result.CommonPrefixes {
+				directories = append(directories, s3DirectorySummary(directory))
+			}
+		}
+		for _, object := range result.Contents {
+			if search != "" && !strings.Contains(strings.ToLower(object.Key), search) {
+				continue
+			}
+			objects = append(objects, s3ObjectSummary(object))
+		}
+		nextCursor = result.NextContinuationToken
+		if search == "" || len(objects) >= limit || !result.IsTruncated || nextCursor == "" {
+			break
+		}
+		if page == maxS3SearchPages-1 {
+			scanLimited = true
+		}
+	}
+
+	if search != "" && len(objects) >= limit {
+		isTruncated = nextCursor != ""
+	}
+	return s3ListResult(client.bucket, prefix, search, directories, objects, isTruncated, nextCursor, scanned, scanLimited), nil
+}
+
+func s3ObjectSummary(object s3Object) map[string]any {
+	return map[string]any{
+		"key":           object.Key,
+		"size":          object.Size,
+		"last_modified": object.LastModified,
+		"etag":          strings.Trim(object.ETag, `"`),
+		"storage_class": object.StorageClass,
+	}
+}
+
+func s3DirectorySummary(directory s3CommonPrefix) map[string]any {
+	return map[string]any{
+		"prefix": directory.Prefix,
+		"name":   directoryName(directory.Prefix),
+	}
+}
+
+func s3ListResult(bucket string, prefix string, search string, directories []map[string]any, objects []map[string]any, isTruncated bool, nextCursor string, scanned int, scanLimited bool) connectors.ActionResult {
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"bucket":          bucket,
+			"prefix":          prefix,
+			"search":          search,
+			"directories":     directories,
+			"directory_count": len(directories),
+			"objects":         objects,
+			"count":           len(objects),
+			"is_truncated":    isTruncated,
+			"next_cursor":     nextCursor,
+			"scanned":         scanned,
+			"scan_limited":    scanLimited,
+		},
+		DisplayText: fmt.Sprintf("%d folder(s), %d object(s)", len(directories), len(objects)),
+	}
+}
+
+func executeGetObjectMetadata(ctx context.Context, client *s3Client, input map[string]any) (connectors.ActionResult, error) {
+	key := normalizeObjectKey(input, "key")
+	headers, err := client.HeadObject(ctx, key)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	output := objectMetadataOutput(client.bucket, key, headers)
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      output,
+		DisplayText: fmt.Sprintf("%s · %s bytes", key, fmt.Sprint(output["content_length"])),
+	}, nil
+}
+
+func executeDownloadObject(ctx context.Context, client *s3Client, input map[string]any) (connectors.ActionResult, error) {
+	key := normalizeObjectKey(input, "key")
+	maxBytes := normalizeInt(input, "max_bytes", defaultDownloadMax, 1, maxDownloadBytes)
+	data, headers, err := client.GetObject(ctx, key, maxBytes)
+	if err != nil {
+		return connectors.ActionResult{}, err
+	}
+	output := map[string]any{
+		"bucket":         client.bucket,
+		"key":            key,
+		"filename":       objectFilename(key),
+		"content_type":   headers.Get("Content-Type"),
+		"content_length": len(data),
+		"content_base64": base64.StdEncoding.EncodeToString(data),
+	}
+	return connectors.ActionResult{
+		Status:      connectors.ResultCompleted,
+		Output:      output,
+		DisplayText: fmt.Sprintf("Downloaded %d byte(s) from %s.", len(data), key),
+	}, nil
+}
+
+func executeUploadObject(ctx context.Context, client *s3Client, input map[string]any) (connectors.ActionResult, error) {
+	key := normalizeObjectKey(input, "key")
+	data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(stringValue(input, "content_base64")))
+	if err != nil {
+		return connectors.ActionResult{}, fmt.Errorf("decode content_base64: %w", err)
+	}
+	if len(data) > maxUploadBytes {
+		return connectors.ActionResult{}, fmt.Errorf("object content is larger than %d bytes", maxUploadBytes)
+	}
+	overwrite := boolValue(input, "overwrite")
+	if !overwrite {
+		if _, err := client.HeadObject(ctx, key); err == nil {
+			return connectors.ActionResult{}, fmt.Errorf("object %q already exists; set overwrite=true to replace it", key)
+		} else if !isNotFoundError(err) {
+			return connectors.ActionResult{}, err
+		}
+	}
+	contentType := strings.TrimSpace(stringValue(input, "content_type"))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	if err := client.PutObject(ctx, key, data, contentType, nil); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"bucket":       client.bucket,
+			"key":          key,
+			"bytes":        len(data),
+			"content_type": contentType,
+			"overwritten":  overwrite,
+		},
+		DisplayText: fmt.Sprintf("Uploaded %d byte(s) to %s.", len(data), key),
+	}, nil
+}
+
+func executeRenameObject(ctx context.Context, client *s3Client, input map[string]any) (connectors.ActionResult, error) {
+	sourceKey := normalizeObjectKey(input, "source_key")
+	destinationKey := normalizeObjectKey(input, "destination_key")
+	overwrite := boolValue(input, "overwrite")
+	if !overwrite {
+		if _, err := client.HeadObject(ctx, destinationKey); err == nil {
+			return connectors.ActionResult{}, fmt.Errorf("object %q already exists; set overwrite=true to replace it", destinationKey)
+		} else if !isNotFoundError(err) {
+			return connectors.ActionResult{}, err
+		}
+	}
+	if err := client.CopyObject(ctx, sourceKey, destinationKey); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	if err := client.DeleteObject(ctx, sourceKey); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"bucket":          client.bucket,
+			"source_key":      sourceKey,
+			"destination_key": destinationKey,
+			"overwritten":     overwrite,
+		},
+		DisplayText: fmt.Sprintf("Renamed %s to %s.", sourceKey, destinationKey),
+	}, nil
+}
+
+func executeDeleteObject(ctx context.Context, client *s3Client, input map[string]any) (connectors.ActionResult, error) {
+	key := normalizeObjectKey(input, "key")
+	if err := client.DeleteObject(ctx, key); err != nil {
+		return connectors.ActionResult{}, err
+	}
+	return connectors.ActionResult{
+		Status: connectors.ResultCompleted,
+		Output: map[string]any{
+			"bucket":  client.bucket,
+			"key":     key,
+			"deleted": true,
+		},
+		DisplayText: fmt.Sprintf("Deleted %s.", key),
+	}, nil
+}
+
+type s3Client struct {
+	scheme       string
+	host         string
+	port         int
+	region       string
+	bucket       string
+	pathStyle    bool
+	accessKey    string
+	secretKey    string
+	sessionToken string
+	httpClient   *http.Client
+}
+
+func newS3Client(ctx context.Context, runtime connectors.RuntimeContext) (*s3Client, error) {
+	transport, _ := runtime.Capability(connectors.NetworkTransportCapabilityName).(connectors.NetworkTransport)
+	if transport == nil {
+		return nil, ErrMissingTransport
+	}
+	accessKey := strings.TrimSpace(stringValue(runtime.Profile.Public, "access_key_id"))
+	if accessKey == "" {
+		return nil, fmt.Errorf("%w: access_key_id is required", ErrMissingSecret)
+	}
+	secretKey, err := runtime.Secrets.GetSecret(ctx, "secret_access_key")
+	if err != nil || strings.TrimSpace(secretKey) == "" {
+		return nil, fmt.Errorf("%w: secret_access_key is required", ErrMissingSecret)
+	}
+	sessionToken, _ := runtime.Secrets.GetSecret(ctx, "session_token")
+	client := &s3Client{
+		scheme:       s3Scheme(runtime.Target),
+		host:         s3Host(runtime.Target),
+		port:         s3Port(runtime.Target),
+		region:       s3Region(runtime.Target),
+		bucket:       s3Bucket(runtime.Target),
+		pathStyle:    s3PathStyle(runtime.Target),
+		accessKey:    accessKey,
+		secretKey:    strings.TrimSpace(secretKey),
+		sessionToken: strings.TrimSpace(sessionToken),
+	}
+	if client.bucket == "" {
+		return nil, fmt.Errorf("%w: bucket is required", ErrInvalidConfig)
+	}
+	request := connectors.NetworkDialRequest{
+		Mode:               connectionMode(runtime.Target),
+		Host:               client.host,
+		Port:               client.port,
+		TransportTargetRef: strings.TrimSpace(stringValue(runtime.Target.Config, "transport_target_ref")),
+	}
+	httpTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
+			return transport.DialConnectorTCP(ctx, request)
+		},
+		ForceAttemptHTTP2:     false,
+		MaxIdleConns:          2,
+		IdleConnTimeout:       30 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	client.httpClient = &http.Client{Timeout: s3HTTPTimeout, Transport: httpTransport}
+	return client, nil
+}
+
+func (client *s3Client) HeadBucket(ctx context.Context) (http.Header, error) {
+	_, headers, err := client.Do(ctx, http.MethodHead, "", nil, nil, maxS3ResponseBytes)
+	return headers, err
+}
+
+func (client *s3Client) ListObjects(ctx context.Context, prefix string, token string, limit int, delimiter bool) (s3ListBucketResult, error) {
+	query := url.Values{}
+	query.Set("list-type", "2")
+	query.Set("max-keys", strconv.Itoa(limit))
+	if prefix != "" {
+		query.Set("prefix", prefix)
+	}
+	if delimiter {
+		query.Set("delimiter", "/")
+	}
+	if token != "" {
+		query.Set("continuation-token", token)
+	}
+	data, _, err := client.Do(ctx, http.MethodGet, "", query, nil, maxS3ResponseBytes)
+	if err != nil {
+		return s3ListBucketResult{}, err
+	}
+	var result s3ListBucketResult
+	if err := xml.Unmarshal(data, &result); err != nil {
+		return s3ListBucketResult{}, fmt.Errorf("decode s3 list response: %w", err)
+	}
+	return result, nil
+}
+
+func (client *s3Client) HeadObject(ctx context.Context, key string) (http.Header, error) {
+	_, headers, err := client.Do(ctx, http.MethodHead, key, nil, nil, maxS3ResponseBytes)
+	return headers, err
+}
+
+func (client *s3Client) GetObject(ctx context.Context, key string, maxBytes int) ([]byte, http.Header, error) {
+	return client.Do(ctx, http.MethodGet, key, nil, nil, maxBytes)
+}
+
+func (client *s3Client) PutObject(ctx context.Context, key string, data []byte, contentType string, headers http.Header) error {
+	if headers == nil {
+		headers = http.Header{}
+	}
+	headers.Set("Content-Type", contentType)
+	_, _, err := client.Do(ctx, http.MethodPut, key, nil, s3RequestBody{Headers: headers, Data: data}, maxS3ResponseBytes)
+	return err
+}
+
+func (client *s3Client) CopyObject(ctx context.Context, sourceKey string, destinationKey string) error {
+	headers := http.Header{}
+	headers.Set("X-Amz-Copy-Source", "/"+awsPathEscape(client.bucket)+"/"+awsPathEscape(sourceKey))
+	_, _, err := client.Do(ctx, http.MethodPut, destinationKey, nil, s3RequestBody{Headers: headers}, maxS3ResponseBytes)
+	return err
+}
+
+func (client *s3Client) DeleteObject(ctx context.Context, key string) error {
+	_, _, err := client.Do(ctx, http.MethodDelete, key, nil, nil, maxS3ResponseBytes)
+	return err
+}
+
+func (client *s3Client) Do(ctx context.Context, method string, key string, query url.Values, body any, limit int) ([]byte, http.Header, error) {
+	var payload []byte
+	headers := http.Header{}
+	if requestBody, ok := body.(s3RequestBody); ok {
+		payload = requestBody.Data
+		headers = requestBody.Headers.Clone()
+	} else if body != nil {
+		return nil, nil, fmt.Errorf("unsupported s3 request body")
+	}
+	if headers == nil {
+		headers = http.Header{}
+	}
+	u := client.URL(key, query)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), bytes.NewReader(payload))
+	if err != nil {
+		return nil, nil, err
+	}
+	for name, values := range headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+	client.Sign(req, payload)
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+	readLimit := limit
+	if readLimit <= 0 {
+		readLimit = maxS3ResponseBytes
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, int64(readLimit)+1))
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(data) > readLimit {
+		return nil, resp.Header, fmt.Errorf("s3 response is larger than %d bytes", readLimit)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, resp.Header, s3HTTPError(resp.StatusCode, data)
+	}
+	return data, resp.Header, nil
+}
+
+func (client *s3Client) URL(key string, query url.Values) *url.URL {
+	host := net.JoinHostPort(client.host, strconv.Itoa(client.port))
+	if (client.scheme == "http" && client.port == 80) || (client.scheme == "https" && client.port == 443) {
+		host = client.host
+	}
+	path := ""
+	rawPath := ""
+	if client.pathStyle {
+		path = "/" + client.bucket
+		rawPath = "/" + awsPathEscape(client.bucket)
+		if key != "" {
+			path += "/" + key
+			rawPath += "/" + awsPathEscape(key)
+		}
+	} else {
+		host = client.bucket + "." + host
+		path = "/"
+		rawPath = "/"
+		if key != "" {
+			path += key
+			rawPath += awsPathEscape(key)
+		}
+	}
+	u := &url.URL{Scheme: client.scheme, Host: host, Path: path}
+	if rawPath != "" && rawPath != path {
+		u.RawPath = rawPath
+	}
+	if len(query) > 0 {
+		u.RawQuery = canonicalQuery(query)
+	}
+	return u
+}
+
+func (client *s3Client) Sign(req *http.Request, payload []byte) {
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+	payloadHash := sha256Hex(payload)
+	req.Header.Set("X-Amz-Date", amzDate)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	if client.sessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", client.sessionToken)
+	}
+	canonicalRequest, signedHeaders := canonicalRequest(req, payloadHash)
+	credentialScope := dateStamp + "/" + client.region + "/s3/aws4_request"
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+	signingKey := awsSigningKey(client.secretKey, dateStamp, client.region)
+	signature := hmacSHA256Hex(signingKey, stringToSign)
+	req.Header.Set("Authorization", fmt.Sprintf(
+		"AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		client.accessKey,
+		credentialScope,
+		signedHeaders,
+		signature,
+	))
+}
+
+func (client *s3Client) endpointDisplay() string {
+	return fmt.Sprintf("%s://%s", client.scheme, net.JoinHostPort(client.host, strconv.Itoa(client.port)))
+}
+
+type s3RequestBody struct {
+	Headers http.Header
+	Data    []byte
+}
+
+type s3ListBucketResult struct {
+	XMLName               xml.Name         `xml:"ListBucketResult"`
+	Name                  string           `xml:"Name"`
+	Prefix                string           `xml:"Prefix"`
+	KeyCount              int              `xml:"KeyCount"`
+	MaxKeys               int              `xml:"MaxKeys"`
+	IsTruncated           bool             `xml:"IsTruncated"`
+	NextContinuationToken string           `xml:"NextContinuationToken"`
+	Contents              []s3Object       `xml:"Contents"`
+	CommonPrefixes        []s3CommonPrefix `xml:"CommonPrefixes"`
+}
+
+type s3Object struct {
+	Key          string `xml:"Key"`
+	LastModified string `xml:"LastModified"`
+	ETag         string `xml:"ETag"`
+	Size         int64  `xml:"Size"`
+	StorageClass string `xml:"StorageClass"`
+}
+
+type s3CommonPrefix struct {
+	Prefix string `xml:"Prefix"`
+}
+
+func canonicalRequest(req *http.Request, payloadHash string) (string, string) {
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+	headers := map[string]string{
+		"host":                 host,
+		"x-amz-content-sha256": payloadHash,
+		"x-amz-date":           req.Header.Get("X-Amz-Date"),
+	}
+	for name, values := range req.Header {
+		lower := strings.ToLower(name)
+		if strings.HasPrefix(lower, "x-amz-") || lower == "content-type" {
+			headers[lower] = strings.Join(values, ",")
+		}
+	}
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var canonicalHeaders strings.Builder
+	for _, key := range keys {
+		canonicalHeaders.WriteString(key)
+		canonicalHeaders.WriteByte(':')
+		canonicalHeaders.WriteString(canonicalHeaderValue(headers[key]))
+		canonicalHeaders.WriteByte('\n')
+	}
+	signedHeaders := strings.Join(keys, ";")
+	canonicalURI := req.URL.EscapedPath()
+	if canonicalURI == "" {
+		canonicalURI = "/"
+	}
+	return strings.Join([]string{
+		req.Method,
+		canonicalURI,
+		canonicalQuery(req.URL.Query()),
+		canonicalHeaders.String(),
+		signedHeaders,
+		payloadHash,
+	}, "\n"), signedHeaders
+}
+
+func awsSigningKey(secret string, dateStamp string, region string) []byte {
+	dateKey := hmacSHA256([]byte("AWS4"+secret), dateStamp)
+	regionKey := hmacSHA256(dateKey, region)
+	serviceKey := hmacSHA256(regionKey, "s3")
+	return hmacSHA256(serviceKey, "aws4_request")
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(data))
+	return mac.Sum(nil)
+}
+
+func hmacSHA256Hex(key []byte, data string) string {
+	return hex.EncodeToString(hmacSHA256(key, data))
+}
+
+func sha256Hex(data []byte) string {
+	if len(data) == 0 {
+		return emptySHA256Hex
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func canonicalQuery(values url.Values) string {
+	if len(values) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0)
+	for _, key := range keys {
+		rawValues := append([]string(nil), values[key]...)
+		sort.Strings(rawValues)
+		for _, value := range rawValues {
+			parts = append(parts, awsQueryEscape(key)+"="+awsQueryEscape(value))
+		}
+	}
+	return strings.Join(parts, "&")
+}
+
+func awsPathEscape(value string) string {
+	segments := strings.Split(value, "/")
+	for i, segment := range segments {
+		segments[i] = awsQueryEscape(segment)
+	}
+	return strings.Join(segments, "/")
+}
+
+func awsQueryEscape(value string) string {
+	escaped := url.QueryEscape(value)
+	escaped = strings.ReplaceAll(escaped, "+", "%20")
+	escaped = strings.ReplaceAll(escaped, "%7E", "~")
+	return escaped
+}
+
+func canonicalHeaderValue(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func s3HTTPError(status int, data []byte) error {
+	message := strings.TrimSpace(string(data))
+	if len(message) > 800 {
+		message = message[:800] + "...[truncated]"
+	}
+	if message == "" {
+		message = http.StatusText(status)
+	}
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("s3 authentication or permission failed: %s", message)
+	case http.StatusNotFound:
+		return fmt.Errorf("s3 object or bucket not found: %s", message)
+	default:
+		return fmt.Errorf("s3 request failed with HTTP %d: %s", status, message)
+	}
+}
+
+func classifyS3TestError(err error) connectors.TestStatus {
+	if err == nil {
+		return connectors.TestOK
+	}
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "authentication") || strings.Contains(message, "permission") || strings.Contains(message, "forbidden") || strings.Contains(message, "unauthorized"):
+		return connectors.TestFailedAuth
+	case strings.Contains(message, "no such host") || strings.Contains(message, "connection refused") || strings.Contains(message, "timeout") || strings.Contains(message, "network"):
+		return connectors.TestFailedNetwork
+	case strings.Contains(message, "tls") || strings.Contains(message, "certificate"):
+		return connectors.TestFailedTLS
+	default:
+		return connectors.TestUnknownError
+	}
+}
+
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "not found") || strings.Contains(message, "404")
+}
+
+func objectMetadataOutput(bucket string, key string, headers http.Header) map[string]any {
+	output := map[string]any{
+		"bucket":         bucket,
+		"key":            key,
+		"content_type":   headers.Get("Content-Type"),
+		"content_length": int64Header(headers, "Content-Length"),
+		"etag":           strings.Trim(headers.Get("ETag"), `"`),
+		"last_modified":  headers.Get("Last-Modified"),
+		"metadata":       userMetadata(headers),
+	}
+	return output
+}
+
+func safeHeaders(headers http.Header) map[string]string {
+	result := map[string]string{}
+	for name, values := range headers {
+		lower := strings.ToLower(name)
+		if lower == "authorization" || strings.Contains(lower, "token") || strings.Contains(lower, "secret") || strings.Contains(lower, "credential") {
+			continue
+		}
+		if len(values) > 0 {
+			result[name] = values[0]
+		}
+	}
+	return result
+}
+
+func userMetadata(headers http.Header) map[string]string {
+	result := map[string]string{}
+	for name, values := range headers {
+		if !strings.HasPrefix(strings.ToLower(name), "x-amz-meta-") || len(values) == 0 {
+			continue
+		}
+		result[strings.TrimPrefix(strings.ToLower(name), "x-amz-meta-")] = values[0]
+	}
+	return result
+}
+
+func int64Header(headers http.Header, name string) int64 {
+	value := strings.TrimSpace(headers.Get(name))
+	if value == "" {
+		return 0
+	}
+	parsed, _ := strconv.ParseInt(value, 10, 64)
+	return parsed
+}
+
+func firstHeader(headers http.Header, names ...string) string {
+	for _, name := range names {
+		if value := strings.TrimSpace(headers.Get(name)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func uploadBytes(contentText string, contentBase64 string) ([]byte, error) {
+	if contentBase64 != "" {
+		data, err := base64.StdEncoding.DecodeString(contentBase64)
+		if err != nil {
+			return nil, fmt.Errorf("decode content_base64: %w", err)
+		}
+		return data, nil
+	}
+	return []byte(contentText), nil
+}
+
+func normalizeObjectKey(input map[string]any, name string) string {
+	key := strings.TrimSpace(stringValue(input, name))
+	key = strings.TrimLeft(key, "/")
+	return key
+}
+
+func objectFilename(key string) string {
+	parts := strings.Split(strings.TrimRight(key, "/"), "/")
+	if len(parts) == 0 || strings.TrimSpace(parts[len(parts)-1]) == "" {
+		return "s3-object"
+	}
+	return parts[len(parts)-1]
+}
+
+func directoryName(prefix string) string {
+	parts := strings.Split(strings.TrimRight(prefix, "/"), "/")
+	if len(parts) == 0 || strings.TrimSpace(parts[len(parts)-1]) == "" {
+		return prefix
+	}
+	return parts[len(parts)-1]
+}
+
+func s3Scheme(target connectors.TargetView) string {
+	scheme := strings.ToLower(strings.TrimSpace(stringValue(target.Config, "scheme")))
+	if scheme != "http" && scheme != "https" {
+		return defaultS3Scheme
+	}
+	return scheme
+}
+
+func s3Host(target connectors.TargetView) string {
+	host := strings.TrimSpace(stringValue(target.Config, "host"))
+	if host == "" {
+		return defaultS3Host
+	}
+	return host
+}
+
+func s3Port(target connectors.TargetView) int {
+	defaultPort := defaultS3Port
+	if s3Scheme(target) == "http" {
+		defaultPort = 80
+	}
+	return normalizeInt(target.Config, "port", defaultPort, 1, 65535)
+}
+
+func s3Region(target connectors.TargetView) string {
+	region := strings.TrimSpace(stringValue(target.Config, "region"))
+	if region == "" {
+		return defaultS3Region
+	}
+	return region
+}
+
+func s3Bucket(target connectors.TargetView) string {
+	return strings.TrimSpace(stringValue(target.Config, "bucket"))
+}
+
+func s3PathStyle(target connectors.TargetView) bool {
+	value, ok := target.Config["path_style"]
+	if !ok {
+		return true
+	}
+	return boolish(value)
+}
+
+func connectionMode(target connectors.TargetView) string {
+	mode := strings.TrimSpace(stringValue(target.Config, "connection_mode"))
+	if mode == "" {
+		return "direct"
+	}
+	return mode
+}
+
+func copyMap(value map[string]any) map[string]any {
+	out := map[string]any{}
+	for key, item := range value {
+		out[key] = item
+	}
+	return out
+}
+
+func stringValue(values map[string]any, name string) string {
+	if values == nil {
+		return ""
+	}
+	switch value := values[name].(type) {
+	case string:
+		return value
+	case fmt.Stringer:
+		return value.String()
+	case float64:
+		if value == float64(int64(value)) {
+			return strconv.FormatInt(int64(value), 10)
+		}
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(value)
+	case int64:
+		return strconv.FormatInt(value, 10)
+	case bool:
+		return strconv.FormatBool(value)
+	default:
+		if value == nil {
+			return ""
+		}
+		return fmt.Sprint(value)
+	}
+}
+
+func normalizeInt(values map[string]any, name string, fallback int, minValue int, maxValue int) int {
+	value, ok := values[name]
+	if !ok || value == nil || value == "" {
+		return fallback
+	}
+	parsed := fallback
+	switch typed := value.(type) {
+	case int:
+		parsed = typed
+	case int64:
+		parsed = int(typed)
+	case float64:
+		parsed = int(typed)
+	case string:
+		if candidate, err := strconv.Atoi(strings.TrimSpace(typed)); err == nil {
+			parsed = candidate
+		}
+	}
+	if parsed < minValue {
+		return minValue
+	}
+	if parsed > maxValue {
+		return maxValue
+	}
+	return parsed
+}
+
+func boolValue(values map[string]any, name string) bool {
+	if values == nil {
+		return false
+	}
+	return boolish(values[name])
+}
+
+func boolish(value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		parsed, _ := strconv.ParseBool(strings.TrimSpace(typed))
+		return parsed
+	case float64:
+		return typed != 0
+	case int:
+		return typed != 0
+	default:
+		return false
+	}
+}

--- a/backend/internal/connectors/s3/s3.go
+++ b/backend/internal/connectors/s3/s3.go
@@ -1093,7 +1093,7 @@ func classifyS3TestError(err error) connectors.TestStatus {
 	switch {
 	case strings.Contains(message, "authentication") || strings.Contains(message, "permission") || strings.Contains(message, "forbidden") || strings.Contains(message, "unauthorized"):
 		return connectors.TestFailedAuth
-	case strings.Contains(message, "no such host") || strings.Contains(message, "connection refused") || strings.Contains(message, "timeout") || strings.Contains(message, "network"):
+	case strings.Contains(message, "no such host") || strings.Contains(message, "connection refused") || strings.Contains(message, "timeout") || strings.Contains(message, "deadline exceeded") || strings.Contains(message, "network"):
 		return connectors.TestFailedNetwork
 	case strings.Contains(message, "tls") || strings.Contains(message, "certificate"):
 		return connectors.TestFailedTLS

--- a/backend/internal/connectors/s3/s3_test.go
+++ b/backend/internal/connectors/s3/s3_test.go
@@ -1,0 +1,359 @@
+package s3connector
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+func TestPrepareUploadRedactsContentPreview(t *testing.T) {
+	connector := New()
+	prepared, err := connector.PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     s3TestTarget(t, "http://127.0.0.1:9000"),
+		Profile:    s3TestProfile(),
+		ActionName: ActionUploadObject,
+		Input: map[string]any{
+			"key":          "/daily/secret.txt",
+			"content_text": "super-secret-content",
+			"content_type": "text/plain",
+			"overwrite":    true,
+		},
+		Reason: "unit test",
+	})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if prepared.Risk != connectors.RiskWrite {
+		t.Fatalf("risk = %q", prepared.Risk)
+	}
+	if prepared.Payload["key"] != "daily/secret.txt" {
+		t.Fatalf("key = %#v", prepared.Payload["key"])
+	}
+	if strings.Contains(strings.Join(mapValues(prepared.Preview), " "), "super-secret-content") {
+		t.Fatalf("preview leaked upload content: %#v", prepared.Preview)
+	}
+	if prepared.Payload["content_base64"] == "" {
+		t.Fatalf("payload missing normalized content")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(prepared.Payload["content_base64"].(string))
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if string(decoded) != "super-secret-content" {
+		t.Fatalf("decoded payload = %q", decoded)
+	}
+}
+
+func TestExecuteListObjectsSignsBoundedRequest(t *testing.T) {
+	var requestedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.String()
+		if r.Header.Get("Authorization") == "" {
+			t.Fatal("missing authorization header")
+		}
+		if r.Header.Get("X-Amz-Date") == "" {
+			t.Fatal("missing x-amz-date header")
+		}
+		if r.URL.Path != "/test-bucket" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("list-type") != "2" {
+			t.Fatalf("query = %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<ListBucketResult>
+<Name>test-bucket</Name>
+<IsTruncated>false</IsTruncated>
+<Contents><Key>daily/app.aipdb</Key><LastModified>2026-06-29T10:00:00.000Z</LastModified><ETag>"abc"</ETag><Size>42</Size><StorageClass>STANDARD</StorageClass></Contents>
+<Contents><Key>daily/notes.txt</Key><LastModified>2026-06-29T10:01:00.000Z</LastModified><ETag>"def"</ETag><Size>12</Size><StorageClass>STANDARD</StorageClass></Contents>
+</ListBucketResult>`))
+	}))
+	defer server.Close()
+
+	connector := New()
+	result, err := connector.ExecuteAction(context.Background(), s3TestRuntime(t, server.URL), connectors.PreparedAction{
+		ActionName: ActionListObjects,
+		Payload:    map[string]any{"prefix": "daily/", "search": "app", "limit": 10},
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	output := result.Output.(map[string]any)
+	if output["count"] != 1 {
+		t.Fatalf("count = %#v output=%#v", output["count"], output)
+	}
+	objects := output["objects"].([]map[string]any)
+	if objects[0]["key"] != "daily/app.aipdb" {
+		t.Fatalf("objects = %#v", objects)
+	}
+	if !strings.Contains(requestedPath, "prefix=daily%2F") {
+		t.Fatalf("requested path = %q", requestedPath)
+	}
+}
+
+func TestExecuteListObjectsSearchScansSubsequentPages(t *testing.T) {
+	requests := 0
+	var sawCursor bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get("Authorization") == "" {
+			t.Fatal("missing authorization header")
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		switch requests {
+		case 1:
+			_, _ = w.Write([]byte(`<ListBucketResult>
+<Name>test-bucket</Name>
+<IsTruncated>true</IsTruncated>
+<NextContinuationToken>page-2</NextContinuationToken>
+<Contents><Key>daily/other.txt</Key><LastModified>2026-06-29T10:00:00.000Z</LastModified><ETag>"abc"</ETag><Size>42</Size><StorageClass>STANDARD</StorageClass></Contents>
+</ListBucketResult>`))
+		case 2:
+			sawCursor = r.URL.Query().Get("continuation-token") == "page-2"
+			_, _ = w.Write([]byte(`<ListBucketResult>
+<Name>test-bucket</Name>
+<IsTruncated>false</IsTruncated>
+<Contents><Key>assets/candleswarm-icon.svg</Key><LastModified>2026-06-29T10:01:00.000Z</LastModified><ETag>"def"</ETag><Size>12</Size><StorageClass>STANDARD</StorageClass></Contents>
+</ListBucketResult>`))
+		default:
+			t.Fatalf("unexpected extra request %d", requests)
+		}
+	}))
+	defer server.Close()
+
+	connector := New()
+	result, err := connector.ExecuteAction(context.Background(), s3TestRuntime(t, server.URL), connectors.PreparedAction{
+		ActionName: ActionListObjects,
+		Payload:    map[string]any{"search": "candleswarm-icon.svg", "limit": 10},
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d", requests)
+	}
+	if !sawCursor {
+		t.Fatal("second request did not use continuation cursor")
+	}
+	output := result.Output.(map[string]any)
+	if output["count"] != 1 {
+		t.Fatalf("count = %#v output=%#v", output["count"], output)
+	}
+	objects := output["objects"].([]map[string]any)
+	if objects[0]["key"] != "assets/candleswarm-icon.svg" {
+		t.Fatalf("objects = %#v", objects)
+	}
+}
+
+func TestExecuteListObjectsReturnsDirectoryPrefixes(t *testing.T) {
+	var requestedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.String()
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<ListBucketResult>
+<Name>test-bucket</Name>
+<IsTruncated>false</IsTruncated>
+<CommonPrefixes><Prefix>2025/</Prefix></CommonPrefixes>
+<CommonPrefixes><Prefix>2026/</Prefix></CommonPrefixes>
+<Contents><Key>root.txt</Key><LastModified>2026-06-29T10:00:00.000Z</LastModified><ETag>"abc"</ETag><Size>42</Size><StorageClass>STANDARD</StorageClass></Contents>
+</ListBucketResult>`))
+	}))
+	defer server.Close()
+
+	connector := New()
+	result, err := connector.ExecuteAction(context.Background(), s3TestRuntime(t, server.URL), connectors.PreparedAction{
+		ActionName: ActionListObjects,
+		Payload:    map[string]any{"limit": 10},
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(requestedPath, "delimiter=%2F") {
+		t.Fatalf("requested path = %q", requestedPath)
+	}
+	output := result.Output.(map[string]any)
+	if output["directory_count"] != 2 {
+		t.Fatalf("directory_count = %#v output=%#v", output["directory_count"], output)
+	}
+	directories := output["directories"].([]map[string]any)
+	if directories[0]["prefix"] != "2025/" || directories[1]["name"] != "2026" {
+		t.Fatalf("directories = %#v", directories)
+	}
+}
+
+func TestPrepareListObjectsUsesNonSecretCursorPayload(t *testing.T) {
+	connector := New()
+	prepared, err := connector.PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     s3TestTarget(t, "http://127.0.0.1:9000"),
+		Profile:    s3TestProfile(),
+		ActionName: ActionListObjects,
+		Input: map[string]any{
+			"prefix": "daily/",
+			"search": "app",
+			"cursor": "opaque-pagination-cursor",
+			"limit":  10,
+		},
+		Reason: "unit test",
+	})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if prepared.Payload["cursor"] != "opaque-pagination-cursor" {
+		t.Fatalf("cursor = %#v", prepared.Payload["cursor"])
+	}
+	if _, ok := prepared.Payload["continuation_token"]; ok {
+		t.Fatalf("payload should not use token-named pagination field: %#v", prepared.Payload)
+	}
+}
+
+func TestExecuteUploadRejectsExistingObjectWithoutOverwrite(t *testing.T) {
+	putCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			putCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	connector := New()
+	_, err := connector.ExecuteAction(context.Background(), s3TestRuntime(t, server.URL), connectors.PreparedAction{
+		ActionName: ActionUploadObject,
+		Payload: map[string]any{
+			"key":            "daily/app.txt",
+			"content_base64": base64.StdEncoding.EncodeToString([]byte("hello")),
+			"content_type":   "text/plain",
+			"overwrite":      false,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected overwrite guard error")
+	}
+	if putCalled {
+		t.Fatal("put should not run when overwrite guard fails")
+	}
+}
+
+func TestS3URLPreservesRawPathEscaping(t *testing.T) {
+	client := &s3Client{
+		scheme:    "https",
+		host:      "s3.example.com",
+		port:      443,
+		bucket:    "my bucket",
+		pathStyle: true,
+	}
+	u := client.URL("folder name/object #1.txt", nil)
+	if u.Path != "/my bucket/folder name/object #1.txt" {
+		t.Fatalf("path = %q", u.Path)
+	}
+	if u.EscapedPath() != "/my%20bucket/folder%20name/object%20%231.txt" {
+		t.Fatalf("escaped path = %q", u.EscapedPath())
+	}
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	canonical, signedHeaders := canonicalRequest(req, emptySHA256Hex)
+	if signedHeaders != "host;x-amz-content-sha256;x-amz-date" {
+		t.Fatalf("signed headers = %q", signedHeaders)
+	}
+	if !strings.Contains(canonical, "\nhost:s3.example.com\n") {
+		t.Fatalf("canonical request missing url host: %q", canonical)
+	}
+}
+
+func s3TestRuntime(t *testing.T, rawURL string) connectors.RuntimeContext {
+	t.Helper()
+	return connectors.RuntimeContext{
+		Target:       s3TestTarget(t, rawURL),
+		Profile:      s3TestProfile(),
+		Secrets:      staticSecrets{"secret_access_key": "test-secret"},
+		Capabilities: s3TestCapabilities{},
+	}
+}
+
+func s3TestTarget(t *testing.T, rawURL string) connectors.TargetView {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	host, portText, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		t.Fatalf("split host: %v", err)
+	}
+	return connectors.TargetView{
+		ID:            7,
+		Ref:           "s3:7:70",
+		ConnectorKind: Kind,
+		Name:          "object-store",
+		Config: map[string]any{
+			"connection_mode": "direct",
+			"scheme":          parsed.Scheme,
+			"host":            host,
+			"port":            portText,
+			"region":          "us-east-1",
+			"bucket":          "test-bucket",
+			"path_style":      true,
+		},
+	}
+}
+
+func s3TestProfile() connectors.CredentialProfileView {
+	return connectors.CredentialProfileView{
+		ID:            70,
+		TargetID:      7,
+		ConnectorKind: Kind,
+		Kind:          "access_key",
+		Label:         "default",
+		Public:        map[string]any{"access_key_id": "test-access"},
+	}
+}
+
+type staticSecrets map[string]string
+
+func (secrets staticSecrets) GetSecret(_ context.Context, name string) (string, error) {
+	return secrets[name], nil
+}
+
+type s3TestCapabilities struct{}
+
+func (s3TestCapabilities) RuntimeCapability(name string) connectors.RuntimeCapability {
+	if name == connectors.NetworkTransportCapabilityName {
+		return directTransport{}
+	}
+	return nil
+}
+
+type directTransport struct{}
+
+func (directTransport) ConnectorRuntimeCapability() string {
+	return connectors.NetworkTransportCapabilityName
+}
+
+func (directTransport) DialConnectorTCP(ctx context.Context, request connectors.NetworkDialRequest) (net.Conn, error) {
+	var dialer net.Dialer
+	return dialer.DialContext(ctx, "tcp", net.JoinHostPort(request.Host, strconv.Itoa(request.Port)))
+}
+
+func mapValues(values map[string]any) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, fmt.Sprint(value))
+	}
+	return out
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 AIPermission has published its first public release candidate and is moving
 into the connector-native 0.2 line. The local-only permission gateway is usable
-today with built-in SSH, Postgres, Redis, and RabbitMQ connectors; the next releases focus on
+today with built-in SSH, Postgres, Redis, RabbitMQ, and S3 connectors; the next releases focus on
 dogfooding polish, small safety improvements, clearer contributor paths, and
 additional connector kinds such as API, queues, and storage that share one
 permission pipeline.
@@ -53,7 +53,7 @@ AIPermission is intentionally:
 - Local-only.
 - Single-user.
 - Developer-focused.
-- Connector-based, with built-in SSH, Postgres, Redis, and RabbitMQ.
+- Connector-based, with built-in SSH, Postgres, Redis, RabbitMQ, and S3.
 - Human-in-the-loop.
 
 These requests conflict with the project principles and should normally be
@@ -186,6 +186,8 @@ Goals:
   TCP transport.
 - Add RabbitMQ as the first queue connector with direct and SSH-tunneled
   Management API access.
+- Add S3 as the first object-storage connector with direct and SSH-tunneled
+  S3-compatible endpoint access.
 - Store connector permissions by target/profile/action instead of by a
   connector-specific table.
 - Render connector UI through frontend templates so contributors can add a

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -2,7 +2,7 @@
 
 The MCP surface is connector-first. AIPermission does not expose separate
 product-specific MCP wrappers for SSH, database, cache, queue, or container
-products. SSH, Postgres, Redis, RabbitMQ, Docker, Kubernetes, and future
+products. SSH, Postgres, Redis, RabbitMQ, S3, Docker, Kubernetes, and future
 integrations are reached through the same connector target/action pipeline.
 
 Recommended package use:
@@ -53,6 +53,7 @@ redis:8:3
 rabbitmq:9:4
 docker:10:5
 kubernetes:11:6
+s3:12:7
 ```
 
 The profile chooses which stored credential is used. The connector action still
@@ -60,7 +61,7 @@ runs locally through the gateway; AIPermission does not host a remote connector
 service.
 
 Clients should discover targets and actions at runtime. Do not hardcode SSH,
-Postgres, Redis, RabbitMQ, Docker, or Kubernetes as special MCP modes; future
+Postgres, Redis, RabbitMQ, S3, Docker, or Kubernetes as special MCP modes; future
 connector kinds use the same tools and `target_ref` shape.
 
 ## list_connector_targets
@@ -145,6 +146,11 @@ queue listing, queue detail reads, binding listing, and bounded message peeking
 with `ack_requeue_true`, plus explicit `publish_message` writes. Message
 payload previews and published payloads may contain secrets or customer data;
 prefer approval-required access until the workflow is trusted.
+
+S3 actions include bucket metadata, bounded object listing, object metadata,
+bounded object download/upload, object rename, and explicit delete. Object
+content may contain secrets or customer data; prefer approval-required access
+for downloads, uploads, renames, and deletes until the workflow is trusted.
 
 Docker actions include version metadata, scoped container/image/network/volume
 listing, redacted container inspect metadata, bounded container log tails,

--- a/docs/mvp/scope.md
+++ b/docs/mvp/scope.md
@@ -12,7 +12,7 @@ The MVP is not a DevOps platform. It does not own production operations. It give
 
 The MVP does not introduce first-class management modules for every external
 system. It introduces one connector pipeline. SSH, Postgres, Redis, RabbitMQ,
-Docker, Kubernetes, and future integrations are connector kinds that provide
+S3, Docker, Kubernetes, and future integrations are connector kinds that provide
 their own actions while sharing the same target/profile/action permission model.
 If an allowed SSH target has the needed CLI tools and access, the AI can operate
 at command level through the SSH connector `exec` action. If a structured
@@ -38,9 +38,9 @@ The gateway itself is local-only. It is not designed to run on a remote server f
   SFTP transfer, and host-key approval
 - built-in Postgres connector with schema/table inspection and bounded
   read-only query actions
-- built-in Redis, RabbitMQ, Docker, and Kubernetes connectors for scoped cache,
-  queue, container runtime, and cluster visibility through the shared connector
-  pipeline
+- built-in Redis, RabbitMQ, S3, Docker, and Kubernetes connectors for scoped
+  cache, queue, object storage, container runtime, and cluster visibility
+  through the shared connector pipeline
 - API token creation and revocation
 - token-to-target/profile/action permissions
 - execution rules: `always_run`, `approval_required`, `blocked`

--- a/docs/setup/docker-runtime.md
+++ b/docs/setup/docker-runtime.md
@@ -21,7 +21,7 @@ Pin a specific release image with `AIPERMISSION_VERSION` without the leading
 `v`:
 
 ```txt
-AIPERMISSION_VERSION=0.2.10 docker compose -f docker-compose.release.yml up -d
+AIPERMISSION_VERSION=0.2.11 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, keep shell scripts checked out with LF line endings. Git should do

--- a/docs/skills/aipermission-docs/SKILL.md
+++ b/docs/skills/aipermission-docs/SKILL.md
@@ -133,7 +133,7 @@ Use the established aipermission naming:
 - `gateway` is the local backend that owns credentials, policy, execution, approvals, and audit.
 - `MCP client` means Cursor, Windsurf, or another AI tool integration.
 - `API token` means the gateway access token used by MCP/API clients.
-- `connector target` means a saved SSH, Postgres, Redis, RabbitMQ, Docker, Kubernetes, or future integration target.
+- `connector target` means a saved SSH, Postgres, Redis, RabbitMQ, S3, Docker, Kubernetes, or future integration target.
 - `server` is acceptable only when specifically describing an SSH connector target.
 - `database` means a configured Postgres connector target/profile.
 - `execution rule` means `always_run`, `approval_required`, or `blocked`.

--- a/docs/whatis-aipermission.md
+++ b/docs/whatis-aipermission.md
@@ -13,14 +13,16 @@ Related central notes:
 operate on connector targets without receiving SSH private keys, SSH passwords,
 database credentials, API credentials, or other connector secrets.
 
-The current model ships with SSH, Postgres, Redis, RabbitMQ, and Docker
+The current model ships with SSH, Postgres, Redis, RabbitMQ, S3, and Docker
 connectors. SSH provides live terminal/file-transfer actions, Postgres provides
 structured metadata and bounded read-only query actions, Redis provides bounded
 key browsing plus explicit write/delete actions, RabbitMQ provides queue
 metadata, bindings, bounded message previews, and explicit message publishing,
-and Docker provides scoped container/image/network/volume inventory, logs,
-redacted inspect metadata, scoped container exec, live container console, and
-explicit lifecycle actions. They use the same
+S3 provides S3-compatible bucket browsing, object metadata, bounded
+upload/download, rename, and delete actions, and Docker provides scoped
+container/image/network/volume inventory, logs, redacted inspect metadata,
+scoped container exec, live container console, and explicit lifecycle actions.
+They use the same
 target, credential profile,
 token permission, approval, history, and audit pipeline.
 
@@ -259,7 +261,7 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-SSH, Postgres, Redis, RabbitMQ, Docker, Kubernetes, and future integrations are exposed as
+SSH, Postgres, Redis, RabbitMQ, S3, Docker, Kubernetes, and future integrations are exposed as
 connector actions instead of separate product-specific MCP tools.
 
 ## Connector Action Flow

--- a/frontend/src/connectors/templates/docker/model.js
+++ b/frontend/src/connectors/templates/docker/model.js
@@ -191,6 +191,10 @@ export function usesLiveConsole() {
   return true;
 }
 
+export function recoverableRunningActions() {
+  return [];
+}
+
 export function liveConsoleRuntimeTarget({ target }) {
   return {
     id: target.runtime_id,

--- a/frontend/src/connectors/templates/kubernetes/model.js
+++ b/frontend/src/connectors/templates/kubernetes/model.js
@@ -193,6 +193,10 @@ export function usesLiveConsole() {
   return true;
 }
 
+export function recoverableRunningActions() {
+  return [];
+}
+
 export function liveConsoleRuntimeTarget({ target }) {
   return {
     id: target.runtime_id,

--- a/frontend/src/connectors/templates/postgres/model.js
+++ b/frontend/src/connectors/templates/postgres/model.js
@@ -215,6 +215,10 @@ export function usesLiveConsole() {
   return false;
 }
 
+export function recoverableRunningActions() {
+  return [];
+}
+
 export function deleteDialog({ target }) {
   return {
     title: target ? `Delete ${target.name}` : "Delete connector",

--- a/frontend/src/connectors/templates/rabbitmq/model.js
+++ b/frontend/src/connectors/templates/rabbitmq/model.js
@@ -212,6 +212,10 @@ export function usesLiveConsole() {
   return false;
 }
 
+export function recoverableRunningActions() {
+  return [];
+}
+
 export function deleteDialog({ target }) {
   return {
     title: target ? `Delete ${target.name}` : "Delete connector",

--- a/frontend/src/connectors/templates/redis/model.js
+++ b/frontend/src/connectors/templates/redis/model.js
@@ -203,6 +203,10 @@ export function usesLiveConsole() {
   return false;
 }
 
+export function recoverableRunningActions() {
+  return [];
+}
+
 export function deleteDialog({ target }) {
   return {
     title: target ? `Delete ${target.name}` : "Delete connector",

--- a/frontend/src/connectors/templates/registry.jsx
+++ b/frontend/src/connectors/templates/registry.jsx
@@ -27,6 +27,7 @@ const requiredModelFunctions = Object.freeze([
   "targetProfileLabel",
   "targetSubtitle",
   "test",
+  "recoverableRunningActions",
   "usesLiveConsole",
 ]);
 

--- a/frontend/src/connectors/templates/s3/console.jsx
+++ b/frontend/src/connectors/templates/s3/console.jsx
@@ -1,0 +1,899 @@
+import { CornerUpLeft, Database, Download, FileUp, Folder, Pencil, Plus, RefreshCcw, Search, Trash2, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "../../../components/ui/badge";
+import { Button } from "../../../components/ui/button";
+import { CopyButton } from "../../../components/ui/copy-button";
+import { Dialog } from "../../../components/ui/dialog";
+import { Field, Input, Textarea } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+import { TerminalBlock } from "../../../components/ui/terminal-block";
+import { apiPost, saveBlob } from "../../../lib/api";
+
+const defaultListLimit = 100;
+const defaultUploadDialog = {
+  open: false,
+  mode: "files",
+  prefix: "",
+  files: [],
+  textKey: "",
+  textContent: "",
+  textContentType: "text/plain",
+  overwrite: false,
+  pending: false,
+  error: "",
+};
+const defaultRenameDialog = { open: false, value: "", pending: false, error: "" };
+
+export function S3ConnectorConsoleTemplate({ target, approvals, theme, session, onNewStructuredSession, onRefreshActivity }) {
+  const activeSession = session || { active: false, startedAt: "" };
+  const [prefix, setPrefix] = useState("");
+  const [search, setSearch] = useState("");
+  const [directories, setDirectories] = useState([]);
+  const [objects, setObjects] = useState([]);
+  const [nextToken, setNextToken] = useState("");
+  const [selectedKey, setSelectedKey] = useState("");
+  const [metadata, setMetadata] = useState(null);
+  const [metadataSearch, setMetadataSearch] = useState("");
+  const [uploadDialog, setUploadDialog] = useState(defaultUploadDialog);
+  const [renameDialog, setRenameDialog] = useState(defaultRenameDialog);
+  const [confirmDialog, setConfirmDialog] = useState({ open: false, title: "", description: "", details: [], action: null, pending: false, danger: false });
+  const [state, setState] = useState({ state: "idle", error: "", message: "" });
+  const panelClass = theme === "light" ? "bg-white text-stone-900" : "bg-[#1e1e1e] text-stone-100";
+  const mutedClass = theme === "light" ? "text-stone-500" : "text-stone-400";
+  const borderClass = theme === "light" ? "border-stone-200" : "border-stone-700";
+  const subtlePanelClass = theme === "light" ? "bg-stone-50" : "bg-[#252526]";
+  const inputClass = theme === "light" ? "border-stone-300 bg-white text-stone-900 placeholder:text-stone-400" : "border-stone-700 bg-[#1a1a1a] text-stone-100 placeholder:text-stone-500";
+  const rowHoverClass = theme === "light" ? "hover:bg-stone-50" : "hover:bg-stone-800/60";
+  const activeRowClass = theme === "light" ? "border-emerald-200 bg-emerald-50 text-emerald-950" : "border-emerald-700 bg-emerald-950/40 text-emerald-100";
+  const activeItems = useMemo(() => (approvals?.data || []).filter((item) => item.target_ref === target.ref), [approvals?.data, target.ref]);
+  const latestAction = activeItems[0] || null;
+  const selectedObject = objects.find((item) => item.key === selectedKey) || null;
+  const visibleBytes = useMemo(() => objects.reduce((total, object) => total + Number(object.size || 0), 0), [objects]);
+
+  useEffect(() => {
+    setPrefix("");
+    setSearch("");
+    setDirectories([]);
+    setObjects([]);
+    setNextToken("");
+    setSelectedKey("");
+    setMetadata(null);
+    setMetadataSearch("");
+    setUploadDialog(defaultUploadDialog);
+    setRenameDialog(defaultRenameDialog);
+    setState({ state: "idle", error: "", message: "" });
+  }, [target.ref, activeSession.active, activeSession.startedAt]);
+
+  useEffect(() => {
+    if (!activeSession.active) return;
+    void refreshObjects({ reset: true });
+  }, [activeSession.active, activeSession.startedAt, target.ref]);
+
+  async function runS3Action({ actionName, input, reason, busy = "running", suppressError = false }) {
+    setState({ state: busy, error: "", message: "" });
+    try {
+      const item = await apiPost("/api/connector-actions/local-run", {
+        target_ref: target.ref,
+        action_name: actionName,
+        input,
+        reason,
+      });
+      setState({ state: "idle", error: "", message: item.display_text || "" });
+      await onRefreshActivity?.();
+      return item;
+    } catch (error) {
+      if (suppressError) {
+        setState({ state: "idle", error: "", message: "" });
+      } else {
+        setState({ state: "error", error: error.message || "S3 action failed.", message: "" });
+      }
+      throw error;
+    }
+  }
+
+  async function refreshObjects({ reset = true, token = "", nextPrefix = prefix, nextSearch = search } = {}) {
+    if (!activeSession.active) return;
+    const item = await runS3Action({
+      actionName: "list_objects",
+      input: { prefix: nextPrefix, search: nextSearch, cursor: reset ? "" : token, limit: defaultListLimit },
+      reason: "manual S3 browser object list",
+      busy: "loading",
+    });
+    const nextDirectories = Array.isArray(item.output?.directories) ? item.output.directories : [];
+    const nextObjects = Array.isArray(item.output?.objects) ? item.output.objects : [];
+    setDirectories((current) => (reset ? nextDirectories : [...current, ...nextDirectories]));
+    setObjects((current) => (reset ? nextObjects : [...current, ...nextObjects]));
+    setNextToken(item.output?.next_cursor || "");
+    if (reset && selectedKey && !nextObjects.some((object) => object.key === selectedKey)) {
+      setSelectedKey("");
+      setMetadata(null);
+    }
+    return nextObjects;
+  }
+
+  async function openDirectory(directoryPrefix) {
+    if (!activeSession.active || !directoryPrefix) return;
+    setPrefix(directoryPrefix);
+    setSearch("");
+    setSelectedKey("");
+    setMetadata(null);
+    setMetadataSearch("");
+    await refreshObjects({ reset: true, nextPrefix: directoryPrefix, nextSearch: "" });
+  }
+
+  async function openParentDirectory() {
+    const parent = parentPrefix(prefix);
+    setPrefix(parent);
+    setSearch("");
+    setSelectedKey("");
+    setMetadata(null);
+    setMetadataSearch("");
+    await refreshObjects({ reset: true, nextPrefix: parent, nextSearch: "" });
+  }
+
+  async function selectObject(key) {
+    if (!activeSession.active || !key) return;
+    if (selectedKey === key) {
+      setSelectedKey("");
+      setMetadata(null);
+      setMetadataSearch("");
+      return;
+    }
+    await readObjectMetadata(key);
+  }
+
+  async function readObjectMetadata(key) {
+    setSelectedKey(key);
+    setMetadataSearch("");
+    const item = await runS3Action({
+      actionName: "get_object_metadata",
+      input: { key },
+      reason: "manual S3 browser object metadata",
+      busy: "reading",
+      suppressError: false,
+    });
+    setMetadata(item.output || null);
+  }
+
+  async function downloadSelected() {
+    if (!selectedKey) return;
+    const filename = filenameFromKey(selectedKey);
+    const pickerAvailable = typeof window !== "undefined" && typeof window.showSaveFilePicker === "function";
+    let saveHandle = null;
+    if (pickerAvailable) {
+      try {
+        saveHandle = await window.showSaveFilePicker({ suggestedName: safeDownloadName(filename) });
+      } catch (error) {
+        if (error?.name === "AbortError") {
+          setState({ state: "idle", error: "", message: "Download canceled." });
+          return;
+        }
+        throw error;
+      }
+    }
+    const item = await runS3Action({
+      actionName: "download_object",
+      input: { key: selectedKey },
+      reason: "manual S3 browser object download",
+      busy: "downloading",
+    });
+    const output = item.output || {};
+    const blob = base64Blob(output.content_base64 || "", output.content_type || "application/octet-stream");
+    if (saveHandle) {
+      const writable = await saveHandle.createWritable();
+      await writable.write(blob);
+      await writable.close();
+      setState({ state: "idle", error: "", message: `Saved ${output.filename || filename}.` });
+      return;
+    }
+    await saveBlob(blob, output.filename || filename, { picker: false });
+  }
+
+  function openUploadDialog() {
+    setUploadDialog({
+      ...defaultUploadDialog,
+      open: true,
+      prefix: prefix || "",
+      textKey: prefix || "",
+    });
+  }
+
+  function closeUploadDialog() {
+    setUploadDialog((current) => (current.pending ? current : defaultUploadDialog));
+  }
+
+  function addUploadFiles(fileList) {
+    const files = Array.from(fileList || []);
+    if (files.length === 0) return;
+    setUploadDialog((current) => ({
+      ...current,
+      error: "",
+      files: [
+        ...current.files,
+        ...files.map((file) => ({
+          id: `${file.name}-${file.size}-${file.lastModified}-${Math.random().toString(36).slice(2)}`,
+          file,
+          key: joinObjectKey(current.prefix, file.name),
+          contentType: file.type || "application/octet-stream",
+        })),
+      ],
+    }));
+  }
+
+  function removeUploadFile(id) {
+    setUploadDialog((current) => ({ ...current, files: current.files.filter((item) => item.id !== id) }));
+  }
+
+  function updateUploadFile(id, patch) {
+    setUploadDialog((current) => ({
+      ...current,
+      files: current.files.map((item) => (item.id === id ? { ...item, ...patch } : item)),
+    }));
+  }
+
+  async function uploadObjects(event) {
+    event.preventDefault();
+    if (!activeSession.active || uploadDialog.pending) return;
+    const preparedFiles = uploadDialog.files
+      .map((item) => ({ ...item, key: normalizeObjectKey(item.key) }))
+      .filter((item) => item.key);
+    const textKey = normalizeObjectKey(uploadDialog.textKey);
+    const fileMode = uploadDialog.mode !== "text";
+    const includeText = uploadDialog.mode === "text" && textKey && uploadDialog.textContent;
+    if (fileMode && preparedFiles.length === 0) {
+      setUploadDialog((current) => ({ ...current, error: "Choose one or more files to upload." }));
+      return;
+    }
+    if (!fileMode && !includeText) {
+      setUploadDialog((current) => ({ ...current, error: "Enter an object key and text content." }));
+      return;
+    }
+    setUploadDialog((current) => ({ ...current, pending: true, error: "", message: "" }));
+    let lastKey = "";
+    try {
+      if (fileMode) {
+        for (const item of preparedFiles) {
+          await runS3Action({
+            actionName: "upload_object",
+            input: {
+              key: item.key,
+              content_base64: await fileToBase64(item.file),
+              content_type: item.contentType || item.file.type || "application/octet-stream",
+              overwrite: uploadDialog.overwrite,
+            },
+            reason: "manual S3 browser object upload",
+            busy: "uploading",
+          });
+          lastKey = item.key;
+        }
+      }
+      if (includeText) {
+        await runS3Action({
+          actionName: "upload_object",
+          input: {
+            key: textKey,
+            content_text: uploadDialog.textContent,
+            content_type: uploadDialog.textContentType || "text/plain",
+            overwrite: uploadDialog.overwrite,
+          },
+          reason: "manual S3 browser object upload",
+          busy: "uploading",
+        });
+        lastKey = textKey;
+      }
+      setUploadDialog(defaultUploadDialog);
+      await refreshObjects({ reset: true });
+      if (lastKey) {
+        await readObjectMetadata(lastKey);
+      }
+      setState({ state: "idle", error: "", message: `Uploaded ${fileMode ? preparedFiles.length : 1} object(s).` });
+    } catch (error) {
+      setUploadDialog((current) => ({ ...current, pending: false, error: error.message || "Upload failed." }));
+    }
+  }
+
+  function openRenameDialog() {
+    if (!selectedKey) return;
+    setRenameDialog({ open: true, value: selectedKey, pending: false, error: "" });
+  }
+
+  function closeRenameDialog() {
+    setRenameDialog((current) => (current.pending ? current : defaultRenameDialog));
+  }
+
+  async function renameSelectedObject(event) {
+    event.preventDefault();
+    if (!selectedKey || renameDialog.pending) return;
+    const nextKey = normalizeObjectKey(renameDialog.value);
+    if (!nextKey || nextKey === selectedKey) {
+      setRenameDialog((current) => ({ ...current, error: "Enter a different destination object key." }));
+      return;
+    }
+    setRenameDialog((current) => ({ ...current, pending: true, error: "" }));
+    try {
+      await runS3Action({
+        actionName: "rename_object",
+        input: { source_key: selectedKey, destination_key: nextKey, overwrite: false },
+        reason: "manual S3 browser object rename",
+        busy: "renaming",
+      });
+      setRenameDialog(defaultRenameDialog);
+      setSelectedKey("");
+      setMetadata(null);
+      await refreshObjects({ reset: true });
+      await readObjectMetadata(nextKey);
+    } catch (error) {
+      setRenameDialog((current) => ({ ...current, pending: false, error: error.message || "Rename failed." }));
+    }
+  }
+
+  function requestDelete() {
+    if (!selectedKey) return;
+    openConfirmDialog({
+      title: "Delete S3 object",
+      description: "This permanently deletes the selected object from the bucket.",
+      details: [{ label: "Object", value: selectedKey }],
+      danger: true,
+      action: async () => {
+        await runS3Action({
+          actionName: "delete_object",
+          input: { key: selectedKey },
+          reason: "manual S3 browser object delete",
+          busy: "deleting",
+        });
+        setSelectedKey("");
+        setMetadata(null);
+        setMetadataSearch("");
+        await refreshObjects({ reset: true });
+      },
+    });
+  }
+
+  async function readBucketInfo() {
+    setMetadataSearch("");
+    const item = await runS3Action({
+      actionName: "bucket_info",
+      input: {},
+      reason: "manual S3 browser bucket info",
+      busy: "reading",
+    });
+    setMetadata(item.output || null);
+  }
+
+  function openConfirmDialog({ title, description, details, action, danger = false }) {
+    setConfirmDialog({ open: true, title, description, details, action, pending: false, danger });
+  }
+
+  async function confirmPendingAction() {
+    if (!confirmDialog.action) return;
+    setConfirmDialog((current) => ({ ...current, pending: true }));
+    try {
+      await confirmDialog.action();
+      setConfirmDialog({ open: false, title: "", description: "", details: [], action: null, pending: false, danger: false });
+    } catch {
+      setConfirmDialog((current) => ({ ...current, pending: false }));
+    }
+  }
+
+  if (!activeSession.active) {
+    return (
+      <div className={`grid min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
+        <div className="grid place-items-center p-8 text-center">
+          <div className="grid max-w-lg gap-4">
+            <Database className={`mx-auto h-10 w-10 ${mutedClass}`} />
+            <div>
+              <h3 className="text-lg font-semibold">No active S3 session</h3>
+              <p className={`mt-2 text-sm ${mutedClass}`}>Start a structured session to browse objects through the connector approval, history, and audit pipeline.</p>
+            </div>
+            <Button type="button" className="mx-auto" onClick={onNewStructuredSession}>
+              Start S3 session
+            </Button>
+          </div>
+        </div>
+        <S3EndpointFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
+      <div className="grid min-h-0 gap-4 overflow-hidden p-4 xl:grid-cols-[380px_minmax(0,1fr)]">
+        <section className={`grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+          <div className={`border-b p-3 ${borderClass}`}>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold">Objects</p>
+                <p className={`text-xs ${mutedClass}`}>{directories.length + objects.length} loaded · {target.config?.bucket || "bucket"}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                {latestAction ? <Badge tone={latestAction.status === "failed" ? "bad" : latestAction.status === "completed" ? "good" : "warn"}>{latestAction.action_name}</Badge> : null}
+                <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Bucket info" onClick={readBucketInfo} disabled={state.state !== "idle"}>
+                  <Database className="h-3.5 w-3.5" />
+                </Button>
+                <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Upload objects" onClick={openUploadDialog} disabled={state.state !== "idle"}>
+                  <Plus className="h-3.5 w-3.5" />
+                </Button>
+                <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Refresh objects" onClick={() => refreshObjects({ reset: true })} disabled={state.state !== "idle"}>
+                  <RefreshCcw className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          </div>
+          <form
+            className={`grid gap-2 border-b p-3 ${borderClass}`}
+            onSubmit={(event) => {
+              event.preventDefault();
+              void refreshObjects({ reset: true });
+            }}
+          >
+            <Input className={inputClass} value={prefix} onChange={(event) => setPrefix(event.target.value)} placeholder="Prefix, e.g. backups/2026/" />
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
+              <div className="relative">
+                <Search className={`pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 ${mutedClass}`} />
+                <Input className={`pl-9 ${inputClass}`} value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search object keys" />
+              </div>
+              <Button type="submit" variant="outline" className="h-10" disabled={state.state !== "idle"}>
+                {state.state === "loading" ? "Loading" : "Search"}
+              </Button>
+            </div>
+          </form>
+          <div className="min-h-0 overflow-auto p-2">
+            {prefix && !search ? (
+              <button type="button" className={`mb-1 flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left text-sm transition ${borderClass} ${rowHoverClass}`} onClick={openParentDirectory}>
+                <CornerUpLeft className={`h-4 w-4 shrink-0 ${mutedClass}`} />
+                <span className="min-w-0">
+                  <span className="block truncate font-semibold">..</span>
+                  <span className={`block truncate text-xs ${mutedClass}`}>{parentPrefix(prefix) || "bucket root"}</span>
+                </span>
+              </button>
+            ) : null}
+            {!search
+              ? directories.map((directory) => (
+                  <button
+                    key={directory.prefix}
+                    type="button"
+                    className={`mb-1 flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left text-sm transition ${borderClass} ${rowHoverClass}`}
+                    onClick={() => openDirectory(directory.prefix)}
+                  >
+                    <Folder className="h-4 w-4 shrink-0 text-amber-400" />
+                    <span className="min-w-0">
+                      <span className="block truncate font-mono text-xs font-semibold" title={directory.prefix}>{directory.name || directory.prefix}</span>
+                      <span className={`block truncate text-xs ${mutedClass}`}>{directory.prefix}</span>
+                    </span>
+                  </button>
+                ))
+              : null}
+            {objects.map((object) => (
+              <button
+                key={object.key}
+                type="button"
+                className={`mb-1 grid w-full gap-1 rounded-md border px-3 py-2 text-left text-sm transition ${selectedKey === object.key ? activeRowClass : `${borderClass} ${rowHoverClass}`}`}
+                onClick={() => selectObject(object.key)}
+              >
+                <span className="truncate font-mono text-xs font-semibold" title={object.key}>{object.key}</span>
+                <span className={`text-xs ${selectedKey === object.key ? "" : mutedClass}`}>
+                  {formatBytes(object.size)} · {shortDate(object.last_modified)}
+                </span>
+              </button>
+            ))}
+            {directories.length === 0 && objects.length === 0 ? <Notice>{state.state === "loading" ? "Loading S3 objects..." : "No objects found for this prefix/search."}</Notice> : null}
+          </div>
+          <div className={`flex items-center justify-between gap-2 border-t p-3 ${borderClass}`}>
+            <span className={`text-xs ${mutedClass}`}>{nextToken ? "More objects available" : "End of current listing"}</span>
+            <Button type="button" variant="outline" className="h-8" disabled={!nextToken || state.state !== "idle"} onClick={() => refreshObjects({ reset: false, token: nextToken })}>
+              Load more
+            </Button>
+          </div>
+        </section>
+
+        <section className={`grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+          <div>
+            <div className={`border-b p-3 ${borderClass}`}>
+              <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold">{selectedKey || "S3 object detail"}</p>
+                  <p className={`truncate text-xs ${mutedClass}`}>{selectedObject ? `${formatBytes(selectedObject.size)} · ${shortDate(selectedObject.last_modified)}` : "Select an object or upload a new one."}</p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Download object" disabled={!selectedKey || state.state !== "idle"} onClick={downloadSelected}>
+                    <Download className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button type="button" variant="outline" className="h-8 w-8 px-0" title="Rename object" disabled={!selectedKey || state.state !== "idle"} onClick={openRenameDialog}>
+                    <Pencil className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button type="button" variant="danger" className="h-8 w-8 px-0" title="Delete object" disabled={!selectedKey || state.state !== "idle"} onClick={requestDelete}>
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+            {state.error ? (
+              <div className={`border-b px-3 py-2 text-right text-xs text-red-500 ${borderClass}`}>
+                <span className="break-words">{state.error}</span>
+              </div>
+            ) : null}
+          </div>
+          <div className="grid h-full min-h-0 grid-rows-[minmax(0,1fr)] overflow-hidden p-3">
+            <S3MetadataPanel
+              metadata={metadata}
+              selectedKey={selectedKey}
+              directories={directories}
+              objects={objects}
+              visibleBytes={visibleBytes}
+              prefix={prefix}
+              search={search}
+              metadataSearch={metadataSearch}
+              onMetadataSearch={setMetadataSearch}
+              inputClass={inputClass}
+            />
+          </div>
+        </section>
+      </div>
+      <S3EndpointFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
+      <S3UploadDialog
+        value={uploadDialog}
+        theme={theme}
+        inputClass={inputClass}
+        borderClass={borderClass}
+        mutedClass={mutedClass}
+        subtlePanelClass={subtlePanelClass}
+        onClose={closeUploadDialog}
+        onChange={setUploadDialog}
+        onFiles={addUploadFiles}
+        onRemoveFile={removeUploadFile}
+        onUpdateFile={updateUploadFile}
+        onSubmit={uploadObjects}
+      />
+      <S3RenameDialog value={renameDialog} theme={theme} selectedKey={selectedKey} inputClass={inputClass} onClose={closeRenameDialog} onChange={setRenameDialog} onSubmit={renameSelectedObject} />
+      <S3ConfirmDialog value={confirmDialog} theme={theme} onClose={() => setConfirmDialog({ open: false, title: "", description: "", details: [], action: null, pending: false, danger: false })} onConfirm={confirmPendingAction} />
+    </div>
+  );
+}
+
+function S3EndpointFooter({ target, borderClass, mutedClass }) {
+  const scheme = target.config?.scheme || "https";
+  const host = target.config?.host || "s3.amazonaws.com";
+  const port = target.config?.port || (scheme === "http" ? 80 : 443);
+  const bucket = target.config?.bucket || "bucket";
+  const mode = target.config?.connection_mode === "over_ssh" ? `over ssh · ${target.config?.transport_target_ref || "transport"}` : "direct";
+  return (
+    <div className={`flex items-center justify-between gap-3 border-t px-4 py-2 text-xs ${borderClass} ${mutedClass}`}>
+      <span>S3 transport</span>
+      <span className="truncate">{scheme}://{host}:{port}/{bucket} · {mode}</span>
+    </div>
+  );
+}
+
+function S3MetadataPanel({ metadata, selectedKey, directories, objects, visibleBytes, prefix, search, metadataSearch, onMetadataSearch, inputClass }) {
+  if (!metadata) {
+    return (
+      <TerminalBlock className="min-h-0 text-xs" surface="log">
+        {selectedKey ? "Reading object metadata..." : "Select an object to inspect metadata, or use Bucket info for endpoint details."}
+      </TerminalBlock>
+    );
+  }
+  const isBucketInfo = !metadata.key && Boolean(metadata.bucket);
+  const cards = isBucketInfo
+    ? [
+        { label: "Bucket", value: metadata.bucket || "unknown" },
+        { label: "Endpoint", value: metadata.endpoint || "unknown" },
+        { label: "Region", value: metadata.region || "unknown" },
+        { label: "Visible folders", value: String(directories.length) },
+        { label: "Visible objects", value: String(objects.length) },
+        { label: "Visible size", value: formatBytes(visibleBytes) },
+        { label: "Current prefix", value: prefix || "bucket root" },
+        { label: "Search", value: search || "none" },
+        { label: "Request id", value: metadata.headers?.["X-Amz-Request-Id"] || metadata.headers?.["X-Amz-Id-2"] || "not provided" },
+      ]
+    : [
+        { label: "Object", value: metadata.key || selectedKey || "unknown" },
+        { label: "Bucket", value: metadata.bucket || "unknown" },
+        { label: "Size", value: formatBytes(metadata.content_length) },
+        { label: "Content type", value: metadata.content_type || "unknown" },
+        { label: "Last modified", value: metadata.last_modified || "unknown" },
+        { label: "ETag", value: metadata.etag || "unknown" },
+      ];
+  const rawValue = JSON.stringify(metadata, null, 2);
+  return (
+    <div className="grid min-h-0 grid-rows-[auto_minmax(0,450px)_auto_minmax(0,1fr)] overflow-hidden">
+      <S3ResultHeader title={isBucketInfo ? "Bucket summary" : "Object summary"} subtitle={isBucketInfo ? "visible listing stats" : "metadata"} />
+      <S3MetadataSummary cards={cards} />
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <p className="truncate text-xs font-semibold uppercase tracking-wide text-stone-500">S3 raw data</p>
+        <div className="flex min-w-0 items-center justify-end gap-2">
+          <Input className={`h-8 w-56 text-xs ${inputClass || ""}`} value={metadataSearch} onChange={(event) => onMetadataSearch?.(event.target.value)} placeholder="Search raw data" />
+          <CopyButton value={rawValue} variant="outline" className="h-8 px-2 text-xs" />
+        </div>
+      </div>
+      <div className="mt-2 grid min-h-0 overflow-hidden">
+        <TerminalBlock className="min-h-0 whitespace-pre-wrap break-words text-xs [overflow-wrap:anywhere]" surface="dark">
+          <HighlightedText text={rawValue} query={metadataSearch} />
+        </TerminalBlock>
+      </div>
+    </div>
+  );
+}
+
+function S3ResultHeader({ title, subtitle }) {
+  return (
+    <div className="mb-2 flex items-center justify-between gap-3">
+      <div className="min-w-0">
+        <p className="truncate text-xs font-semibold uppercase tracking-wide text-stone-500">{title}</p>
+        {subtitle ? <p className="truncate text-xs text-stone-500">{subtitle}</p> : null}
+      </div>
+    </div>
+  );
+}
+
+function S3MetadataSummary({ cards }) {
+  return (
+    <div className="min-h-0 overflow-auto rounded-md border border-stone-700 bg-[#1a1a1a] p-3">
+      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+        {cards.map((card) => (
+          <div key={card.label} className="min-w-0 rounded border border-stone-700 bg-[#202020] p-2">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-stone-500">{card.label}</p>
+            <p className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-stone-100">{String(card.value)}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HighlightedText({ text, query }) {
+  const value = String(text || "");
+  const needle = String(query || "");
+  if (!needle.trim()) return value;
+  const lowerValue = value.toLowerCase();
+  const lowerNeedle = needle.toLowerCase();
+  const parts = [];
+  let index = 0;
+  let matchIndex = lowerValue.indexOf(lowerNeedle, index);
+  let key = 0;
+  while (matchIndex !== -1) {
+    if (matchIndex > index) parts.push(value.slice(index, matchIndex));
+    parts.push(
+      <mark key={`m-${key++}`} className="rounded bg-yellow-300 px-0.5 text-stone-950">
+        {value.slice(matchIndex, matchIndex + needle.length)}
+      </mark>
+    );
+    index = matchIndex + needle.length;
+    matchIndex = lowerValue.indexOf(lowerNeedle, index);
+  }
+  if (index < value.length) parts.push(value.slice(index));
+  return parts;
+}
+
+function S3UploadDialog({ value, theme, inputClass, borderClass, mutedClass, subtlePanelClass, onClose, onChange, onFiles, onRemoveFile, onUpdateFile, onSubmit }) {
+  if (!value.open) return null;
+  const darkTextClass = theme === "light" ? "" : "text-stone-200";
+  const fileMode = value.mode !== "text";
+  const canUpload = fileMode ? value.files.some((item) => normalizeObjectKey(item.key)) : Boolean(normalizeObjectKey(value.textKey) && value.textContent);
+  const uploadCount = fileMode ? value.files.filter((item) => normalizeObjectKey(item.key)).length : canUpload ? 1 : 0;
+  return (
+    <Dialog open={value.open} onClose={onClose} title="Upload S3 objects" description="Upload local files or create a small text object." size="wide" closeDisabled={value.pending} closeOnOverlay={false} closeOnEscape={false}>
+      <form className="grid max-h-[calc(100vh-150px)] min-h-0 gap-4 overflow-hidden lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]" onSubmit={onSubmit}>
+        <section className="grid min-h-0 content-start gap-4">
+          <Notice tone="warn">Uploads run as bounded S3 connector write actions. Keep write permissions in Prompt mode until the workflow is trusted.</Notice>
+          <div className={`grid grid-cols-2 rounded-lg border p-1 ${borderClass} ${subtlePanelClass}`}>
+            <button type="button" className={`rounded-md px-3 py-2 text-sm font-semibold ${fileMode ? "bg-emerald-600 text-white" : mutedClass}`} onClick={() => onChange((current) => ({ ...current, mode: "files", error: "" }))} disabled={value.pending}>
+              File upload
+            </button>
+            <button type="button" className={`rounded-md px-3 py-2 text-sm font-semibold ${!fileMode ? "bg-emerald-600 text-white" : mutedClass}`} onClick={() => onChange((current) => ({ ...current, mode: "text", error: "" }))} disabled={value.pending}>
+              Create text object
+            </button>
+          </div>
+          <div className={`grid gap-3 rounded-lg border p-3 ${borderClass} ${subtlePanelClass}`}>
+            {fileMode ? (
+              <>
+                <Field className={darkTextClass}>
+                  Object prefix
+                  <Input
+                    className={inputClass}
+                    value={value.prefix}
+                    onChange={(event) => {
+                      const nextPrefix = event.target.value;
+                      onChange((current) => ({
+                        ...current,
+                        prefix: nextPrefix,
+                        files: current.files.map((item) => ({ ...item, key: joinObjectKey(nextPrefix, item.file.name) })),
+                      }));
+                    }}
+                    placeholder="folder/subfolder/"
+                  />
+                </Field>
+                <Field className={darkTextClass}>
+                  Add files
+                  <Input className={inputClass} type="file" multiple onChange={(event) => onFiles(event.target.files)} />
+                </Field>
+              </>
+            ) : (
+              <>
+                <Field className={darkTextClass}>
+                  Object key
+                  <Input className={inputClass} value={value.textKey} onChange={(event) => onChange((current) => ({ ...current, textKey: event.target.value }))} placeholder="notes/readme.txt" />
+                </Field>
+                <Field className={darkTextClass}>
+                  Content type
+                  <Input className={inputClass} value={value.textContentType} onChange={(event) => onChange((current) => ({ ...current, textContentType: event.target.value }))} placeholder="text/plain" />
+                </Field>
+                <Field className={darkTextClass}>
+                  Content
+                  <Textarea className={`${inputClass} min-h-36 font-mono text-xs`} value={value.textContent} onChange={(event) => onChange((current) => ({ ...current, textContent: event.target.value }))} placeholder="Text content" />
+                </Field>
+              </>
+            )}
+            <label className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${borderClass}`}>
+              <input type="checkbox" checked={value.overwrite} onChange={(event) => onChange((current) => ({ ...current, overwrite: event.target.checked }))} />
+              overwrite existing objects
+            </label>
+          </div>
+        </section>
+        <section className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] gap-3">
+          <div>
+            <p className="text-sm font-semibold">{fileMode ? "Upload queue" : "Text object preview"}</p>
+            <p className={`text-xs ${mutedClass}`}>{fileMode ? `${value.files.length} file${value.files.length === 1 ? "" : "s"} selected` : normalizeObjectKey(value.textKey) || "No object key yet"}</p>
+          </div>
+          <div className={`min-h-0 overflow-auto rounded-lg border ${borderClass}`}>
+            {!fileMode ? (
+              <div className="grid gap-3 p-3">
+                <p className="break-all font-mono text-xs">{normalizeObjectKey(value.textKey) || "notes/readme.txt"}</p>
+                <TerminalBlock className="min-h-48 text-xs" surface="log">
+                  {value.textContent || "Text content preview will appear here."}
+                </TerminalBlock>
+              </div>
+            ) : value.files.length === 0 ? (
+              <div className="grid h-full min-h-48 place-items-center p-6 text-center">
+                <p className={`text-sm ${mutedClass}`}>Selected files will appear here with editable object keys.</p>
+              </div>
+            ) : (
+              <div className="grid divide-y divide-stone-200 dark:divide-stone-700">
+                {value.files.map((item) => (
+                  <div className="grid gap-2 p-3" key={item.id}>
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold" title={item.file.name}>{item.file.name}</p>
+                        <p className={`text-xs ${mutedClass}`}>{formatBytes(item.file.size)} · {item.contentType || "application/octet-stream"}</p>
+                      </div>
+                      <Button type="button" variant="ghost" className="h-8 w-8 px-0" title="Remove file" onClick={() => onRemoveFile(item.id)} disabled={value.pending}>
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    <Input className={inputClass} value={item.key} onChange={(event) => onUpdateFile(item.id, { key: event.target.value })} disabled={value.pending} />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          {value.error ? <Notice tone="bad">{value.error}</Notice> : null}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={onClose} disabled={value.pending}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canUpload || value.pending}>
+              <FileUp className="h-4 w-4" />
+              {value.pending ? "Uploading..." : `Upload ${uploadCount} object(s)`}
+            </Button>
+          </div>
+        </section>
+      </form>
+    </Dialog>
+  );
+}
+
+function S3RenameDialog({ value, theme, selectedKey, inputClass, onClose, onChange, onSubmit }) {
+  if (!value.open) return null;
+  return (
+    <Dialog open={value.open} onClose={onClose} title="Rename S3 object" description="Rename copies the object to a new key and deletes the original key." size="md" closeDisabled={value.pending}>
+      <form className="grid gap-4" onSubmit={onSubmit}>
+        <div className={`grid gap-2 rounded-md border p-3 text-sm ${theme === "light" ? "border-stone-200 bg-stone-50 text-stone-700" : "border-stone-700 bg-stone-900 text-stone-200"}`}>
+          <span className="text-xs font-semibold uppercase tracking-wide opacity-70">Source</span>
+          <span className="break-all font-mono text-xs">{selectedKey}</span>
+        </div>
+        <Field className={theme === "light" ? "" : "text-stone-200"}>
+          Destination key
+          <Input className={inputClass} value={value.value} onChange={(event) => onChange((current) => ({ ...current, value: event.target.value, error: "" }))} autoFocus />
+        </Field>
+        {value.error ? <Notice tone="bad">{value.error}</Notice> : <Notice tone="warn">Review the destination key before renaming.</Notice>}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose} disabled={value.pending}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={value.pending}>
+            {value.pending ? "Renaming..." : "Rename"}
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}
+
+function S3ConfirmDialog({ value, theme, onClose, onConfirm }) {
+  if (!value.open) return null;
+  const detailClass = theme === "light" ? "border-stone-200 bg-stone-50 text-stone-700" : "border-stone-700 bg-stone-900 text-stone-200";
+  return (
+    <Dialog open={value.open} onClose={onClose} title={value.title} description={value.description} size="md" closeDisabled={value.pending}>
+      <div className="grid gap-4">
+        <div className={`grid gap-2 rounded-md border p-3 text-sm ${detailClass}`}>
+          {value.details.map((detail) => (
+            <div className="grid gap-1" key={detail.label}>
+              <span className="text-xs font-semibold uppercase tracking-wide opacity-70">{detail.label}</span>
+              <span className="break-all font-mono text-xs">{detail.value}</span>
+            </div>
+          ))}
+        </div>
+        {value.danger ? <Notice tone="bad">This action changes object storage state and cannot be undone by AIPermission.</Notice> : <Notice tone="warn">Review the object keys before continuing.</Notice>}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose} disabled={value.pending}>
+            Cancel
+          </Button>
+          <Button type="button" variant={value.danger ? "danger" : "default"} onClick={onConfirm} disabled={value.pending}>
+            {value.pending ? "Working..." : value.danger ? "Delete" : "Confirm"}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function fileToBase64(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = String(reader.result || "");
+      resolve(result.includes(",") ? result.split(",").pop() : result);
+    };
+    reader.onerror = () => reject(reader.error || new Error("Failed to read file."));
+    reader.readAsDataURL(file);
+  });
+}
+
+function base64Blob(value, contentType) {
+  const binary = atob(value || "");
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new Blob([bytes], { type: contentType || "application/octet-stream" });
+}
+
+function filenameFromKey(key) {
+  const parts = String(key || "s3-object").split("/").filter(Boolean);
+  return parts[parts.length - 1] || "s3-object";
+}
+
+function safeDownloadName(value) {
+  return String(value || "s3-object").replaceAll(":", "-");
+}
+
+function normalizeObjectKey(value) {
+  return String(value || "").trim().replace(/^\/+/, "");
+}
+
+function joinObjectKey(prefix, name) {
+  const cleanPrefix = normalizeObjectKey(prefix);
+  const cleanName = normalizeObjectKey(name);
+  if (!cleanPrefix) return cleanName;
+  return `${cleanPrefix.replace(/\/+$/, "")}/${cleanName}`;
+}
+
+function parentPrefix(value) {
+  const clean = normalizeObjectKey(value).replace(/\/+$/, "");
+  const index = clean.lastIndexOf("/");
+  if (index <= 0) return "";
+  return `${clean.slice(0, index)}/`;
+}
+
+function formatBytes(value) {
+  const number = Number(value || 0);
+  if (number < 1024) return `${number} B`;
+  if (number < 1024 * 1024) return `${(number / 1024).toFixed(1)} KiB`;
+  return `${(number / 1024 / 1024).toFixed(1)} MiB`;
+}
+
+function shortDate(value) {
+  if (!value) return "unknown";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}

--- a/frontend/src/connectors/templates/s3/credential-form.jsx
+++ b/frontend/src/connectors/templates/s3/credential-form.jsx
@@ -1,0 +1,75 @@
+import { Database, Plus } from "lucide-react";
+import { Button } from "../../../components/ui/button";
+import { Field, Input, Select } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+
+export function S3CredentialFormTemplate({ targets, form, formMode = "create", state, onChange, onSubmit }) {
+  const s3Targets = targets.filter((target) => target.connector_kind === "s3");
+  const editing = formMode === "edit";
+  return (
+    <form className="grid gap-4" onSubmit={onSubmit}>
+      {s3Targets.length === 0 ? (
+        <Notice tone="warn">Create an S3 connector target before adding an S3 credential profile.</Notice>
+      ) : (
+        <Notice tone="good">{editing ? "Update public S3 profile metadata, or enter a new secret to rotate the stored key." : "Create an S3 profile, then bind tokens to this profile from Console or Tokens."}</Notice>
+      )}
+      <Field>
+        Connector target
+        <Select value={form.target_id} onChange={(event) => onChange({ ...form, target_id: event.target.value })} disabled={editing} required>
+          <option value="" disabled>
+            Select S3 target
+          </option>
+          {s3Targets.map((target) => (
+            <option value={target.id} key={target.id}>
+              {target.name} · {target.config?.scheme || "https"}://{target.config?.host}:{target.config?.port || 443}/{target.config?.bucket || "bucket"}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange({ ...form, profile_label: event.target.value })} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange({ ...form, risk_label: event.target.value })} />
+        </Field>
+      </div>
+      <Field>
+        Access key ID
+        <Input value={form.access_key_id} onChange={(event) => onChange({ ...form, access_key_id: event.target.value })} autoComplete="off" required />
+      </Field>
+      <Field>
+        {editing ? "New secret access key" : "Secret access key"}
+        <Input
+          type="password"
+          value={form.secret_access_key}
+          onChange={(event) => onChange({ ...form, secret_access_key: event.target.value })}
+          autoComplete="new-password"
+          required={!editing}
+          placeholder={editing ? "Leave blank to keep current secret" : "S3 secret access key"}
+        />
+      </Field>
+      <Field>
+        {editing ? "New session token" : "Session token"}
+        <Input
+          type="password"
+          value={form.session_token}
+          onChange={(event) => onChange({ ...form, session_token: event.target.value })}
+          autoComplete="new-password"
+          placeholder={editing ? "Leave blank to keep current token" : "Optional temporary session token"}
+        />
+      </Field>
+      {state.state === "error" ? <Notice tone="bad">{state.error}</Notice> : null}
+      <Button type="submit" disabled={state.state === "saving" || s3Targets.length === 0}>
+        <Plus className="h-4 w-4" />
+        {state.state === "saving" ? "Saving..." : editing ? "Save S3 credential" : "Create S3 credential"}
+      </Button>
+      <Notice>
+        <Database className="mr-2 inline h-4 w-4" />
+        S3 secrets are stored in the encrypted local database and are never returned to MCP or REST list responses.
+      </Notice>
+    </form>
+  );
+}

--- a/frontend/src/connectors/templates/s3/form.jsx
+++ b/frontend/src/connectors/templates/s3/form.jsx
@@ -1,0 +1,130 @@
+import { Checkbox, Field, Input, Select } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+import { HostPingButton } from "../host-ping-button";
+
+export function S3ConnectorFormTemplate({ form, mode = "create", targets = [], onChange }) {
+  const editing = mode === "edit";
+  const sshProfiles = sshProfileOptions(targets);
+  const overSSH = form.connection_mode === "over_ssh";
+  return (
+    <>
+      <Notice tone="good">
+        S3 supports S3-compatible providers such as AWS S3 and MinIO. Object downloads/uploads are bounded connector actions; use Prompt permissions before allowing writes.
+      </Notice>
+      <Field>
+        Connector name
+        <Input value={form.name} onChange={(event) => onChange("name", event.target.value)} required />
+      </Field>
+      <Field>
+        Connection mode
+        <Select value={form.connection_mode} onChange={(event) => onChange("connection_mode", event.target.value)}>
+          <option value="direct">Direct from this gateway</option>
+          <option value="over_ssh">Over an SSH connector profile</option>
+        </Select>
+      </Field>
+      {overSSH ? (
+        <Field>
+          SSH transport profile
+          <Select value={form.transport_target_ref} onChange={(event) => onChange("transport_target_ref", event.target.value)} required>
+            <option value="" disabled>
+              Select SSH profile
+            </option>
+            {sshProfiles.map((profile) => (
+              <option value={profile.ref} key={profile.ref}>
+                {profile.label}
+              </option>
+            ))}
+          </Select>
+        </Field>
+      ) : null}
+      {overSSH ? (
+        <Notice>Host and port are resolved from the SSH server. Use 127.0.0.1 when a MinIO/S3-compatible endpoint is only reachable from that server.</Notice>
+      ) : (
+        <Notice>For MinIO or S3-compatible storage running on the same Linux host as AIPermission Docker, use host.docker.internal instead of localhost.</Notice>
+      )}
+      <div className="grid gap-3 sm:grid-cols-[120px_minmax(0,1fr)_120px]">
+        <Field>
+          Scheme
+          <Select value={form.scheme || "https"} onChange={(event) => onChange("scheme", event.target.value)}>
+            <option value="https">HTTPS</option>
+            <option value="http">HTTP</option>
+          </Select>
+        </Field>
+        <Field>
+          <span className="flex items-center justify-between gap-2">
+            <span>Endpoint host</span>
+            <HostPingButton host={form.host} port={form.port} mode={form.connection_mode} transportTargetRef={form.transport_target_ref} />
+          </span>
+          <Input value={form.host} onChange={(event) => onChange("host", event.target.value)} required />
+        </Field>
+        <Field>
+          Port
+          <Input type="number" min="1" max="65535" value={form.port} onChange={(event) => onChange("port", event.target.value)} required />
+        </Field>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Region
+          <Input value={form.region} onChange={(event) => onChange("region", event.target.value)} placeholder="us-east-1" required />
+        </Field>
+        <Field>
+          Bucket
+          <Input value={form.bucket} onChange={(event) => onChange("bucket", event.target.value)} required />
+        </Field>
+      </div>
+      <label className="flex items-start gap-3 rounded-md border border-stone-200 bg-stone-50 p-3 text-sm text-stone-700 dark-notice-neutral">
+        <Checkbox checked={form.path_style !== false} onChange={(event) => onChange("path_style", event.target.checked)} />
+        <span>
+          <span className="block font-semibold">Path-style addressing</span>
+          <span className="text-xs">Use /bucket/key URLs. Keep this enabled for most S3-compatible providers such as MinIO.</span>
+        </span>
+      </label>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange("profile_label", event.target.value)} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange("risk_label", event.target.value)} />
+        </Field>
+      </div>
+      <Field>
+        Access key ID
+        <Input value={form.access_key_id} onChange={(event) => onChange("access_key_id", event.target.value)} autoComplete="off" required />
+      </Field>
+      <Field>
+        Secret access key
+        <Input
+          type="password"
+          value={form.secret_access_key}
+          onChange={(event) => onChange("secret_access_key", event.target.value)}
+          autoComplete="new-password"
+          required={!editing}
+          placeholder={editing ? "Leave blank to keep the current encrypted secret" : "S3 secret access key"}
+        />
+      </Field>
+      <Field>
+        Session token
+        <Input
+          type="password"
+          value={form.session_token}
+          onChange={(event) => onChange("session_token", event.target.value)}
+          autoComplete="new-password"
+          placeholder={editing ? "Leave blank to keep the current session token" : "Optional temporary session token"}
+        />
+      </Field>
+    </>
+  );
+}
+
+function sshProfileOptions(targets) {
+  return (targets || [])
+    .filter((target) => target.connector_kind === "ssh")
+    .flatMap((target) =>
+      (target.profiles || []).map((profile) => ({
+        ref: profile.ref || `${target.connector_kind}:${target.id}:${profile.id}`,
+        label: `${target.name} / ${profile.label} · ${target.config?.host || "host"}:${target.config?.port || 22}`,
+      }))
+    );
+}

--- a/frontend/src/connectors/templates/s3/index.jsx
+++ b/frontend/src/connectors/templates/s3/index.jsx
@@ -1,0 +1,15 @@
+import { S3ConnectorConsoleTemplate } from "./console";
+import { S3CredentialFormTemplate } from "./credential-form";
+import { S3ConnectorFormTemplate } from "./form";
+import { S3ConnectorRowActionsTemplate } from "./list-item";
+import { S3ConnectorOperationsTemplate } from "./operations";
+import * as model from "./model";
+
+export default Object.freeze({
+  Console: S3ConnectorConsoleTemplate,
+  CredentialForm: S3CredentialFormTemplate,
+  Form: S3ConnectorFormTemplate,
+  model,
+  Operations: S3ConnectorOperationsTemplate,
+  RowActions: S3ConnectorRowActionsTemplate,
+});

--- a/frontend/src/connectors/templates/s3/list-item.jsx
+++ b/frontend/src/connectors/templates/s3/list-item.jsx
@@ -1,0 +1,3 @@
+export function S3ConnectorRowActionsTemplate() {
+  return null;
+}

--- a/frontend/src/connectors/templates/s3/metadata.json
+++ b/frontend/src/connectors/templates/s3/metadata.json
@@ -1,0 +1,8 @@
+{
+  "kind": "s3",
+  "label": "S3",
+  "summary": "S3-compatible bucket browsing, object metadata, bounded upload/download, rename, and delete actions.",
+  "version": "0.2",
+  "icon": "database",
+  "badge_tone": "neutral"
+}

--- a/frontend/src/connectors/templates/s3/model.js
+++ b/frontend/src/connectors/templates/s3/model.js
@@ -1,0 +1,331 @@
+import { apiDelete, apiPost, apiPut } from "../../../lib/api";
+import { createTargetWithProfile, updateTargetWithProfile } from "../target-profile-save";
+
+const emptyS3CredentialForm = { target_id: "", profile_label: "default", access_key_id: "", secret_access_key: "", session_token: "", risk_label: "object storage" };
+
+export function emptyForm() {
+  return {
+    connector_kind: "s3",
+    name: "object-store",
+    connection_mode: "direct",
+    scheme: "https",
+    host: "s3.amazonaws.com",
+    port: 443,
+    region: "us-east-1",
+    bucket: "",
+    path_style: true,
+    transport_target_ref: "",
+    profile_label: "default",
+    access_key_id: "",
+    secret_access_key: "",
+    session_token: "",
+    risk_label: "object storage",
+  };
+}
+
+export function formFromTarget({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : {});
+  return {
+    connector_kind: "s3",
+    profile_id: selectedProfile.id ? String(selectedProfile.id) : "",
+    name: target.name || "",
+    connection_mode: target.config?.connection_mode || "direct",
+    scheme: target.config?.scheme || "https",
+    host: target.config?.host || "s3.amazonaws.com",
+    port: target.config?.port || 443,
+    region: target.config?.region || "us-east-1",
+    bucket: target.config?.bucket || "",
+    path_style: target.config?.path_style !== false,
+    transport_target_ref: target.config?.transport_target_ref || "",
+    profile_label: selectedProfile.label || "default",
+    access_key_id: selectedProfile.public?.access_key_id || "",
+    secret_access_key: "",
+    session_token: "",
+    risk_label: selectedProfile.risk_label || "object storage",
+  };
+}
+
+export function activeCredential() {
+  return null;
+}
+
+export function syncForm({ form }) {
+  if (form.connector_kind !== "s3") return form;
+  const next = { ...form };
+  if (next.connection_mode === "direct") {
+    next.transport_target_ref = "";
+  }
+  if (!next.scheme) {
+    next.scheme = "https";
+  }
+  if (!next.port) {
+    next.port = next.scheme === "http" ? 80 : 443;
+  }
+  if (!next.region) {
+    next.region = "us-east-1";
+  }
+  return next;
+}
+
+export function submitDisabled({ state }) {
+  return state.state === "saving";
+}
+
+export function submitLabel({ state, mode }) {
+  if (state.state === "saving") return "Saving...";
+  return mode === "edit" ? "Save changes" : "Create connector";
+}
+
+export async function save({ mode, form, target }) {
+  if (mode === "edit") {
+    await updateTarget({ form, target });
+    return;
+  }
+  await createTarget({ form });
+}
+
+export async function deleteTarget({ target }) {
+  await apiDelete(`/api/connector-targets/${target.id}`);
+}
+
+export function emptyCredentialState({ targets = [] } = {}) {
+  const firstTarget = targets.find((target) => target.connector_kind === "s3");
+  return {
+    form: {
+      ...emptyS3CredentialForm,
+      target_id: String(firstTarget?.id || ""),
+    },
+  };
+}
+
+export function credentialStateFromRow({ row }) {
+  return {
+    form: {
+      target_id: String(row.target_id || ""),
+      profile_label: row.name,
+      access_key_id: row.profile?.public?.access_key_id || "",
+      secret_access_key: "",
+      session_token: "",
+      risk_label: row.profile?.risk_label || "",
+    },
+  };
+}
+
+export function credentialFormProps({ targets, formState, setFormState, formMode, state, onSubmit }) {
+  return {
+    form: formState.form,
+    formMode,
+    targets,
+    state,
+    onChange: (form) => setFormState({ form }),
+    onSubmit: (event) => onSubmit(event, formMode === "edit" ? "update" : "create"),
+  };
+}
+
+export async function saveCredential({ operation, row, formState }) {
+  const form = formState.form;
+  if (operation === "create") {
+    await apiPost(`/api/connector-targets/${form.target_id}/profiles`, {
+      kind: "access_key",
+      label: form.profile_label,
+      public: { access_key_id: form.access_key_id },
+      secret: s3SecretPayload(form),
+      risk_label: form.risk_label,
+    });
+    return { message: "S3 credential created." };
+  }
+  if (operation === "update") {
+    if (!row) throw new Error("S3 credential is not loaded.");
+    const payload = {
+      kind: row.profile?.kind || "access_key",
+      label: form.profile_label,
+      public: { access_key_id: form.access_key_id },
+      risk_label: form.risk_label,
+    };
+    const secret = s3SecretPayload(form);
+    if (Object.keys(secret).length > 0) {
+      payload.secret = secret;
+    }
+    await apiPut(`/api/connector-targets/${form.target_id}/profiles/${row.id}`, payload);
+    return { message: "S3 credential updated." };
+  }
+  throw new Error("Unsupported S3 credential operation.");
+}
+
+export async function deleteCredential({ row }) {
+  await apiDelete(`/api/connector-targets/${row.target_id}/profiles/${row.id}`);
+}
+
+export function credentialRows({ targets }) {
+  return targets.flatMap((target) =>
+    (target.profiles || [])
+      .filter((profile) => target.connector_kind === "s3")
+      .map((profile) => ({
+        row_id: `${target.connector_kind}:${target.id}:${profile.id}`,
+        connector_kind: target.connector_kind,
+        resource_kind: "credential_profile",
+        connector_label: "S3",
+        id: profile.id,
+        target_id: target.id,
+        name: profile.label,
+        kind: profile.kind,
+        profile,
+        target_label: target.name,
+        target_detail: targetEndpoint({ target }),
+        metadata: credentialMetadata(profile),
+        delete_disabled: "",
+      }))
+  );
+}
+
+export async function test({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!selectedProfile) throw new Error("Connector profile is not loaded.");
+  const data = await apiPost(`/api/connector-targets/${target.id}/profiles/${selectedProfile.id}/test`, {});
+  return { ok: data.ok, error: data.message || null, data };
+}
+
+export function canEdit() {
+  return true;
+}
+
+export function canDelete() {
+  return true;
+}
+
+export function credentialHint() {
+  return null;
+}
+
+export function targetEndpoint({ target }) {
+  const scheme = target.config?.scheme || "https";
+  const host = target.config?.host || "s3.amazonaws.com";
+  const port = target.config?.port || (scheme === "http" ? 80 : 443);
+  const bucket = target.config?.bucket || "bucket";
+  const mode = target.config?.connection_mode === "over_ssh" ? "over ssh" : "direct";
+  return `${scheme}://${host}:${port}/${bucket} · ${mode}`;
+}
+
+export function targetDisplayName({ target }) {
+  if (!target) return "S3 target";
+  return target.target_name || target.name || "S3 target";
+}
+
+export function targetSubtitle({ target }) {
+  return targetEndpoint({ target });
+}
+
+export function targetProfileLabel({ target }) {
+  return target?.profile_label || "default";
+}
+
+export function usesLiveConsole() {
+  return false;
+}
+
+export function recoverableRunningActions() {
+  return [];
+}
+
+export function deleteDialog({ target }) {
+  return {
+    title: target ? `Delete ${target.name}` : "Delete connector",
+    description: "Remove this S3 connector target, credential profiles, and token action permissions from AIPermission.",
+    details: [
+      { label: "Connector", value: target?.name },
+      { label: "Reference", value: target ? `${target.connector_kind}:${target.id}` : "" },
+    ],
+    notice: "This removes the connector target and its credential profiles. It does not delete buckets or objects.",
+    actions: [
+      { label: "Cancel", action: "close", variant: "outline" },
+      { label: "Delete connector", pendingLabel: "Deleting...", removeKey: false },
+    ],
+  };
+}
+
+export function operationFromError() {
+  return null;
+}
+
+async function createTarget({ form }) {
+  await createTargetWithProfile({
+    targetPayload: {
+      connector_kind: "s3",
+      name: form.name,
+      config: s3TargetConfigFromForm(form),
+    },
+    profilePayload: {
+      kind: "access_key",
+      label: form.profile_label,
+      public: { access_key_id: form.access_key_id },
+      secret: s3SecretPayload(form),
+      risk_label: form.risk_label || "object storage",
+    },
+  });
+}
+
+async function updateTarget({ form, target }) {
+  const profile = target?.profiles?.find((item) => Number(item.id) === Number(form.profile_id)) || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!target || !profile) throw new Error("S3 connector profile is not loaded.");
+  const profilePayload = {
+    kind: profile.kind || "access_key",
+    label: form.profile_label,
+    public: { access_key_id: form.access_key_id },
+    risk_label: form.risk_label || "object storage",
+  };
+  const secret = s3SecretPayload(form);
+  if (Object.keys(secret).length > 0) {
+    profilePayload.secret = secret;
+  }
+  await updateTargetWithProfile({
+    targetID: target.id,
+    profileID: profile.id,
+    targetPayload: {
+      connector_kind: "s3",
+      name: form.name,
+      config: s3TargetConfigFromForm(form),
+    },
+    profilePayload,
+  });
+}
+
+function s3TargetConfigFromForm(form) {
+  return {
+    connection_mode: form.connection_mode || "direct",
+    scheme: form.scheme || "https",
+    host: form.host,
+    port: Number(form.port || (form.scheme === "http" ? 80 : 443)),
+    region: form.region || "us-east-1",
+    bucket: form.bucket,
+    path_style: form.path_style !== false,
+    transport_target_ref: form.connection_mode === "over_ssh" ? form.transport_target_ref : "",
+  };
+}
+
+function s3SecretPayload(form) {
+  const secret = {};
+  if (form.secret_access_key) {
+    secret.secret_access_key = form.secret_access_key;
+  }
+  if (form.session_token) {
+    secret.session_token = form.session_token;
+  }
+  return secret;
+}
+
+function credentialMetadata(profile) {
+  const values = [];
+  if (profile.public?.access_key_id) {
+    values.push(`access ${maskAccessKey(profile.public.access_key_id)}`);
+  }
+  if (profile.risk_label) {
+    values.push(profile.risk_label);
+  }
+  return values.join(" · ");
+}
+
+function maskAccessKey(value) {
+  const text = String(value || "");
+  if (text.length <= 8) return text;
+  return `${text.slice(0, 4)}...${text.slice(-4)}`;
+}

--- a/frontend/src/connectors/templates/s3/operations.jsx
+++ b/frontend/src/connectors/templates/s3/operations.jsx
@@ -1,0 +1,3 @@
+export function S3ConnectorOperationsTemplate() {
+  return null;
+}

--- a/frontend/src/connectors/templates/ssh/model.js
+++ b/frontend/src/connectors/templates/ssh/model.js
@@ -227,6 +227,10 @@ export function usesLiveConsole() {
   return true;
 }
 
+export function recoverableRunningActions() {
+  return ["exec"];
+}
+
 export function liveConsoleRuntimeTarget({ target }) {
   const profile = target.public || {};
   return {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -340,6 +340,8 @@ test("Console exposes connector action approvals", () => {
   assert.match(consolePageSource, /Search connectors/);
   assert.match(consolePageSource, /Connectors/);
   assert.match(consolePageSource, /targetUsesLiveConsole/);
+  assert.match(consolePageSource, /recoverableRunningActions/);
+  assert.doesNotMatch(consolePageSource, /connector_kind === "ssh"/);
   assert.match(consolePageSource, /getConnectorModel/);
   assert.match(consolePageSource, /ConnectorIcon/);
   assert.match(tokenPermissionPanelSource, /ConnectorTokenPermissionPanel/);

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -236,7 +236,10 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.10"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.11"/);
+  assert.match(releaseSource, /S3 connector/);
+  assert.match(releaseSource, /S3 is now a built-in connector/);
+  assert.match(releaseSource, /Live-console recovery behavior is now defined by connector templates/);
   assert.match(releaseSource, /Kubernetes connector/);
   assert.match(releaseSource, /Kubernetes is now a built-in connector/);
   assert.match(releaseSource, /Docker inventory and images/);

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,48 @@
-export const appVersion = "0.2.10";
+export const appVersion = "0.2.11";
 
 export const changelogEntries = [
+  {
+    version: "0.2.11",
+    label: "S3 connector",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "S3 is now a built-in connector with Direct and Over SSH connection modes.",
+          "S3 Console can browse bucket objects, inspect metadata, download bounded objects, upload bounded objects, rename objects, and delete objects.",
+          "MCP can discover and call S3 actions through the same connector target/profile/action permission pipeline.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Live-console recovery behavior is now defined by connector templates instead of SSH-specific Console code.",
+          "Connector-provisioned credential metadata now stays behind connector contracts instead of generic API handlers.",
+          "Generic target-operation handlers no longer carry stale Docker-shaped request fields.",
+        ],
+      },
+      {
+        title: "Fixed",
+        items: [
+          "Direct connector TCP dials now prefer IPv4 before IPv6 fallback to avoid Docker-hosted gateway timeouts on dual-stack endpoints with unreachable IPv6.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "S3 credentials stay in connector credential profile secrets, and object content upload/download actions are bounded by connector size limits.",
+        ],
+      },
+      {
+        title: "Tests",
+        items: [
+          "S3 connector tests cover SigV4 request signing, path escaping, upload preview redaction, list filtering, and overwrite protection.",
+          "Direct connector dial ordering is covered for dual-stack DNS responses.",
+          "Backend and frontend boundary checks now guard connector isolation rules against regressions.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.10",
     label: "Kubernetes connector",

--- a/frontend/src/pages/console.jsx
+++ b/frontend/src/pages/console.jsx
@@ -152,8 +152,9 @@ export function ConsolePage() {
     .filter((permission) => permission?.expires_at)
     .map((permission) => permissionLifetimeLabel(permission, now));
   const showAlwaysRunWarning = Boolean(mcpRuntime?.data?.enabled && selectedTarget && alwaysRunTokenPermissions.length > 0);
-  const selectedRunningConnectorRequests = selectedTargetUsesLiveConsole && selectedTarget?.connector_kind === "ssh"
-    ? connectorActionApprovals.data.filter((approval) => approval.status === "running" && approval.target_ref === selectedTarget.ref && approval.action_name === "exec")
+  const selectedRecoverableRunningActions = recoverableRunningActions(selectedTarget);
+  const selectedRunningConnectorRequests = selectedTarget && selectedRecoverableRunningActions.length > 0
+    ? connectorActionApprovals.data.filter((approval) => approval.status === "running" && approval.target_ref === selectedTarget.ref && selectedRecoverableRunningActions.includes(approval.action_name))
     : [];
   const selectedRunningRequest = selectedRunningConnectorRequests[0] || null;
   const consoleBannerCount = (showAlwaysRunWarning ? 1 : 0) + (selectedRunningRequest ? 1 : 0) + (newSessionError ? 1 : 0);
@@ -886,6 +887,13 @@ function targetUsesLiveConsole(target) {
   if (!target) return false;
   const model = getConnectorModel(target.connector_kind);
   return Boolean(model?.usesLiveConsole?.({ target }));
+}
+
+function recoverableRunningActions(target) {
+  if (!target) return [];
+  const model = getConnectorModel(target.connector_kind);
+  const actions = model?.recoverableRunningActions?.({ target });
+  return Array.isArray(actions) ? actions.filter(Boolean).map(String) : [];
 }
 
 function selectedTargetStatus({ target, session, pendingCount = 0, runningCount = 0 }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,7 +2564,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Highlights

- Adds S3 as a built-in connector with Direct and Over SSH modes.
- Adds S3 Console browsing for folders/objects, metadata, upload, download, rename, and delete flows.
- Keeps S3 MCP access on the existing generic connector action pipeline.

## Validation

- node scripts/secret-scan.js
- make test
- make build
- make audit
- cd backend && go test -race ./...
- cd backend && go vet ./...
- cd backend && govulncheck ./...
- docker compose config --quiet
- cd packages/mcp && npm audit --omit=dev --audit-level=moderate && npm pack --dry-run
- cd packages/npm-placeholder && npm pack --dry-run

## Notes

- Dependabot PRs were left untouched per project hygiene rules.
- After merge, publish @aipermission/mcp@0.2.11 to npm.