### PR TITLE
Release 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.12] - 2026-06-30
+
+### Changed
+
+- Improved S3 MCP/operator guidance so agents use `bucket_info`,
+  `list_objects`, directory `browse_input`, pagination `cursor`, object
+  metadata, bounded download/upload, rename, and delete actions more reliably.
+- Added S3 list response hints for folder browsing and pagination, including
+  `assistant_hints`, per-folder `browse_input`, and `next_page_input`.
+- Clarified S3 action input descriptions for prefix browsing, search,
+  pagination, metadata-first reads, bounded object content, overwrite behavior,
+  and destructive deletes.
+
+### Security
+
+- S3 operator guidance now explicitly warns agents not to put access keys,
+  signed URLs, reusable tokens, or other secret material into connector action
+  input.
+
+### Tests
+
+- Added S3 connector coverage for directory browse hints and pagination
+  follow-up input.
+
 ## [0.2.11] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ Implemented:
   explicit message publishing
 - built-in S3 connector with Direct and Over SSH connection modes,
   S3-compatible bucket browsing, object metadata, bounded object
-  upload/download, rename, and delete actions
+  upload/download, rename, and delete actions, plus MCP-friendly folder/prefix
+  browsing hints for AI agents
 - built-in Docker connector over an SSH transport profile, with scoped
   container/image/network/volume inventory, redacted inspect metadata, bounded
   logs, scoped container exec, live container console, and explicit
@@ -377,10 +378,14 @@ count/truncation limits and `ack_requeue_true`.
 
 For S3, call `get_connector_actions(target_ref)` to discover actions such as
 `bucket_info`, `list_objects`, `get_object_metadata`, `download_object`,
-`upload_object`, `rename_object`, and `delete_object`. Object content may
-contain secrets; downloads and uploads are bounded connector actions and large
-transfer-center style object movement is intentionally out of scope for the
-initial S3 connector.
+`upload_object`, `rename_object`, and `delete_object`. Use `prefix` and
+directory `browse_input` values to browse folder-like object groups, and use
+`cursor` or `next_page_input` for pagination. Object content may contain
+secrets; use `get_object_metadata` before downloading content, keep
+`overwrite=false` unless replacement was explicitly approved, and treat delete
+as destructive. Downloads and uploads are bounded connector actions and large
+transfer-center style object movement is intentionally out of scope for the S3
+connector.
 
 For Docker, call `get_connector_actions(target_ref)` to discover bounded
 actions such as `docker_version`, `list_containers`, `list_images`,

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ To pin a specific release image, set `AIPERMISSION_VERSION` without the leading
 `v`:
 
 ```bash
-AIPERMISSION_VERSION=0.2.11 docker compose -f docker-compose.release.yml up -d
+AIPERMISSION_VERSION=0.2.12 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, clone the repository with Git's default text handling or make sure

--- a/backend/internal/connectors/s3/s3.go
+++ b/backend/internal/connectors/s3/s3.go
@@ -197,15 +197,20 @@ func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (conne
 		Connector:   Label,
 		ConnectorID: Kind,
 		Usage: []string{
-			"Use list_objects with a prefix or search filter before reading object details.",
+			"Use bucket_info first when you need to verify bucket reachability or endpoint metadata.",
+			"Use list_objects with prefix to browse folders. Folder entries return browse_input; call list_objects with that input to enter the folder.",
+			"Use list_objects with cursor from next_cursor to fetch the next page. Do not send continuation_token; use the cursor field only.",
+			"Use search for bounded key lookup across pages. When search is set, folder grouping is disabled and results are returned as matching objects.",
 			"Use get_object_metadata to inspect one object without downloading content.",
-			"Use download_object only for bounded object reads; large transfer-center style downloads are a future feature.",
-			"Use upload_object and rename_object only for intentional writes.",
-			"Use delete_object carefully; it is destructive and should normally require approval.",
+			"Use download_object only for bounded object reads. It returns base64 content for the requested object up to max_bytes.",
+			"Use upload_object with overwrite=false by default. If the object exists, ask the operator before retrying with overwrite=true.",
+			"Use rename_object only for intentional object moves. It copies to the destination key and then deletes the source key.",
+			"Use delete_object carefully; it is destructive and should normally require explicit approval.",
 		},
 		Warnings: []string{
 			"S3 objects may contain secrets or customer data. Redaction is best-effort; avoid reading object content unless explicitly approved.",
 			"download_object and upload_object are intentionally size-bounded in the connector action pipeline.",
+			"Do not put access keys, secret keys, signed URLs, or reusable tokens into action input. Store credentials in the selected credential profile.",
 			"S3 credential profiles decide what the object storage service itself allows.",
 		},
 	}, nil
@@ -229,10 +234,10 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 			Category:    "browser",
 			Risk:        connectors.RiskRead,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
-				{Name: "prefix", Label: "Prefix", Type: connectors.FieldString, Description: "Optional object key prefix."},
-				{Name: "search", Label: "Search", Type: connectors.FieldString, Description: "Optional case-insensitive key search applied after listing."},
-				{Name: "cursor", Label: "Cursor", Type: connectors.FieldString, Description: "Optional pagination cursor returned by a previous list."},
-				{Name: "limit", Label: "Limit", Type: connectors.FieldNumber, Default: defaultS3ListLimit},
+				{Name: "prefix", Label: "Prefix", Type: connectors.FieldString, Description: "Optional object key prefix. Use a folder prefix ending in / to browse inside that folder."},
+				{Name: "search", Label: "Search", Type: connectors.FieldString, Description: "Optional case-insensitive key search applied across bounded list pages. Folder grouping is disabled while searching."},
+				{Name: "cursor", Label: "Cursor", Type: connectors.FieldString, Description: "Optional pagination cursor returned as next_cursor by a previous list_objects response."},
+				{Name: "limit", Label: "Limit", Type: connectors.FieldNumber, Default: defaultS3ListLimit, Description: "Maximum objects to return, capped by the connector."},
 			}},
 			OutputHint: connectors.OutputHint{Format: "json", MaxRows: maxS3ListLimit},
 		},
@@ -243,7 +248,7 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 			Category:    "browser",
 			Risk:        connectors.RiskRead,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
-				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true, Description: "Exact object key returned by list_objects."},
 			}},
 			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 32 << 10},
 		},
@@ -254,8 +259,8 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 			Category:    "browser",
 			Risk:        connectors.RiskRead,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
-				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
-				{Name: "max_bytes", Label: "Max bytes", Type: connectors.FieldNumber, Default: defaultDownloadMax},
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true, Description: "Exact object key returned by list_objects."},
+				{Name: "max_bytes", Label: "Max bytes", Type: connectors.FieldNumber, Default: defaultDownloadMax, Description: "Maximum bytes to read, capped by the connector."},
 			}},
 			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: maxDownloadBytes},
 		},
@@ -266,11 +271,11 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 			Category:    "write",
 			Risk:        connectors.RiskWrite,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
-				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
-				{Name: "content_text", Label: "Text content", Type: connectors.FieldMultiline},
-				{Name: "content_base64", Label: "Base64 content", Type: connectors.FieldMultiline},
-				{Name: "content_type", Label: "Content type", Type: connectors.FieldString, Default: "application/octet-stream"},
-				{Name: "overwrite", Label: "Overwrite existing object", Type: connectors.FieldBoolean, Default: false},
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true, Description: "Destination object key."},
+				{Name: "content_text", Label: "Text content", Type: connectors.FieldMultiline, Description: "Text payload for small text objects. Use this or content_base64, not both."},
+				{Name: "content_base64", Label: "Base64 content", Type: connectors.FieldMultiline, Description: "Base64 payload for binary objects. Use this or content_text, not both."},
+				{Name: "content_type", Label: "Content type", Type: connectors.FieldString, Default: "application/octet-stream", Description: "Object content type to send with the upload."},
+				{Name: "overwrite", Label: "Overwrite existing object", Type: connectors.FieldBoolean, Default: false, Description: "Leave false unless the operator explicitly approved replacing an existing object."},
 			}},
 			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
 		},
@@ -281,9 +286,9 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 			Category:    "write",
 			Risk:        connectors.RiskWrite,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
-				{Name: "source_key", Label: "Source key", Type: connectors.FieldString, Required: true},
-				{Name: "destination_key", Label: "Destination key", Type: connectors.FieldString, Required: true},
-				{Name: "overwrite", Label: "Overwrite destination", Type: connectors.FieldBoolean, Default: false},
+				{Name: "source_key", Label: "Source key", Type: connectors.FieldString, Required: true, Description: "Existing object key to move."},
+				{Name: "destination_key", Label: "Destination key", Type: connectors.FieldString, Required: true, Description: "New object key."},
+				{Name: "overwrite", Label: "Overwrite destination", Type: connectors.FieldBoolean, Default: false, Description: "Leave false unless the operator explicitly approved replacing the destination object."},
 			}},
 			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
 		},
@@ -294,7 +299,7 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 			Category:    "destructive",
 			Risk:        connectors.RiskDestructive,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
-				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true},
+				{Name: "key", Label: "Key", Type: connectors.FieldString, Required: true, Description: "Exact object key to delete."},
 			}},
 			OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 4000},
 		},
@@ -556,29 +561,64 @@ func s3ObjectSummary(object s3Object) map[string]any {
 
 func s3DirectorySummary(directory s3CommonPrefix) map[string]any {
 	return map[string]any{
-		"prefix": directory.Prefix,
-		"name":   directoryName(directory.Prefix),
+		"prefix":       directory.Prefix,
+		"name":         directoryName(directory.Prefix),
+		"browse_input": map[string]any{"prefix": directory.Prefix, "limit": defaultS3ListLimit},
 	}
 }
 
 func s3ListResult(bucket string, prefix string, search string, directories []map[string]any, objects []map[string]any, isTruncated bool, nextCursor string, scanned int, scanLimited bool) connectors.ActionResult {
+	hints := s3ListAssistantHints(prefix, search, len(directories), len(objects), isTruncated, nextCursor, scanLimited)
+	output := map[string]any{
+		"bucket":          bucket,
+		"prefix":          prefix,
+		"search":          search,
+		"directories":     directories,
+		"directory_count": len(directories),
+		"objects":         objects,
+		"count":           len(objects),
+		"is_truncated":    isTruncated,
+		"next_cursor":     nextCursor,
+		"scanned":         scanned,
+		"scan_limited":    scanLimited,
+		"assistant_hints": hints,
+	}
+	if isTruncated && nextCursor != "" {
+		output["next_page_input"] = map[string]any{
+			"prefix": prefix,
+			"search": search,
+			"cursor": nextCursor,
+			"limit":  defaultS3ListLimit,
+		}
+	}
 	return connectors.ActionResult{
-		Status: connectors.ResultCompleted,
-		Output: map[string]any{
-			"bucket":          bucket,
-			"prefix":          prefix,
-			"search":          search,
-			"directories":     directories,
-			"directory_count": len(directories),
-			"objects":         objects,
-			"count":           len(objects),
-			"is_truncated":    isTruncated,
-			"next_cursor":     nextCursor,
-			"scanned":         scanned,
-			"scan_limited":    scanLimited,
-		},
+		Status:      connectors.ResultCompleted,
+		Output:      output,
 		DisplayText: fmt.Sprintf("%d folder(s), %d object(s)", len(directories), len(objects)),
 	}
+}
+
+func s3ListAssistantHints(prefix string, search string, directoryCount int, objectCount int, isTruncated bool, nextCursor string, scanLimited bool) []string {
+	hints := []string{}
+	if directoryCount > 0 {
+		hints = append(hints, "To enter a folder, call list_objects with that folder's browse_input.")
+	}
+	if objectCount > 0 {
+		hints = append(hints, "Use get_object_metadata before download_object when you only need size, type, or headers.")
+	}
+	if isTruncated && nextCursor != "" {
+		hints = append(hints, "More objects are available. Call list_objects with next_page_input or use next_cursor as cursor.")
+	}
+	if search != "" {
+		hints = append(hints, "Search scans bounded pages and returns matching objects without folder grouping.")
+	}
+	if scanLimited {
+		hints = append(hints, "Search stopped at the connector page limit; narrow the prefix or search term for a deeper lookup.")
+	}
+	if prefix == "" && search == "" && directoryCount == 0 && objectCount == 0 {
+		hints = append(hints, "The bucket root is empty or the credential profile cannot see objects under this prefix.")
+	}
+	return hints
 }
 
 func executeGetObjectMetadata(ctx context.Context, client *s3Client, input map[string]any) (connectors.ActionResult, error) {

--- a/backend/internal/connectors/s3/s3_test.go
+++ b/backend/internal/connectors/s3/s3_test.go
@@ -188,6 +188,48 @@ func TestExecuteListObjectsReturnsDirectoryPrefixes(t *testing.T) {
 	if directories[0]["prefix"] != "2025/" || directories[1]["name"] != "2026" {
 		t.Fatalf("directories = %#v", directories)
 	}
+	browseInput := directories[0]["browse_input"].(map[string]any)
+	if browseInput["prefix"] != "2025/" {
+		t.Fatalf("browse_input = %#v", browseInput)
+	}
+	hints := output["assistant_hints"].([]string)
+	if len(hints) == 0 || !strings.Contains(strings.Join(hints, " "), "browse_input") {
+		t.Fatalf("assistant_hints = %#v", hints)
+	}
+}
+
+func TestExecuteListObjectsReturnsNextPageInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<ListBucketResult>
+<Name>test-bucket</Name>
+<IsTruncated>true</IsTruncated>
+<NextContinuationToken>page-2</NextContinuationToken>
+<Contents><Key>daily/one.txt</Key><LastModified>2026-06-29T10:00:00.000Z</LastModified><ETag>"abc"</ETag><Size>42</Size><StorageClass>STANDARD</StorageClass></Contents>
+</ListBucketResult>`))
+	}))
+	defer server.Close()
+
+	connector := New()
+	result, err := connector.ExecuteAction(context.Background(), s3TestRuntime(t, server.URL), connectors.PreparedAction{
+		ActionName: ActionListObjects,
+		Payload:    map[string]any{"prefix": "daily/", "limit": 10},
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	output := result.Output.(map[string]any)
+	if output["next_cursor"] != "page-2" {
+		t.Fatalf("next_cursor = %#v", output["next_cursor"])
+	}
+	nextPageInput := output["next_page_input"].(map[string]any)
+	if nextPageInput["prefix"] != "daily/" || nextPageInput["cursor"] != "page-2" {
+		t.Fatalf("next_page_input = %#v", nextPageInput)
+	}
+	hints := output["assistant_hints"].([]string)
+	if len(hints) == 0 || !strings.Contains(strings.Join(hints, " "), "next_cursor") {
+		t.Fatalf("assistant_hints = %#v", hints)
+	}
 }
 
 func TestPrepareListObjectsUsesNonSecretCursorPayload(t *testing.T) {

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -151,6 +151,11 @@ S3 actions include bucket metadata, bounded object listing, object metadata,
 bounded object download/upload, object rename, and explicit delete. Object
 content may contain secrets or customer data; prefer approval-required access
 for downloads, uploads, renames, and deletes until the workflow is trusted.
+Use `prefix` to browse folder-like object groups, `browse_input` from directory
+entries to enter a folder, and `cursor` from `next_cursor` or `next_page_input`
+to fetch the next page. Do not send `continuation_token` as an action input.
+Use `get_object_metadata` before `download_object` when content is not needed.
+Leave `overwrite=false` unless replacement was explicitly approved.
 
 Docker actions include version metadata, scoped container/image/network/volume
 listing, redacted container inspect metadata, bounded container log tails,
@@ -200,6 +205,59 @@ Example response:
   "output": {
     "exit_code": 0,
     "stdout": "active\n"
+  }
+}
+```
+
+Example S3 directory browse:
+
+```json
+{
+  "target_ref": "s3:12:7",
+  "action_name": "list_objects",
+  "input": {
+    "prefix": "backups/2026/",
+    "limit": 100
+  },
+  "reason": "List backup objects under the requested prefix before reading metadata."
+}
+```
+
+Example S3 list response shape:
+
+```json
+{
+  "status": "completed",
+  "target_ref": "s3:12:7",
+  "connector_kind": "s3",
+  "action_name": "list_objects",
+  "display_text": "1 folder(s), 2 object(s)",
+  "output": {
+    "directories": [
+      {
+        "name": "daily",
+        "prefix": "backups/2026/daily/",
+        "browse_input": {
+          "prefix": "backups/2026/daily/",
+          "limit": 100
+        }
+      }
+    ],
+    "objects": [
+      {
+        "key": "backups/2026/app.aipdb",
+        "size": 2048
+      }
+    ],
+    "next_cursor": "opaque-page-cursor",
+    "next_page_input": {
+      "prefix": "backups/2026/",
+      "cursor": "opaque-page-cursor",
+      "limit": 100
+    },
+    "assistant_hints": [
+      "To enter a folder, call list_objects with that folder's browse_input."
+    ]
   }
 }
 ```

--- a/docs/skills/aipermission-operator/SKILL.md
+++ b/docs/skills/aipermission-operator/SKILL.md
@@ -151,6 +151,30 @@ explicitly supports that behavior.
 MCP connector responses never include file contents, gateway temp paths, archive
 staging paths, or local upload contents.
 
+## S3/Object Storage Practice
+
+For S3 connector targets, discover actions with `get_connector_actions` and
+prefer this sequence:
+
+1. Use `bucket_info` only to verify bucket reachability or endpoint metadata.
+2. Use `list_objects` to browse. Pass `prefix` to enter a folder-like prefix,
+   and use `browse_input` from directory entries when it is returned.
+3. Use `cursor` from `next_cursor` or `next_page_input` for pagination. Do not
+   send fields named `continuation_token`; S3 pagination tokens are not
+   credentials here, but the connector exposes them as `cursor` to avoid
+   secret-like input names.
+4. Use `get_object_metadata` before `download_object` when you only need size,
+   type, headers, or existence.
+5. Use `download_object` only for bounded object reads explicitly requested by
+   the operator.
+6. Keep `overwrite=false` for `upload_object` and `rename_object` unless the
+   operator explicitly approved replacement.
+7. Treat `delete_object` as destructive and ask for explicit confirmation if
+   approval mode does not already provide it.
+
+Object content may contain secrets or customer data. Avoid downloading or
+echoing object contents unless the operator asked for that exact object.
+
 ## Secret Hygiene
 
 Command text, action input, action output, history, audit records, and console

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -236,7 +236,9 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.11"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.12"/);
+  assert.match(releaseSource, /S3 MCP polish/);
+  assert.match(releaseSource, /S3 list responses now include assistant_hints/);
   assert.match(releaseSource, /S3 connector/);
   assert.match(releaseSource, /S3 is now a built-in connector/);
   assert.match(releaseSource, /Live-console recovery behavior is now defined by connector templates/);

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,32 @@
-export const appVersion = "0.2.11";
+export const appVersion = "0.2.12";
 
 export const changelogEntries = [
+  {
+    version: "0.2.12",
+    label: "S3 MCP polish",
+    sections: [
+      {
+        title: "Changed",
+        items: [
+          "S3 MCP/operator guidance now explains bucket_info, list_objects, folder browse_input, pagination cursor, metadata reads, bounded transfers, rename, and delete actions more clearly.",
+          "S3 list responses now include assistant_hints, per-folder browse_input, and next_page_input so AI agents can browse object prefixes without guessing field names.",
+          "S3 action input descriptions now clarify prefix browsing, search, pagination, metadata-first reads, bounded content, overwrite behavior, and destructive deletes.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "S3 operator guidance now explicitly warns agents not to put access keys, signed URLs, reusable tokens, or other secret material into connector action input.",
+        ],
+      },
+      {
+        title: "Tests",
+        items: [
+          "S3 connector tests now cover directory browse hints and pagination follow-up input.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.11",
     label: "S3 connector",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2564,7 +2564,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/resources/aipermission-operator/SKILL.md
+++ b/packages/mcp/resources/aipermission-operator/SKILL.md
@@ -151,6 +151,30 @@ explicitly supports that behavior.
 MCP connector responses never include file contents, gateway temp paths, archive
 staging paths, or local upload contents.
 
+## S3/Object Storage Practice
+
+For S3 connector targets, discover actions with `get_connector_actions` and
+prefer this sequence:
+
+1. Use `bucket_info` only to verify bucket reachability or endpoint metadata.
+2. Use `list_objects` to browse. Pass `prefix` to enter a folder-like prefix,
+   and use `browse_input` from directory entries when it is returned.
+3. Use `cursor` from `next_cursor` or `next_page_input` for pagination. Do not
+   send fields named `continuation_token`; S3 pagination tokens are not
+   credentials here, but the connector exposes them as `cursor` to avoid
+   secret-like input names.
+4. Use `get_object_metadata` before `download_object` when you only need size,
+   type, headers, or existence.
+5. Use `download_object` only for bounded object reads explicitly requested by
+   the operator.
+6. Keep `overwrite=false` for `upload_object` and `rename_object` unless the
+   operator explicitly approved replacement.
+7. Treat `delete_object` as destructive and ask for explicit confirmation if
+   approval mode does not already provide it.
+
+Object content may contain secrets or customer data. Avoid downloading or
+echoing object contents unless the operator asked for that exact object.
+
 ## Secret Hygiene
 
 Command text, action input, action output, history, audit records, and console

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- Improve S3 MCP browsing hints with directory browse inputs and pagination follow-up inputs.
- Document the S3 operator workflow for bucket info, prefix browsing, metadata-first reads, bounded transfers, overwrite behavior, and destructive deletes.
- Prepare 0.2.12 changelog, in-app release notes, and MCP package metadata.

## Validation

- make test
- make build
- make audit
- git diff --check
- node scripts/secret-scan.js
- cd backend && go vet ./...
- cd backend && go test -race ./...
- cd backend && govulncheck ./...
- docker compose config --quiet
- cd packages/mcp && npm pack --dry-run
- cd packages/npm-placeholder && npm pack --dry-run
- Full local Docker Compose rebuild and S3 MCP smoke test against a temporary aipermission-smoke object

## Notes

- Local-only, single-user release.
- Do not squash; use rebase merge to preserve the release commits.