### PR TITLE
release: AIPermission v0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.17] - 2026-07-31
+
 ### Added
 
 - Added Valkey compatibility to the built-in Redis connector, including

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+### Added
+
+- Added Valkey compatibility to the built-in Redis connector, including
+  Redis/Valkey product selection, server identity detection, Direct and Over
+  SSH connections, and the existing bounded key browser/action surface.
+
+### Changed
+
+- Renamed the product-facing connector label to Redis / Valkey while preserving
+  the existing `redis` connector kind, target refs, permissions, and actions.
+
+### Security
+
+- Bounded RESP line, bulk, array, nesting, total-byte, and total-value parsing
+  before allocation so malformed Redis-compatible responses fail closed.
+
 ## [0.2.16] - 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ AIPermission is intentionally designed as a local developer gateway.
 
 - The gateway runs on the developer's own machine.
 - Remote systems are connector targets reached from that local gateway.
-- SSH, Postgres, ClickHouse, Redis, RabbitMQ, S3, Docker, and Kubernetes are
+- SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, and Kubernetes are
   built-in connector types, not separate product modes.
 - The web UI, REST API, and MCP API are not designed to be shared on a LAN.
 - The project does not support running the gateway as a remote hosted service.
@@ -119,7 +119,7 @@ Implemented:
 - Go backend with SQLite storage
 - React web UI
 - connector target/profile/action pipeline for SSH, Postgres, ClickHouse,
-  Redis, RabbitMQ, S3, Docker, Kubernetes, and future local integrations
+  Redis / Valkey, RabbitMQ, S3, Docker, Kubernetes, and future local integrations
 - local Projects for grouping connector targets, filtering History/Audit, and
   limiting which project target refs each MCP token can discover or call
 - [Project Vault](docs/project-vault.md) for encrypted project-scoped secret inventory, expiry/usage
@@ -141,8 +141,9 @@ Implemented:
 - built-in ClickHouse connector over the native protocol with Direct and Over
   SSH connection modes, database/table/column inspection, bounded read-only
   analytics SQL, query timeouts, and output caps
-- built-in Redis connector with Direct and Over SSH connection modes, bounded
-  key scanning, key inspection, string writes, TTL updates, and explicit deletes
+- built-in Redis / Valkey connector with Direct and Over SSH connection modes,
+  server identity detection, bounded key scanning, key inspection, string
+  writes, TTL updates, and explicit deletes
 - built-in RabbitMQ connector with Direct and Over SSH connection modes, queue
   browsing, vhost metadata, binding inspection, bounded message peeking, and
   explicit message publishing
@@ -173,7 +174,7 @@ Implemented:
 - global MCP Started/Stopped switch that preserves permissions while blocking live execution
 - persistent web console with live PTY streaming
 - UI bulk SSH command execution across selected connector targets with per-target history rows
-- MCP bridge with connector action tools for SSH, Postgres, ClickHouse, Redis,
+- MCP bridge with connector action tools for SSH, Postgres, ClickHouse, Redis / Valkey,
   RabbitMQ, S3, Docker, Kubernetes, and future local integrations
 - approval dialog with Run / Decline / note
 - approval-context snapshots that stale old pending connector actions after
@@ -373,7 +374,7 @@ call_connector_action(target_ref, action_name, input?, reason?)
 get_connector_action_request(request_id)
 ```
 
-The MCP surface is connector-first. SSH, Postgres, ClickHouse, Redis, RabbitMQ,
+The MCP surface is connector-first. SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ,
 S3, Docker, Kubernetes, and future integrations use the same
 target/profile/action permission pipeline. `list_connector_targets` also applies the token's enabled project
 scope before returning target refs. It is
@@ -393,8 +394,12 @@ Use a dedicated read-only ClickHouse user and keep exploratory analytics on
 `approval_required`; connector validation is defense in depth, not a SQL
 sandbox or a replacement for database grants.
 
-For Redis, call `get_connector_actions(target_ref)` to discover actions such as
-`scan_keys`, `get_key`, `set_string`, `expire_key`, and `delete_keys`.
+For Redis or Valkey, call `get_connector_actions(target_ref)` to discover
+actions such as `scan_keys`, `get_key`, `set_string`, `expire_key`, and
+`delete_keys`. Both products use the existing `redis:<target_id>:<profile_id>`
+target ref and action catalog. The current connector is a standalone/single
+endpoint RESP2 integration; it does not route Redis Cluster `MOVED`/`ASK`
+responses, discover Sentinel primaries, or negotiate RESP3.
 
 For RabbitMQ, call `get_connector_actions(target_ref)` to discover actions such
 as `overview`, `list_vhosts`, `list_queues`, `get_queue`, `list_bindings`, and

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ To pin a specific release image, set `AIPERMISSION_VERSION` without the leading
 `v`:
 
 ```bash
-AIPERMISSION_VERSION=0.2.16 docker compose -f docker-compose.release.yml up -d
+AIPERMISSION_VERSION=0.2.17 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, clone the repository with Git's default text handling or make sure

--- a/backend/internal/connectors/README.md
+++ b/backend/internal/connectors/README.md
@@ -1,7 +1,8 @@
 # Connectors
 
 `internal/connectors` defines the internal contract for connector-shaped
-targets. SSH, Postgres, ClickHouse, Redis, and future API integrations use the
+targets. SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker,
+Kubernetes, and future API integrations use the
 same gateway pipeline:
 
 ```text
@@ -179,8 +180,10 @@ metadata icons during frontend tests.
 Built-in connectors may depend on runtime packages for their own transport.
 SSH uses SSH key, persistent terminal, and SFTP primitives. Postgres and
 ClickHouse use connector-owned database drivers plus shared SQL safety, bounded
-result, frontend model, and console primitives. Redis uses a bounded RESP client and
-the shared network transport capability. Those transport details stay inside
+result, frontend model, and console primitives. Redis / Valkey uses one bounded
+RESP2 client and the shared network transport capability. The configured server
+product is connector-owned target metadata; both products intentionally retain
+the `redis` connector kind, action names, and target-ref prefix. Those transport details stay inside
 the connector implementation; page-level UI, MCP tools, token permissions,
 history, and audit use the shared target/profile/action vocabulary.
 

--- a/backend/internal/connectors/redis/client.go
+++ b/backend/internal/connectors/redis/client.go
@@ -7,11 +7,18 @@ import (
 	"io"
 	"net"
 	"strconv"
-	"strings"
 	"time"
 )
 
-const redisCommandTimeout = 10 * time.Second
+const (
+	redisCommandTimeout  = 10 * time.Second
+	maxRESPLineBytes     = 64 << 10
+	maxRESPBulkBytes     = 1 << 20
+	maxRESPResponseBytes = 8 << 20
+	maxRESPArrayItems    = 4096
+	maxRESPValues        = 8192
+	maxRESPNestingDepth  = 16
+)
 
 type respKind byte
 
@@ -29,6 +36,11 @@ type respValue struct {
 	number int64
 	array  []respValue
 	null   bool
+}
+
+type respReadBudget struct {
+	bytes  int
+	values int
 }
 
 type redisClient struct {
@@ -80,19 +92,32 @@ func (client *redisClient) Do(args ...string) (respValue, error) {
 }
 
 func readRESPValue(reader *bufio.Reader) (respValue, error) {
+	return readRESPValueAtDepth(reader, 0, &respReadBudget{})
+}
+
+func readRESPValueAtDepth(reader *bufio.Reader, depth int, budget *respReadBudget) (respValue, error) {
+	if depth > maxRESPNestingDepth {
+		return respValue{}, fmt.Errorf("redis response nesting exceeds %d levels", maxRESPNestingDepth)
+	}
+	if err := budget.consumeValue(); err != nil {
+		return respValue{}, err
+	}
 	prefix, err := reader.ReadByte()
 	if err != nil {
 		return respValue{}, err
 	}
+	if err := budget.consumeBytes(1); err != nil {
+		return respValue{}, err
+	}
 	switch respKind(prefix) {
 	case respSimpleString:
-		text, err := readRESPLine(reader)
+		text, err := readRESPLine(reader, budget)
 		return respValue{kind: respSimpleString, text: text}, err
 	case respError:
-		text, err := readRESPLine(reader)
+		text, err := readRESPLine(reader, budget)
 		return respValue{kind: respError, text: text}, err
 	case respInteger:
-		text, err := readRESPLine(reader)
+		text, err := readRESPLine(reader, budget)
 		if err != nil {
 			return respValue{}, err
 		}
@@ -102,7 +127,7 @@ func readRESPValue(reader *bufio.Reader) (respValue, error) {
 		}
 		return respValue{kind: respInteger, number: number}, nil
 	case respBulkString:
-		text, err := readRESPLine(reader)
+		text, err := readRESPLine(reader, budget)
 		if err != nil {
 			return respValue{}, err
 		}
@@ -110,8 +135,17 @@ func readRESPValue(reader *bufio.Reader) (respValue, error) {
 		if err != nil {
 			return respValue{}, err
 		}
-		if size < 0 {
+		if size == -1 {
 			return respValue{kind: respBulkString, null: true}, nil
+		}
+		if size < -1 {
+			return respValue{}, fmt.Errorf("invalid redis bulk string size %d", size)
+		}
+		if size > maxRESPBulkBytes {
+			return respValue{}, fmt.Errorf("redis bulk string exceeds %d bytes", maxRESPBulkBytes)
+		}
+		if err := budget.consumeBytes(size + 2); err != nil {
+			return respValue{}, err
 		}
 		buf := make([]byte, size+2)
 		if _, err := io.ReadFull(reader, buf); err != nil {
@@ -122,7 +156,7 @@ func readRESPValue(reader *bufio.Reader) (respValue, error) {
 		}
 		return respValue{kind: respBulkString, text: string(buf[:size])}, nil
 	case respArray:
-		text, err := readRESPLine(reader)
+		text, err := readRESPLine(reader, budget)
 		if err != nil {
 			return respValue{}, err
 		}
@@ -130,12 +164,18 @@ func readRESPValue(reader *bufio.Reader) (respValue, error) {
 		if err != nil {
 			return respValue{}, err
 		}
-		if count < 0 {
+		if count == -1 {
 			return respValue{kind: respArray, null: true}, nil
+		}
+		if count < -1 {
+			return respValue{}, fmt.Errorf("invalid redis array size %d", count)
+		}
+		if count > maxRESPArrayItems {
+			return respValue{}, fmt.Errorf("redis array exceeds %d items", maxRESPArrayItems)
 		}
 		items := make([]respValue, 0, count)
 		for i := 0; i < count; i++ {
-			item, err := readRESPValue(reader)
+			item, err := readRESPValueAtDepth(reader, depth+1, budget)
 			if err != nil {
 				return respValue{}, err
 			}
@@ -147,12 +187,44 @@ func readRESPValue(reader *bufio.Reader) (respValue, error) {
 	}
 }
 
-func readRESPLine(reader *bufio.Reader) (string, error) {
-	line, err := reader.ReadString('\n')
-	if err != nil {
-		return "", err
+func readRESPLine(reader *bufio.Reader, budget *respReadBudget) (string, error) {
+	line := make([]byte, 0, 128)
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		if len(line)+len(fragment) > maxRESPLineBytes {
+			return "", fmt.Errorf("redis response line exceeds %d bytes", maxRESPLineBytes)
+		}
+		if consumeErr := budget.consumeBytes(len(fragment)); consumeErr != nil {
+			return "", consumeErr
+		}
+		line = append(line, fragment...)
+		if err == nil {
+			break
+		}
+		if err != bufio.ErrBufferFull {
+			return "", err
+		}
 	}
-	return strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r"), nil
+	if !bytes.HasSuffix(line, []byte("\r\n")) {
+		return "", fmt.Errorf("invalid redis response line terminator")
+	}
+	return string(line[:len(line)-2]), nil
+}
+
+func (budget *respReadBudget) consumeBytes(count int) error {
+	if count < 0 || budget.bytes > maxRESPResponseBytes-count {
+		return fmt.Errorf("redis response exceeds %d bytes", maxRESPResponseBytes)
+	}
+	budget.bytes += count
+	return nil
+}
+
+func (budget *respReadBudget) consumeValue() error {
+	if budget.values >= maxRESPValues {
+		return fmt.Errorf("redis response exceeds %d values", maxRESPValues)
+	}
+	budget.values++
+	return nil
 }
 
 func respString(value respValue) string {

--- a/backend/internal/connectors/redis/redis.go
+++ b/backend/internal/connectors/redis/redis.go
@@ -14,8 +14,11 @@ import (
 
 const (
 	Kind    = "redis"
-	Label   = "Redis"
+	Label   = "Redis / Valkey"
 	Version = "0.2"
+
+	ServerFamilyRedis  = "redis"
+	ServerFamilyValkey = "valkey"
 
 	ActionPing       = "ping"
 	ActionInfo       = "info"
@@ -66,6 +69,17 @@ func (Connector) Version() string {
 func (Connector) TargetSchema() connectors.Schema {
 	return connectors.Schema{Fields: []connectors.Field{
 		{
+			Name:        "server_family",
+			Label:       "Server product",
+			Type:        connectors.FieldSelect,
+			Default:     ServerFamilyRedis,
+			Description: "Choose Redis or Valkey. Both use the same bounded RESP connector actions.",
+			Options: []connectors.FieldOption{
+				{Value: ServerFamilyRedis, Label: "Redis"},
+				{Value: ServerFamilyValkey, Label: "Valkey"},
+			},
+		},
+		{
 			Name:        "connection_mode",
 			Label:       "Connection mode",
 			Type:        connectors.FieldSelect,
@@ -83,7 +97,7 @@ func (Connector) TargetSchema() connectors.Schema {
 			Type:        connectors.FieldString,
 			Required:    true,
 			Default:     defaultRedisHost,
-			Description: "Redis host as seen by the selected connection mode. For Over SSH this is usually 127.0.0.1 on the remote server.",
+			Description: "Redis-compatible host as seen by the selected connection mode. For Over SSH this is usually 127.0.0.1 on the remote server.",
 		},
 		{
 			Name:        "port",
@@ -91,14 +105,14 @@ func (Connector) TargetSchema() connectors.Schema {
 			Type:        connectors.FieldNumber,
 			Required:    true,
 			Default:     defaultRedisPort,
-			Description: "Redis TCP port.",
+			Description: "Redis-compatible RESP TCP port.",
 		},
 		{
 			Name:        "database",
 			Label:       "Database",
 			Type:        connectors.FieldNumber,
 			Default:     0,
-			Description: "Redis logical database number.",
+			Description: "Logical database number.",
 		},
 		{
 			Name:        "transport_target_ref",
@@ -114,20 +128,20 @@ func (Connector) CredentialSchemas() []connectors.CredentialSchema {
 		{
 			Kind:        "username_password",
 			Label:       "Username and password",
-			Description: "Redis ACL username and password stored through the encrypted vault layer. Leave both empty for local unauthenticated Redis.",
+			Description: "Redis or Valkey ACL username and password stored through the encrypted vault layer. Leave both empty for local unauthenticated access.",
 			Schema: connectors.Schema{Fields: []connectors.Field{
 				{
 					Name:        "username",
 					Label:       "Username",
 					Type:        connectors.FieldString,
-					Description: "Optional Redis ACL username.",
+					Description: "Optional Redis or Valkey ACL username.",
 				},
 				{
 					Name:        "password",
 					Label:       "Password",
 					Type:        connectors.FieldSecret,
 					Secret:      true,
-					Description: "Optional Redis password.",
+					Description: "Optional Redis or Valkey password.",
 				},
 			}},
 		},
@@ -135,13 +149,14 @@ func (Connector) CredentialSchemas() []connectors.CredentialSchema {
 }
 
 func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (connectors.ConnectorHelp, error) {
-	title := "Redis target"
+	product := serverFamilyLabel(serverFamily(target))
+	title := product + " target"
 	if strings.TrimSpace(target.Name) != "" {
-		title = "Redis target: " + target.Name
+		title = product + " target: " + target.Name
 	}
 	return connectors.ConnectorHelp{
 		Title:       title,
-		Summary:     "Browse Redis keys and run bounded key operations through AIPermission approval rules.",
+		Summary:     "Browse Redis or Valkey keys and run bounded key operations through AIPermission approval rules.",
 		Connector:   Label,
 		ConnectorID: Kind,
 		Usage: []string{
@@ -151,9 +166,10 @@ func (Connector) GetHelp(_ context.Context, target connectors.TargetView) (conne
 			"Use delete_keys carefully; it is destructive and should normally require approval.",
 		},
 		Warnings: []string{
-			"Redis values may contain secrets. Redaction is best-effort; avoid intentionally reading secrets unless the operator approved that access.",
+			"Redis and Valkey values may contain secrets. Redaction is best-effort; avoid intentionally reading secrets unless the operator approved that access.",
 			"scan_keys uses SCAN, not KEYS, and returns bounded batches.",
-			"Redis credential profiles decide what the Redis server itself allows.",
+			"Credential profiles decide what the Redis-compatible server itself allows.",
+			"Cluster-aware MOVED/ASK routing and Sentinel discovery are not supported in this connector version.",
 		},
 	}, nil
 }
@@ -163,7 +179,7 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 		{
 			Name:        ActionPing,
 			Label:       "Ping",
-			Description: "Check Redis connectivity and selected database access.",
+			Description: "Check Redis or Valkey connectivity and selected database access.",
 			Category:    "metadata",
 			Risk:        connectors.RiskRead,
 			InputSchema: connectors.Schema{},
@@ -172,7 +188,7 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 		{
 			Name:        ActionInfo,
 			Label:       "Server info",
-			Description: "Read bounded Redis INFO metadata.",
+			Description: "Read bounded Redis or Valkey INFO metadata.",
 			Category:    "metadata",
 			Risk:        connectors.RiskRead,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
@@ -183,7 +199,7 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 		{
 			Name:        ActionScanKeys,
 			Label:       "Scan keys",
-			Description: "List Redis keys with SCAN using a bounded count.",
+			Description: "List keys with SCAN using a bounded count.",
 			Category:    "browser",
 			Risk:        connectors.RiskRead,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
@@ -196,7 +212,7 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 		{
 			Name:        ActionGetKey,
 			Label:       "Read key",
-			Description: "Read a bounded Redis key preview by type.",
+			Description: "Read a bounded key preview by type.",
 			Category:    "browser",
 			Risk:        connectors.RiskRead,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
@@ -209,7 +225,7 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 		{
 			Name:        ActionSetString,
 			Label:       "Set string",
-			Description: "Set a Redis string value with optional TTL.",
+			Description: "Set a string value with optional TTL.",
 			Category:    "write",
 			Risk:        connectors.RiskWrite,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
@@ -222,7 +238,7 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 		{
 			Name:        ActionExpireKey,
 			Label:       "Set TTL",
-			Description: "Set or clear a Redis key TTL.",
+			Description: "Set or clear a key TTL.",
 			Category:    "write",
 			Risk:        connectors.RiskWrite,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
@@ -234,7 +250,7 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 		{
 			Name:        ActionDeleteKeys,
 			Label:       "Delete keys",
-			Description: "Delete one or more Redis keys.",
+			Description: "Delete one or more keys.",
 			Category:    "destructive",
 			Risk:        connectors.RiskDestructive,
 			InputSchema: connectors.Schema{Fields: []connectors.Field{
@@ -247,26 +263,27 @@ func (Connector) GetActionList(context.Context, connectors.TargetView, connector
 
 func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) (connectors.PreparedAction, error) {
 	input := copyMap(req.Input)
+	product := serverFamilyLabel(serverFamily(req.Target))
 	risk := connectors.RiskRead
 	title := ""
 	summary := ""
 	switch req.ActionName {
 	case ActionPing:
-		title = "Ping Redis"
-		summary = "Check Redis connectivity."
+		title = "Ping " + product
+		summary = "Check Redis-compatible connectivity."
 	case ActionInfo:
 		section := strings.TrimSpace(stringValue(input, "section"))
-		title = "Read Redis INFO"
+		title = "Read " + product + " INFO"
 		if section != "" {
-			title = "Read Redis INFO " + section
+			title += " " + section
 		}
-		summary = "Read bounded Redis metadata."
+		summary = "Read bounded Redis-compatible metadata."
 	case ActionScanKeys:
 		pattern := normalizeStringDefault(input, "pattern", "*")
 		limit := normalizeInt(input, "limit", defaultScanLimit, 1, maxScanLimit)
 		input["pattern"] = pattern
 		input["limit"] = limit
-		title = "Scan Redis keys"
+		title = "Scan " + product + " keys"
 		summary = fmt.Sprintf("Scan keys matching %q with limit %d.", pattern, limit)
 	case ActionGetKey:
 		key := strings.TrimSpace(stringValue(input, "key"))
@@ -276,7 +293,7 @@ func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) 
 		input["key"] = key
 		input["limit"] = normalizeInt(input, "limit", defaultValueLimit, 1, maxValueLimit)
 		input["max_bytes"] = normalizeInt(input, "max_bytes", defaultMaxValueBytes, 1, maxValueBytes)
-		title = "Read Redis key"
+		title = "Read " + product + " key"
 		summary = key
 	case ActionSetString:
 		risk = connectors.RiskWrite
@@ -289,7 +306,7 @@ func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) 
 		}
 		input["key"] = key
 		input["ttl_seconds"] = normalizeInt(input, "ttl_seconds", 0, 0, 31_536_000)
-		title = "Set Redis string"
+		title = "Set " + product + " string"
 		summary = key
 	case ActionExpireKey:
 		risk = connectors.RiskWrite
@@ -303,7 +320,7 @@ func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) 
 		}
 		input["key"] = key
 		input["ttl_seconds"] = ttl
-		title = "Set Redis TTL"
+		title = "Set " + product + " TTL"
 		summary = key
 	case ActionDeleteKeys:
 		risk = connectors.RiskDestructive
@@ -312,8 +329,8 @@ func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) 
 			return connectors.PreparedAction{}, err
 		}
 		input["keys"] = keys
-		title = "Delete Redis keys"
-		summary = fmt.Sprintf("Delete %d Redis key(s).", len(keys))
+		title = "Delete " + product + " keys"
+		summary = fmt.Sprintf("Delete %d %s key(s).", len(keys), product)
 	default:
 		return connectors.PreparedAction{}, ErrUnsupportedAction
 	}
@@ -333,6 +350,7 @@ func (Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) 
 		ContextMaterial: map[string]any{
 			"target":          req.Target.Name,
 			"profile":         req.Profile.Label,
+			"server_family":   serverFamily(req.Target),
 			"connection_mode": connectionMode(req.Target),
 			"database":        redisDatabase(req.Target),
 		},
@@ -375,13 +393,35 @@ func (connector Connector) TestConnection(ctx context.Context, runtime connector
 	if err != nil {
 		return connectors.TestResult{Status: classifyRedisTestError(err), Message: err.Error()}, nil
 	}
+	configuredFamily := serverFamily(runtime.Target)
+	details := map[string]any{
+		"response":                 respString(value),
+		"database":                 redisDatabase(runtime.Target),
+		"configured_server_family": configuredFamily,
+	}
+	detectedFamily := configuredFamily
+	message := serverFamilyLabel(configuredFamily) + " connection ok."
+	if identity, detectErr := detectRedisServer(client); detectErr == nil {
+		detectedFamily = identity.Family
+		for key, item := range identity.details() {
+			details[key] = item
+		}
+		details["server_family_match"] = detectedFamily == configuredFamily
+		message = serverFamilyLabel(detectedFamily) + " connection ok."
+		if detectedFamily != configuredFamily {
+			message = fmt.Sprintf(
+				"%s connection ok; target is configured as %s.",
+				serverFamilyLabel(detectedFamily),
+				serverFamilyLabel(configuredFamily),
+			)
+		}
+	} else {
+		details["server_detection"] = "unavailable"
+	}
 	return connectors.TestResult{
 		Status:  connectors.TestOK,
-		Message: "Redis connection ok.",
-		Details: map[string]any{
-			"response": respString(value),
-			"database": redisDatabase(runtime.Target),
-		},
+		Message: message,
+		Details: details,
 	}, nil
 }
 
@@ -458,10 +498,14 @@ func executeInfo(client *redisClient, input map[string]any) (connectors.ActionRe
 		return connectors.ActionResult{}, err
 	}
 	info := truncateString(respString(value), maxValueBytes)
-	parsed := parseRedisInfo(info)
+	document := parseRedisInfoDocument(info)
+	output := map[string]any{"section": section, "info": document.sections, "raw": info}
+	if identity, ok := redisServerIdentityFromFields(document.fields); ok {
+		output["server"] = identity.details()
+	}
 	return connectors.ActionResult{
 		Status:      connectors.ResultCompleted,
-		Output:      map[string]any{"section": section, "info": parsed, "raw": info},
+		Output:      output,
 		DisplayText: info,
 	}, nil
 }
@@ -579,7 +623,7 @@ func executeSetString(client *redisClient, input map[string]any) (connectors.Act
 	return connectors.ActionResult{
 		Status:      connectors.ResultCompleted,
 		Output:      map[string]any{"key": key, "response": respString(response)},
-		DisplayText: fmt.Sprintf("Set Redis key %q.", key),
+		DisplayText: fmt.Sprintf("Set key %q.", key),
 	}, nil
 }
 
@@ -602,7 +646,7 @@ func executeExpireKey(client *redisClient, input map[string]any) (connectors.Act
 	return connectors.ActionResult{
 		Status:      connectors.ResultCompleted,
 		Output:      map[string]any{"key": key, "changed": value.number == 1, "ttl_seconds": ttl},
-		DisplayText: fmt.Sprintf("Updated TTL for Redis key %q.", key),
+		DisplayText: fmt.Sprintf("Updated TTL for key %q.", key),
 	}, nil
 }
 
@@ -622,8 +666,107 @@ func executeDeleteKeys(client *redisClient, input map[string]any) (connectors.Ac
 			"keys":    keys,
 			"deleted": value.number,
 		},
-		DisplayText: fmt.Sprintf("Deleted %d Redis key(s).", value.number),
+		DisplayText: fmt.Sprintf("Deleted %d key(s).", value.number),
 	}, nil
+}
+
+type redisServerIdentity struct {
+	Family               string
+	ServerName           string
+	Version              string
+	CompatibilityVersion string
+}
+
+func detectRedisServer(client *redisClient) (redisServerIdentity, error) {
+	value, err := client.Do("INFO", "server")
+	if err != nil {
+		return redisServerIdentity{}, err
+	}
+	identity, ok := redisServerIdentityFromInfo(respString(value))
+	if !ok {
+		return redisServerIdentity{}, fmt.Errorf("server identity is unavailable")
+	}
+	return identity, nil
+}
+
+func redisServerIdentityFromInfo(raw string) (redisServerIdentity, bool) {
+	return redisServerIdentityFromFields(parseRedisInfoDocument(raw).fields)
+}
+
+func redisServerIdentityFromFields(fields map[string]string) (redisServerIdentity, bool) {
+	serverName := strings.ToLower(strings.TrimSpace(fields["server_name"]))
+	valkeyVersion := strings.TrimSpace(fields["valkey_version"])
+	redisVersion := strings.TrimSpace(fields["redis_version"])
+	if serverName == ServerFamilyValkey || valkeyVersion != "" {
+		return redisServerIdentity{
+			Family:               ServerFamilyValkey,
+			ServerName:           firstNonEmpty(serverName, ServerFamilyValkey),
+			Version:              valkeyVersion,
+			CompatibilityVersion: redisVersion,
+		}, true
+	}
+	if serverName != "" || redisVersion != "" {
+		return redisServerIdentity{
+			Family:     ServerFamilyRedis,
+			ServerName: firstNonEmpty(serverName, ServerFamilyRedis),
+			Version:    redisVersion,
+		}, true
+	}
+	return redisServerIdentity{}, false
+}
+
+func (identity redisServerIdentity) details() map[string]any {
+	details := map[string]any{
+		"detected_server_family": identity.Family,
+		"server_name":            identity.ServerName,
+	}
+	if identity.Version != "" {
+		details["server_version"] = identity.Version
+	}
+	if identity.CompatibilityVersion != "" {
+		details["compatibility_version"] = identity.CompatibilityVersion
+	}
+	return details
+}
+
+type redisInfoDocument struct {
+	sections map[string]any
+	fields   map[string]string
+}
+
+func parseRedisInfoDocument(raw string) redisInfoDocument {
+	document := redisInfoDocument{
+		sections: map[string]any{},
+		fields:   map[string]string{},
+	}
+	current := "default"
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "# ") {
+			current = strings.TrimSpace(strings.TrimPrefix(line, "# "))
+			if _, ok := document.sections[current]; !ok {
+				document.sections[current] = map[string]string{}
+			}
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		document.fields[strings.ToLower(key)] = value
+		bucket, _ := document.sections[current].(map[string]string)
+		if bucket == nil {
+			bucket = map[string]string{}
+			document.sections[current] = bucket
+		}
+		bucket[key] = value
+	}
+	return document
 }
 
 func redisKeyType(client *redisClient, key string) (string, error) {
@@ -652,35 +795,6 @@ func redisScanCollection(client *redisClient, command string, key string, limit 
 		}
 	}
 	return items, nil
-}
-
-func parseRedisInfo(raw string) map[string]any {
-	sections := map[string]any{}
-	current := "default"
-	for _, line := range strings.Split(raw, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		if strings.HasPrefix(line, "# ") {
-			current = strings.TrimSpace(strings.TrimPrefix(line, "# "))
-			if _, ok := sections[current]; !ok {
-				sections[current] = map[string]string{}
-			}
-			continue
-		}
-		parts := strings.SplitN(line, ":", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		bucket, _ := sections[current].(map[string]string)
-		if bucket == nil {
-			bucket = map[string]string{}
-			sections[current] = bucket
-		}
-		bucket[parts[0]] = parts[1]
-	}
-	return sections
 }
 
 func redisKeyDisplay(output map[string]any) string {
@@ -720,6 +834,20 @@ func connectionMode(target connectors.TargetView) string {
 		return "direct"
 	}
 	return mode
+}
+
+func serverFamily(target connectors.TargetView) string {
+	if strings.EqualFold(strings.TrimSpace(stringValue(target.Config, "server_family")), ServerFamilyValkey) {
+		return ServerFamilyValkey
+	}
+	return ServerFamilyRedis
+}
+
+func serverFamilyLabel(family string) string {
+	if family == ServerFamilyValkey {
+		return "Valkey"
+	}
+	return "Redis"
 }
 
 func redisHost(target connectors.TargetView) string {
@@ -882,6 +1010,15 @@ func min(left int, right int) int {
 		return left
 	}
 	return right
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 var _ connectors.Connector = Connector{}

--- a/backend/internal/connectors/redis/redis_test.go
+++ b/backend/internal/connectors/redis/redis_test.go
@@ -30,6 +30,66 @@ func TestTargetSchemaExposesRedisAndValkeyProducts(t *testing.T) {
 	}
 }
 
+func TestRESPReaderRejectsOversizedOrMalformedFrames(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		want     string
+	}{
+		{
+			name:     "bulk string",
+			response: fmt.Sprintf("$%d\r\n", maxRESPBulkBytes+1),
+			want:     "bulk string exceeds",
+		},
+		{
+			name:     "array",
+			response: fmt.Sprintf("*%d\r\n", maxRESPArrayItems+1),
+			want:     "array exceeds",
+		},
+		{
+			name:     "negative bulk string",
+			response: "$-2\r\n",
+			want:     "invalid redis bulk string size",
+		},
+		{
+			name:     "negative array",
+			response: "*-2\r\n",
+			want:     "invalid redis array size",
+		},
+		{
+			name:     "line",
+			response: "+" + strings.Repeat("x", maxRESPLineBytes) + "\r\n",
+			want:     "response line exceeds",
+		},
+		{
+			name:     "nesting",
+			response: strings.Repeat("*1\r\n", maxRESPNestingDepth+2) + "+OK\r\n",
+			want:     "response nesting exceeds",
+		},
+		{
+			name: "total bytes",
+			response: "*9\r\n" + strings.Repeat(
+				fmt.Sprintf("$%d\r\n%s\r\n", maxRESPBulkBytes, strings.Repeat("x", maxRESPBulkBytes)),
+				9,
+			),
+			want: "response exceeds",
+		},
+		{
+			name:     "total values",
+			response: fmt.Sprintf("*%d\r\n", maxRESPArrayItems) + strings.Repeat("*1\r\n+OK\r\n", maxRESPArrayItems),
+			want:     "response exceeds",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := readRESPValue(bufio.NewReader(strings.NewReader(test.response)))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestGetHelpUsesConfiguredServerProduct(t *testing.T) {
 	help, err := Connector{}.GetHelp(context.Background(), connectors.TargetView{
 		Name:   "cache",

--- a/backend/internal/connectors/redis/redis_test.go
+++ b/backend/internal/connectors/redis/redis_test.go
@@ -6,13 +6,71 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/aipermission/aipermission/backend/internal/connectors"
 )
 
+func TestTargetSchemaExposesRedisAndValkeyProducts(t *testing.T) {
+	schema := Connector{}.TargetSchema()
+	if len(schema.Fields) == 0 || schema.Fields[0].Name != "server_family" {
+		t.Fatalf("server family field missing: %#v", schema.Fields)
+	}
+	field := schema.Fields[0]
+	if field.Default != ServerFamilyRedis {
+		t.Fatalf("default server family = %#v", field.Default)
+	}
+	if !reflect.DeepEqual(field.Options, []connectors.FieldOption{
+		{Value: ServerFamilyRedis, Label: "Redis"},
+		{Value: ServerFamilyValkey, Label: "Valkey"},
+	}) {
+		t.Fatalf("server family options = %#v", field.Options)
+	}
+}
+
+func TestGetHelpUsesConfiguredServerProduct(t *testing.T) {
+	help, err := Connector{}.GetHelp(context.Background(), connectors.TargetView{
+		Name:   "cache",
+		Config: map[string]any{"server_family": ServerFamilyValkey},
+	})
+	if err != nil {
+		t.Fatalf("get help: %v", err)
+	}
+	if help.Title != "Valkey target: cache" || help.Connector != Label {
+		t.Fatalf("help = %#v", help)
+	}
+}
+
+func TestExistingTargetWithoutServerFamilyDefaultsToRedis(t *testing.T) {
+	target := connectors.TargetView{Name: "existing-cache", Config: map[string]any{"connection_mode": "direct"}}
+	if family := serverFamily(target); family != ServerFamilyRedis {
+		t.Fatalf("server family = %q", family)
+	}
+	help, err := Connector{}.GetHelp(context.Background(), target)
+	if err != nil {
+		t.Fatalf("get help: %v", err)
+	}
+	if help.Title != "Redis target: existing-cache" {
+		t.Fatalf("help title = %q", help.Title)
+	}
+	prepared, err := Connector{}.PrepareAction(context.Background(), connectors.ActionRequest{
+		Target:     target,
+		Profile:    connectors.CredentialProfileView{Label: "default"},
+		ActionName: ActionPing,
+		Input:      map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("prepare action: %v", err)
+	}
+	if prepared.Title != "Ping Redis" || prepared.ContextMaterial["server_family"] != ServerFamilyRedis {
+		t.Fatalf("prepared = %#v", prepared)
+	}
+}
+
 func TestPrepareActionNormalizesRedisScan(t *testing.T) {
-	target := connectors.TargetView{ID: 1, Ref: "redis:1:2", ConnectorKind: Kind, Name: "cache", Config: map[string]any{"connection_mode": "direct"}}
+	target := connectors.TargetView{ID: 1, Ref: "redis:1:2", ConnectorKind: Kind, Name: "cache", Config: map[string]any{"server_family": ServerFamilyValkey, "connection_mode": "direct"}}
 	profile := connectors.CredentialProfileView{ID: 2, TargetID: 1, ConnectorKind: Kind, Kind: "username_password", Label: "default"}
 
 	prepared, err := Connector{}.PrepareAction(context.Background(), connectors.ActionRequest{
@@ -29,6 +87,12 @@ func TestPrepareActionNormalizesRedisScan(t *testing.T) {
 	}
 	if prepared.Risk != connectors.RiskRead {
 		t.Fatalf("risk = %q", prepared.Risk)
+	}
+	if prepared.Title != "Scan Valkey keys" {
+		t.Fatalf("title = %q", prepared.Title)
+	}
+	if prepared.ContextMaterial["server_family"] != ServerFamilyValkey {
+		t.Fatalf("context material = %#v", prepared.ContextMaterial)
 	}
 }
 
@@ -73,6 +137,281 @@ func TestExecuteActionScansBoundedKeys(t *testing.T) {
 	}
 }
 
+func TestConnectionDetectsValkeyServerIdentity(t *testing.T) {
+	runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+		switch command[0] {
+		case "PING":
+			return "+PONG\r\n"
+		case "INFO":
+			if !reflect.DeepEqual(command, []string{"INFO", "server"}) {
+				t.Fatalf("command = %#v", command)
+			}
+			return respBulk("# Server\r\nserver_name:valkey\r\nvalkey_version:8.1.3\r\nredis_version:7.2.4\r\n")
+		default:
+			t.Fatalf("unexpected command = %#v", command)
+			return ""
+		}
+	})
+	runtime.Target.Config["server_family"] = ServerFamilyValkey
+
+	result, err := Connector{}.TestConnection(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if result.Status != connectors.TestOK || result.Message != "Valkey connection ok." {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.Details["detected_server_family"] != ServerFamilyValkey ||
+		result.Details["server_version"] != "8.1.3" ||
+		result.Details["compatibility_version"] != "7.2.4" {
+		t.Fatalf("details = %#v", result.Details)
+	}
+}
+
+func TestConnectionDetectsRedisServerIdentity(t *testing.T) {
+	runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+		switch command[0] {
+		case "PING":
+			return "+PONG\r\n"
+		case "INFO":
+			return respBulk("# Server\r\nredis_version:7.2.5\r\n")
+		default:
+			t.Fatalf("unexpected command = %#v", command)
+			return ""
+		}
+	})
+
+	result, err := Connector{}.TestConnection(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if result.Status != connectors.TestOK || result.Message != "Redis connection ok." {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.Details["detected_server_family"] != ServerFamilyRedis || result.Details["server_version"] != "7.2.5" {
+		t.Fatalf("details = %#v", result.Details)
+	}
+	if result.Details["server_family_match"] != true {
+		t.Fatalf("details = %#v", result.Details)
+	}
+}
+
+func TestConnectionReportsConfiguredServerProductMismatch(t *testing.T) {
+	runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+		switch command[0] {
+		case "PING":
+			return "+PONG\r\n"
+		case "INFO":
+			return respBulk("# Server\r\nredis_version:7.2.5\r\n")
+		default:
+			t.Fatalf("unexpected command = %#v", command)
+			return ""
+		}
+	})
+	runtime.Target.Config["server_family"] = ServerFamilyValkey
+
+	result, err := Connector{}.TestConnection(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if result.Status != connectors.TestOK || result.Message != "Redis connection ok; target is configured as Valkey." {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.Details["server_family_match"] != false ||
+		result.Details["configured_server_family"] != ServerFamilyValkey ||
+		result.Details["detected_server_family"] != ServerFamilyRedis {
+		t.Fatalf("details = %#v", result.Details)
+	}
+}
+
+func TestConnectionAllowsRestrictedProfileWithoutInfoPermission(t *testing.T) {
+	runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+		switch command[0] {
+		case "PING":
+			return "+PONG\r\n"
+		case "INFO":
+			return "-NOPERM this user has no permissions to run the 'info' command\r\n"
+		default:
+			t.Fatalf("unexpected command = %#v", command)
+			return ""
+		}
+	})
+	runtime.Target.Config["server_family"] = ServerFamilyValkey
+
+	result, err := Connector{}.TestConnection(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if result.Status != connectors.TestOK || result.Message != "Valkey connection ok." {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.Details["server_detection"] != "unavailable" {
+		t.Fatalf("details = %#v", result.Details)
+	}
+}
+
+func TestValkeyConnectionUsesACLAndSelectedDatabase(t *testing.T) {
+	commands := [][]string{}
+	var commandsMu sync.Mutex
+	runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+		commandsMu.Lock()
+		commands = append(commands, append([]string(nil), command...))
+		commandsMu.Unlock()
+		switch command[0] {
+		case "AUTH", "SELECT":
+			return "+OK\r\n"
+		case "PING":
+			return "+PONG\r\n"
+		case "INFO":
+			return respBulk("# Server\r\nserver_name:valkey\r\nvalkey_version:8.1.3\r\nredis_version:7.2.4\r\n")
+		default:
+			t.Fatalf("unexpected command = %#v", command)
+			return ""
+		}
+	})
+	runtime.Target.Config["server_family"] = ServerFamilyValkey
+	runtime.Target.Config["database"] = 2
+	runtime.Profile.Public = map[string]any{"username": "app"}
+	runtime.Secrets = testSecrets{"password": "secret"}
+
+	result, err := Connector{}.TestConnection(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if result.Status != connectors.TestOK {
+		t.Fatalf("result = %#v", result)
+	}
+	want := [][]string{
+		{"AUTH", "app", "secret"},
+		{"SELECT", "2"},
+		{"PING"},
+		{"INFO", "server"},
+	}
+	commandsMu.Lock()
+	defer commandsMu.Unlock()
+	if !reflect.DeepEqual(commands, want) {
+		t.Fatalf("commands = %#v, want %#v", commands, want)
+	}
+}
+
+func TestInfoActionReturnsValkeyIdentity(t *testing.T) {
+	runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+		if !reflect.DeepEqual(command, []string{"INFO", "server"}) {
+			t.Fatalf("command = %#v", command)
+		}
+		return respBulk("# Server\r\nserver_name:valkey\r\nvalkey_version:8.1.3\r\nredis_version:7.2.4\r\n")
+	})
+	result, err := Connector{}.ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+		ActionName: ActionInfo,
+		Payload:    map[string]any{"section": "server"},
+	})
+	if err != nil {
+		t.Fatalf("execute info: %v", err)
+	}
+	output := result.Output.(map[string]any)
+	server := output["server"].(map[string]any)
+	if server["detected_server_family"] != ServerFamilyValkey || server["server_version"] != "8.1.3" {
+		t.Fatalf("server = %#v", server)
+	}
+	info := output["info"].(map[string]any)
+	serverSection := info["Server"].(map[string]string)
+	if serverSection["server_name"] != "valkey" || serverSection["valkey_version"] != "8.1.3" {
+		t.Fatalf("info = %#v", info)
+	}
+	if !strings.Contains(result.DisplayText, "server_name:valkey") {
+		t.Fatalf("display text = %q", result.DisplayText)
+	}
+}
+
+func TestValkeyCompatibleKeyActions(t *testing.T) {
+	t.Run("read string", func(t *testing.T) {
+		runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+			switch command[0] {
+			case "TYPE":
+				return "+string\r\n"
+			case "PTTL":
+				return ":60000\r\n"
+			case "GET":
+				return respBulk(`{"ok":true}`)
+			default:
+				t.Fatalf("unexpected command = %#v", command)
+				return ""
+			}
+		})
+		result, err := Connector{}.ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+			ActionName: ActionGetKey,
+			Payload:    map[string]any{"key": "app:status", "limit": 10, "max_bytes": 1024},
+		})
+		if err != nil {
+			t.Fatalf("get key: %v", err)
+		}
+		output := result.Output.(map[string]any)
+		if output["type"] != "string" || output["value"] != `{"ok":true}` || output["ttl_ms"] != int64(60000) {
+			t.Fatalf("output = %#v", output)
+		}
+	})
+
+	t.Run("set string", func(t *testing.T) {
+		runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+			want := []string{"SET", "app:status", "ready", "EX", "60"}
+			if !reflect.DeepEqual(command, want) {
+				t.Fatalf("command = %#v, want %#v", command, want)
+			}
+			return "+OK\r\n"
+		})
+		result, err := Connector{}.ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+			ActionName: ActionSetString,
+			Payload:    map[string]any{"key": "app:status", "value": "ready", "ttl_seconds": 60},
+		})
+		if err != nil {
+			t.Fatalf("set string: %v", err)
+		}
+		if result.Status != connectors.ResultCompleted {
+			t.Fatalf("result = %#v", result)
+		}
+	})
+
+	t.Run("update ttl", func(t *testing.T) {
+		runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+			want := []string{"EXPIRE", "app:status", "60"}
+			if !reflect.DeepEqual(command, want) {
+				t.Fatalf("command = %#v, want %#v", command, want)
+			}
+			return ":1\r\n"
+		})
+		result, err := Connector{}.ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+			ActionName: ActionExpireKey,
+			Payload:    map[string]any{"key": "app:status", "ttl_seconds": 60},
+		})
+		if err != nil {
+			t.Fatalf("expire key: %v", err)
+		}
+		if result.Output.(map[string]any)["changed"] != true {
+			t.Fatalf("result = %#v", result)
+		}
+	})
+
+	t.Run("delete keys", func(t *testing.T) {
+		runtime := testRuntimeWithScript(t, func(t *testing.T, command []string) string {
+			want := []string{"DEL", "app:one", "app:two"}
+			if !reflect.DeepEqual(command, want) {
+				t.Fatalf("command = %#v, want %#v", command, want)
+			}
+			return ":2\r\n"
+		})
+		result, err := Connector{}.ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+			ActionName: ActionDeleteKeys,
+			Payload:    map[string]any{"keys": []any{"app:one", "app:two"}},
+		})
+		if err != nil {
+			t.Fatalf("delete keys: %v", err)
+		}
+		if result.Output.(map[string]any)["deleted"] != int64(2) {
+			t.Fatalf("result = %#v", result)
+		}
+	})
+}
+
 func testRuntimeWithScript(t *testing.T, handler func(*testing.T, []string) string) connectors.RuntimeContext {
 	t.Helper()
 	return connectors.RuntimeContext{
@@ -89,9 +428,12 @@ func testRuntimeWithScript(t *testing.T, handler func(*testing.T, []string) stri
 	}
 }
 
-type testSecrets struct{}
+type testSecrets map[string]string
 
-func (testSecrets) GetSecret(context.Context, string) (string, error) {
+func (secrets testSecrets) GetSecret(_ context.Context, name string) (string, error) {
+	if value, ok := secrets[name]; ok {
+		return value, nil
+	}
 	return "", fmt.Errorf("missing")
 }
 
@@ -133,4 +475,8 @@ func (transport scriptedTransport) DialConnectorTCP(context.Context, connectors.
 		}
 	}()
 	return client, nil
+}
+
+func respBulk(value string) string {
+	return fmt.Sprintf("$%d\r\n%s\r\n", len(value), value)
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 AIPermission has published its first public release candidate and is moving
 into the connector-native 0.2 line. The local-only permission gateway is usable
-today with built-in SSH, Postgres, ClickHouse, Redis, RabbitMQ, S3, Docker, and
+today with built-in SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, and
 Kubernetes connectors; the next releases focus on
 dogfooding polish, small safety improvements, clearer contributor paths, and
 additional connector kinds such as API, queues, and storage that share one
@@ -54,7 +54,7 @@ AIPermission is intentionally:
 - Local-only.
 - Single-user.
 - Developer-focused.
-- Connector-based, with built-in SSH, Postgres, ClickHouse, Redis, RabbitMQ,
+- Connector-based, with built-in SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ,
   S3, Docker, and Kubernetes.
 - Human-in-the-loop.
 

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -2,7 +2,7 @@
 
 The MCP surface is connector-first. AIPermission does not expose separate
 product-specific MCP wrappers for SSH, database, cache, queue, or container
-products. SSH, Postgres, ClickHouse, Redis, RabbitMQ, S3, Docker, Kubernetes,
+products. SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, Kubernetes,
 and future integrations are reached through the same connector target/action
 pipeline.
 
@@ -67,7 +67,7 @@ runs locally through the gateway; AIPermission does not host a remote connector
 service.
 
 Clients should discover targets and actions at runtime. Do not hardcode SSH,
-Postgres, ClickHouse, Redis, RabbitMQ, S3, Docker, or Kubernetes as special MCP
+Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, or Kubernetes as special MCP
 modes; future connector kinds use the same tools and `target_ref` shape.
 
 Project Vault tools are a separate project-capability surface because they
@@ -215,8 +215,13 @@ run with ClickHouse `readonly=1`, and are capped by timeout, row count, cell
 size, and output bytes. Use a dedicated least-privilege ClickHouse user; these
 checks are defense in depth and do not replace database grants.
 
-Redis actions include bounded key scanning, key inspection, string writes, TTL
-updates, and explicit key deletes.
+Redis / Valkey actions include bounded key scanning, key inspection, string
+writes, TTL updates, and explicit key deletes. Redis and Valkey targets share
+the `redis` connector kind and target-ref prefix so clients must discover the
+configured and detected product from connector metadata rather than hardcode a
+second MCP mode. The current implementation uses RESP2 against one configured
+endpoint and does not implement Cluster `MOVED`/`ASK` routing, Sentinel
+discovery, or RESP3.
 
 RabbitMQ actions include overview metadata, visible vhost listing, bounded
 queue listing, queue detail reads, binding listing, and bounded message peeking

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -253,7 +253,7 @@ the service port, not ICMP ping:
 ```
 
 When `mode=over_ssh`, the TCP checks are dialed through the referenced SSH
-connector profile so the result matches what Redis, Postgres, RabbitMQ, or a
+connector profile so the result matches what Redis / Valkey, Postgres, RabbitMQ, or a
 future TCP-backed connector would see from that SSH target.
 
 `POST /api/connector-targets/{id}/operations/docker-check` runs a read-only,

--- a/docs/development/add-a-connector.md
+++ b/docs/development/add-a-connector.md
@@ -355,23 +355,24 @@ that can produce/restore backup artifacts implements `BackupRestorer`. Core owns
 HTTP upload/download, confirmation, vault persistence, and audit; the connector
 owns only the external service-specific work.
 
-## Built-In Example: Redis
+## Built-In Example: Redis / Valkey
 
-The built-in Redis connector adds only Redis-specific behavior:
+The built-in Redis / Valkey connector adds only protocol/product-specific behavior:
 
-- target fields such as connection mode, host, port, database index, and
-  optional SSH transport target ref
+- target fields such as server product, connection mode, host, port, database
+  index, and optional SSH transport target ref
 - credential profile fields such as username/password or token
 - actions such as `ping`, `info`, `scan_keys`, `get_key`, `set_string`,
   `expire_key`, and `delete_keys`
-- connector help that explains safe key inspection
-- UI templates for Redis target rows, credential profiles, and key-browser
+- connector help that explains safe key inspection and the standalone RESP2
+  boundary
+- UI templates for Redis / Valkey target rows, credential profiles, and key-browser
   console output
 
-It should not add a Redis-specific token permission table, approval table,
+It should not add a Redis/Valkey-specific token permission table, approval table,
 history page, audit route, MCP tool family, or global UI page.
 
-Redis checklist:
+Redis / Valkey checklist:
 
 - `backend/internal/connectors/redis/redis.go`
 - `backend/internal/connectors/redis/client.go`
@@ -388,6 +389,13 @@ Redis checklist:
 - `frontend/src/connectors/templates/redis/console.jsx`
 - frontend smoke/runtime tests that assert the shipped connector folders
 - README, REST/MCP docs, and connector-specific safety notes
+
+Valkey compatibility remains inside this connector because both products use
+the same bounded action catalog and RESP2 transport. The user-selected
+`server_family` affects product labels and approval context, while the technical
+connector kind and target refs remain `redis`. Do not add a duplicate `valkey`
+connector folder, backend registry entry, generic route branch, permission
+table, or MCP wrapper merely to change the product identity.
 
 ## Built-In Example: RabbitMQ
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -30,10 +30,10 @@ target + credential profile + action
   -> history + audit
 ```
 
-SSH, Postgres, ClickHouse, Redis, RabbitMQ, S3, Docker, and Kubernetes are
+SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, and Kubernetes are
 built-in connectors that share the same target/profile, permission, approval,
 history, and audit model. SSH owns a live terminal and file-transfer surface;
-Postgres and ClickHouse own structured database actions; Redis owns bounded
+Postgres and ClickHouse own structured database actions; Redis / Valkey owns bounded
 key-browser actions; RabbitMQ owns queue browsing and bounded message previews.
 Future connectors should add their own execution surface without adding a new
 permission or audit pipeline.
@@ -50,7 +50,7 @@ Connector work has two classes:
 
 | Capability | Normal structured connector | Runtime-integrated connector |
 |---|---|---|
-| Examples | Postgres, Redis, API recipes | SSH live terminal and SFTP |
+| Examples | Postgres, Redis / Valkey, API recipes | SSH live terminal and SFTP |
 | Backend connector package | yes | yes |
 | Frontend template folder | yes | yes |
 | Shared target/profile/action permissions | yes | yes |

--- a/docs/mvp/scope.md
+++ b/docs/mvp/scope.md
@@ -11,7 +11,7 @@ Main target:
 The MVP is not a DevOps platform. It does not own production operations. It gives a developer a controlled, token-scoped, auditable execution channel for debugging, maintenance, incident triage, and temporary AI-assisted automation.
 
 The MVP does not introduce first-class management modules for every external
-system. It introduces one connector pipeline. SSH, Postgres, ClickHouse, Redis,
+system. It introduces one connector pipeline. SSH, Postgres, ClickHouse, Redis / Valkey,
 RabbitMQ, S3, Docker, Kubernetes, and future integrations are connector kinds that provide
 their own actions while sharing the same target/profile/action permission model.
 If an allowed SSH target has the needed CLI tools and access, the AI can operate
@@ -40,7 +40,7 @@ The gateway itself is local-only. It is not designed to run on a remote server f
   read-only query actions
 - built-in ClickHouse connector with native-protocol metadata inspection and
   bounded read-only analytics SQL
-- built-in Redis, RabbitMQ, S3, Docker, and Kubernetes connectors for scoped
+- built-in Redis / Valkey, RabbitMQ, S3, Docker, and Kubernetes connectors for scoped
   cache, queue, object storage, container runtime, and cluster visibility
   through the shared connector pipeline
 - API token creation and revocation

--- a/docs/project-principles.md
+++ b/docs/project-principles.md
@@ -8,7 +8,7 @@ part of the security model, not marketing copy.
 - Local-only
 - Single-user
 - Developer-focused
-- Connector-based, with built-in SSH, Postgres, ClickHouse, Redis, RabbitMQ,
+- Connector-based, with built-in SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ,
   S3, Docker, and Kubernetes
 - Human-in-the-loop
 

--- a/docs/skills/aipermission-docs/SKILL.md
+++ b/docs/skills/aipermission-docs/SKILL.md
@@ -138,7 +138,7 @@ Use the established aipermission naming:
 - `gateway` is the local backend that owns credentials, policy, execution, approvals, and audit.
 - `MCP client` means Cursor, Windsurf, or another AI tool integration.
 - `API token` means the gateway access token used by MCP/API clients.
-- `connector target` means a saved SSH, Postgres, ClickHouse, Redis, RabbitMQ, S3, Docker, Kubernetes, or future integration target.
+- `connector target` means a saved SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, Kubernetes, or future integration target.
 - `server` is acceptable only when specifically describing an SSH connector target.
 - `database` means a configured Postgres or ClickHouse connector target/profile.
 - `execution rule` means `always_run`, `approval_required`, or `blocked`.

--- a/docs/whatis-aipermission.md
+++ b/docs/whatis-aipermission.md
@@ -14,10 +14,10 @@ Related central notes:
 operate on connector targets without receiving SSH private keys, SSH passwords,
 database credentials, API credentials, or other connector secrets.
 
-The current model ships with SSH, Postgres, ClickHouse, Redis, RabbitMQ, S3,
+The current model ships with SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3,
 Docker, and Kubernetes connectors. SSH provides live terminal/file-transfer
 actions, Postgres and ClickHouse provide structured metadata and bounded
-read-only query actions, Redis provides bounded
+read-only query actions, Redis / Valkey provides bounded
 key browsing plus explicit write/delete actions, RabbitMQ provides queue
 metadata, bindings, bounded message previews, and explicit message publishing,
 S3 provides S3-compatible bucket browsing, object metadata, bounded
@@ -99,7 +99,7 @@ for a database.
 This model also works well with AI client instructions or skills. For example,
 a developer can define a workflow like "check a new VPS before adding it to the
 cluster", "inspect container health across allowed SSH targets", "describe a
-readonly Postgres schema", "inspect Redis cache keys", or later "call this
+readonly Postgres schema", "inspect Redis or Valkey cache keys", or later "call this
 internal API operation through a stored credential profile." aipermission
 provides the execution layer without exposing credentials.
 
@@ -154,7 +154,7 @@ aipermission gateway
         | auth + permission check + approval flow
         v
 Connector target
-SSH server / Postgres database / ClickHouse analytics database / Redis cache / RabbitMQ broker / Docker host / future local integration
+SSH server / Postgres database / ClickHouse analytics database / Redis or Valkey cache / RabbitMQ broker / Docker host / future local integration
 ```
 
 The AI assistant does not receive SSH credentials or database passwords.
@@ -250,7 +250,7 @@ allowed connector targets:
 The AI assistant can see and use only connector targets in the token's enabled
 projects and actions allowed by that token. Project scope is checked before the
 target/profile/action grant. For example, if the token can access five SSH targets, one
-Postgres target, one Redis target, and one Docker profile scoped to a single
+Postgres target, one Redis/Valkey target, and one Docker profile scoped to a single
 container, `list_connector_targets` returns only those target/profile refs.
 
 If the same token exists in more than one unlocked database, MCP authentication returns a conflict. The gateway does not guess which workspace should receive the command.
@@ -271,7 +271,7 @@ get_vault_action_request(request_id)
 cancel_vault_action_request(request_id)
 ```
 
-SSH, Postgres, ClickHouse, Redis, RabbitMQ, S3, Docker, Kubernetes, and future integrations are exposed as
+SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, Kubernetes, and future integrations are exposed as
 connector actions instead of separate product-specific MCP tools.
 
 Project Vault is project-capability-scoped rather than connector-action-scoped.

--- a/frontend/src/connectors/templates/redis/console.jsx
+++ b/frontend/src/connectors/templates/redis/console.jsx
@@ -8,12 +8,15 @@ import { Checkbox, Input, Textarea } from "../../../components/ui/form";
 import { Notice } from "../../../components/ui/notice";
 import { TerminalBlock } from "../../../components/ui/terminal-block";
 import { apiPost } from "../../../lib/api";
+import { serverProductLabel, validateStringWrite } from "./model";
 
 const defaultPattern = "*";
 const defaultLimit = 100;
+const emptyConfirmDialog = Object.freeze({ open: false, type: "", title: "", description: "", details: [], tone: "warn", pending: false, error: "", onConfirm: null });
 
 export function RedisConnectorConsoleTemplate({ target, approvals, theme, session, onNewStructuredSession, onRefreshActivity }) {
   const activeSession = session || { active: false, startedAt: "" };
+  const product = serverProductLabel(target);
   const [pattern, setPattern] = useState(defaultPattern);
   const [cursor, setCursor] = useState("0");
   const [keys, setKeys] = useState([]);
@@ -26,7 +29,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
   const [ttlDraft, setTTLDraft] = useState("");
   const [state, setState] = useState({ state: "idle", error: "", message: "" });
   const [resultMode, setResultMode] = useState("value");
-  const [confirmDialog, setConfirmDialog] = useState({ open: false, type: "", title: "", description: "", details: [], tone: "warn", pending: false, onConfirm: null });
+  const [confirmDialog, setConfirmDialog] = useState(emptyConfirmDialog);
   const panelClass = theme === "light" ? "bg-white text-stone-900" : "bg-[#1e1e1e] text-stone-100";
   const mutedClass = theme === "light" ? "text-stone-500" : "text-stone-400";
   const borderClass = theme === "light" ? "border-stone-200" : "border-stone-700";
@@ -69,7 +72,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
       await onRefreshActivity?.();
       return item;
     } catch (error) {
-      setState({ state: "error", error: error.message || "Redis action failed.", message: "" });
+      setState({ state: "idle", error: error.message || `${product} action failed.`, message: "" });
       throw error;
     }
   }
@@ -81,7 +84,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
     const item = await runRedisAction({
       actionName: "scan_keys",
       input: { pattern: effectivePattern, cursor: startCursor, limit: defaultLimit },
-      reason: "manual Redis browser key scan",
+      reason: `manual ${product} browser key scan`,
       busy: "scanning",
     });
     const output = item.output || {};
@@ -107,7 +110,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
     const item = await runRedisAction({
       actionName: "get_key",
       input: { key, limit: 250, max_bytes: 262144 },
-      reason: "manual Redis browser key read",
+      reason: `manual ${product} browser key read`,
       busy: "reading",
     });
     const output = item.output || {};
@@ -119,13 +122,17 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
   async function saveStringValue(event) {
     event?.preventDefault?.();
     const key = activeKey || newKey.trim();
-    if (!key) return;
     const value = activeKey ? valueDraft : newValue;
+    const validationError = validateStringWrite({ key, value });
+    if (validationError) {
+      setState({ state: "idle", error: validationError, message: "" });
+      return;
+    }
     const ttlSeconds = Number(ttlDraft) > 0 ? Number(ttlDraft) : 0;
     openConfirmDialog({
       type: "save-string",
-      title: activeKey ? "Save Redis string" : "Create Redis string key",
-      description: activeKey ? "This will overwrite the selected key as a Redis string." : "This will create a Redis string key.",
+      title: activeKey ? `Save ${product} string` : `Create ${product} string key`,
+      description: activeKey ? `This will overwrite the selected key as a ${product} string.` : `This will create a ${product} string key.`,
       tone: "warn",
       details: [
         { label: "Key", value: key },
@@ -135,7 +142,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
         await runRedisAction({
           actionName: "set_string",
           input: { key, value, ttl_seconds: ttlSeconds },
-          reason: "manual Redis browser string write",
+          reason: `manual ${product} browser string write`,
           busy: "writing",
         });
         setNewKey("");
@@ -152,7 +159,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
     const normalizedTTL = Number.isFinite(ttlSeconds) ? ttlSeconds : -1;
     openConfirmDialog({
       type: "ttl",
-      title: normalizedTTL < 0 ? "Persist Redis key" : "Update Redis TTL",
+      title: normalizedTTL < 0 ? `Persist ${product} key` : `Update ${product} TTL`,
       description: normalizedTTL < 0 ? "This removes the expiration from the selected key." : "This changes when the selected key expires.",
       tone: "warn",
       details: [
@@ -163,7 +170,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
         await runRedisAction({
           actionName: "expire_key",
           input: { key: activeKey, ttl_seconds: normalizedTTL },
-          reason: "manual Redis browser TTL update",
+          reason: `manual ${product} browser TTL update`,
           busy: "writing",
         });
         await loadKey(activeKey);
@@ -176,15 +183,15 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
     if (keysToDelete.length === 0) return;
     openConfirmDialog({
       type: "delete",
-      title: `Delete ${keysToDelete.length} Redis key${keysToDelete.length === 1 ? "" : "s"}`,
-      description: "This permanently deletes the selected Redis key data.",
+      title: `Delete ${keysToDelete.length} ${product} key${keysToDelete.length === 1 ? "" : "s"}`,
+      description: `This permanently deletes the selected ${product} key data.`,
       tone: "bad",
       details: keysToDelete.slice(0, 8).map((key) => ({ label: "Key", value: key })).concat(keysToDelete.length > 8 ? [{ label: "More", value: `${keysToDelete.length - 8} additional key(s)` }] : []),
       onConfirm: async () => {
         await runRedisAction({
           actionName: "delete_keys",
           input: { keys: keysToDelete },
-          reason: "manual Redis browser key delete",
+          reason: `manual ${product} browser key delete`,
           busy: "deleting",
         });
         setKeys((current) => current.filter((key) => !keysToDelete.includes(key)));
@@ -199,7 +206,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
   }
 
   function openConfirmDialog({ type, title, description, details, tone, onConfirm }) {
-    setConfirmDialog({ open: true, type, title, description, details, tone, pending: false, onConfirm });
+    setConfirmDialog({ open: true, type, title, description, details, tone, pending: false, error: "", onConfirm });
   }
 
   async function confirmPendingAction() {
@@ -207,9 +214,9 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
     setConfirmDialog((current) => ({ ...current, pending: true }));
     try {
       await confirmDialog.onConfirm();
-      setConfirmDialog({ open: false, type: "", title: "", description: "", details: [], tone: "warn", pending: false, onConfirm: null });
-    } catch {
-      setConfirmDialog((current) => ({ ...current, pending: false }));
+      setConfirmDialog(emptyConfirmDialog);
+    } catch (error) {
+      setConfirmDialog((current) => ({ ...current, pending: false, error: error.message || `${product} action failed.` }));
     }
   }
 
@@ -224,11 +231,11 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
           <div className="grid max-w-lg gap-4">
             <Database className={`mx-auto h-10 w-10 ${mutedClass}`} />
             <div>
-              <h3 className="text-lg font-semibold">No active Redis session</h3>
-              <p className={`mt-2 text-sm ${mutedClass}`}>Start a structured session to browse Redis keys through the connector approval, history, and audit pipeline.</p>
+              <h3 className="text-lg font-semibold">No active {product} session</h3>
+              <p className={`mt-2 text-sm ${mutedClass}`}>Start a structured session to browse {product} keys through the connector approval, history, and audit pipeline.</p>
             </div>
             <Button type="button" className="mx-auto" onClick={onNewStructuredSession}>
-              Start Redis session
+              Start {product} session
             </Button>
           </div>
         </div>
@@ -293,7 +300,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
                 <span className="truncate font-mono text-xs" title={key}>{key}</span>
               </button>
             ))}
-            {keys.length === 0 ? <Notice>{state.state === "scanning" ? "Scanning Redis keys..." : "No keys loaded. Scan to browse this database."}</Notice> : null}
+            {keys.length === 0 ? <Notice>{state.state === "scanning" ? `Scanning ${product} keys...` : "No keys loaded. Scan to browse this database."}</Notice> : null}
           </div>
           <div className={`flex items-center justify-between gap-2 border-t p-3 ${borderClass}`}>
             <Button type="button" variant="outline" className="h-8 px-3 text-xs" disabled={cursor === "0" || state.state !== "idle"} onClick={() => scanKeys({ reset: false })}>
@@ -310,7 +317,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
           <div className={`flex flex-wrap items-center justify-between gap-3 border-b p-3 ${borderClass} ${subtlePanelClass}`}>
             <div className="min-w-0">
               <p className="text-sm font-semibold">{activeKey || "New string key"}</p>
-              <p className={`truncate text-xs ${mutedClass}`}>{keyResult ? keyMetaText(keyResult) : creatingKey ? "Create a Redis string value." : "Select a key from the browser."}</p>
+              <p className={`truncate text-xs ${mutedClass}`}>{keyResult ? keyMetaText(keyResult) : creatingKey ? `Create a ${product} string value.` : "Select a key from the browser."}</p>
             </div>
             <div className="flex items-center gap-2">
               {keyResult?.type ? <Badge tone={keyResult.type === "none" ? "neutral" : "good"}>{keyResult.type}</Badge> : null}
@@ -339,7 +346,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
                   <Save className="h-3.5 w-3.5" />
                 </Button>
               </div>
-              <Button type="button" className="h-8 px-3 text-xs" disabled={state.state !== "idle" || !canSaveString} onClick={saveStringValue} title={editableString ? "Save Redis string value" : "This Redis type is read-only in the MVP"}>
+              <Button type="button" className="h-8 px-3 text-xs" disabled={state.state !== "idle" || !canSaveString} onClick={saveStringValue} title={editableString ? `Save ${product} string value` : `This ${product} type is read-only in the MVP`}>
                 {activeKey ? <Save className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
                 {activeKey ? (editableString ? "Save string" : "Read only") : "Create key"}
               </Button>
@@ -355,7 +362,7 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
             )}
           </div>
           <div className={`grid gap-2 border-t p-3 ${borderClass}`}>
-            {keyResult && keyResult.type !== "string" && resultMode === "value" ? <Notice tone="warn">This Redis type is read-only in the MVP. TTL changes are still available from the toolbar.</Notice> : null}
+            {keyResult && keyResult.type !== "string" && resultMode === "value" ? <Notice tone="warn">This {product} type is read-only in the MVP. TTL changes are still available from the toolbar.</Notice> : null}
             {state.error ? <Notice tone="bad">{state.error}</Notice> : null}
             {state.message ? <Notice tone="good">{state.message}</Notice> : null}
           </div>
@@ -363,12 +370,12 @@ export function RedisConnectorConsoleTemplate({ target, approvals, theme, sessio
       </div>
 
       <RedisEndpointFooter target={target} borderClass={borderClass} mutedClass={mutedClass} />
-      <RedisConfirmDialog value={confirmDialog} theme={theme} onClose={() => setConfirmDialog({ open: false, type: "", title: "", description: "", details: [], tone: "warn", pending: false, onConfirm: null })} onConfirm={confirmPendingAction} />
+      <RedisConfirmDialog value={confirmDialog} theme={theme} product={product} onClose={() => setConfirmDialog(emptyConfirmDialog)} onConfirm={confirmPendingAction} />
     </div>
   );
 }
 
-function RedisConfirmDialog({ value, theme, onClose, onConfirm }) {
+function RedisConfirmDialog({ value, theme, product, onClose, onConfirm }) {
   const danger = value.tone === "bad";
   const noticeTone = danger ? "bad" : "warn";
   const detailClass = theme === "light" ? "bg-stone-50" : "bg-stone-900/70 text-stone-100";
@@ -386,7 +393,8 @@ function RedisConfirmDialog({ value, theme, onClose, onConfirm }) {
       bodyClassName={theme === "light" ? "" : "bg-[#252526]"}
     >
       <div className="grid gap-4">
-        <Notice tone={noticeTone}>{danger ? "This operation cannot be undone." : "Review the Redis write before continuing."}</Notice>
+        <Notice tone={noticeTone}>{danger ? "This operation cannot be undone." : `Review the ${product} write before continuing.`}</Notice>
+        {value.error ? <Notice tone="bad">{value.error}</Notice> : null}
         {value.details?.length ? (
           <div className={`max-h-56 overflow-auto rounded-md border border-stone-300 p-3 text-sm ${detailClass}`}>
             {value.details.map((item, index) => (
@@ -424,7 +432,7 @@ function RedisEndpointFooter({ target, borderClass, mutedClass }) {
   return (
     <div className={`flex min-w-0 items-center justify-between gap-3 border-t px-3 py-2 text-xs ${borderClass}`}>
       <span className={`truncate font-mono ${mutedClass}`}>{target.ref}</span>
-      <span className={`truncate ${mutedClass}`}>{target.config?.host}:{target.config?.port} db {target.config?.database || 0}</span>
+      <span className={`truncate ${mutedClass}`}>{serverProductLabel(target)} · {target.config?.host}:{target.config?.port} db {target.config?.database || 0}</span>
     </div>
   );
 }

--- a/frontend/src/connectors/templates/redis/credential-form.jsx
+++ b/frontend/src/connectors/templates/redis/credential-form.jsx
@@ -2,28 +2,31 @@ import { Database, Plus } from "lucide-react";
 import { Button } from "../../../components/ui/button";
 import { Field, Input, Select } from "../../../components/ui/form";
 import { Notice } from "../../../components/ui/notice";
+import { connectorProductLabel, serverProductLabel } from "./model";
 
 export function RedisCredentialFormTemplate({ targets, form, formMode = "create", state, onChange, onSubmit }) {
   const redisTargets = targets.filter((target) => target.connector_kind === "redis");
+  const selectedTarget = redisTargets.find((target) => Number(target.id) === Number(form.target_id));
+  const product = selectedTarget ? serverProductLabel(selectedTarget) : connectorProductLabel;
   const editing = formMode === "edit";
   return (
     <form className="grid gap-4" onSubmit={onSubmit}>
       {redisTargets.length === 0 ? (
-        <Notice tone="warn">Create a Redis connector target before adding a Redis credential profile.</Notice>
+        <Notice tone="warn">Create a {connectorProductLabel} connector target before adding a credential profile.</Notice>
       ) : (
         <Notice tone="good">
-          {editing ? "Update public Redis profile metadata, or enter a new password to rotate the stored secret." : "Create a Redis profile, then bind tokens to this profile from Console or Tokens."}
+          {editing ? `Update public ${product} profile metadata, or enter a new password to rotate the stored secret.` : `Create a ${product} profile, then bind tokens to this profile from Console or Tokens.`}
         </Notice>
       )}
       <Field>
         Connector target
         <Select value={form.target_id} onChange={(event) => onChange({ ...form, target_id: event.target.value })} disabled={editing} required>
           <option value="" disabled>
-            Select Redis target
+            Select {connectorProductLabel} target
           </option>
           {redisTargets.map((target) => (
             <option value={target.id} key={target.id}>
-              {target.name} · {target.config?.host}:{target.config?.port}/{target.config?.database || 0}
+              {target.name} · {serverProductLabel(target)} · {target.config?.host}:{target.config?.port}/{target.config?.database || 0}
             </option>
           ))}
         </Select>
@@ -40,7 +43,7 @@ export function RedisCredentialFormTemplate({ targets, form, formMode = "create"
       </div>
       <Field>
         Username
-        <Input value={form.username} onChange={(event) => onChange({ ...form, username: event.target.value })} autoComplete="off" placeholder="optional Redis ACL username" />
+        <Input value={form.username} onChange={(event) => onChange({ ...form, username: event.target.value })} autoComplete="off" placeholder={`optional ${product} ACL username`} />
       </Field>
       <Field>
         {editing ? "New password" : "Password"}
@@ -49,17 +52,17 @@ export function RedisCredentialFormTemplate({ targets, form, formMode = "create"
           value={form.password}
           onChange={(event) => onChange({ ...form, password: event.target.value })}
           autoComplete="new-password"
-          placeholder={editing ? "Leave blank to keep current password" : "optional Redis password"}
+          placeholder={editing ? "Leave blank to keep current password" : `optional ${product} password`}
         />
       </Field>
       {state.state === "error" ? <Notice tone="bad">{state.error}</Notice> : null}
       <Button type="submit" disabled={state.state === "saving" || redisTargets.length === 0}>
         <Plus className="h-4 w-4" />
-        {state.state === "saving" ? "Saving..." : editing ? "Save Redis credential" : "Create Redis credential"}
+        {state.state === "saving" ? "Saving..." : editing ? `Save ${product} credential` : `Create ${product} credential`}
       </Button>
       <Notice>
         <Database className="mr-2 inline h-4 w-4" />
-        Redis secrets are stored in the encrypted local database and are never returned to MCP or REST list responses.
+        Redis and Valkey secrets are stored in the encrypted local database and are never returned to MCP or REST list responses.
       </Notice>
     </form>
   );

--- a/frontend/src/connectors/templates/redis/form.jsx
+++ b/frontend/src/connectors/templates/redis/form.jsx
@@ -1,19 +1,28 @@
 import { Field, Input, Select } from "../../../components/ui/form";
 import { Notice } from "../../../components/ui/notice";
 import { HostPingButton } from "../host-ping-button";
+import { serverProductLabel } from "./model";
 
 export function RedisConnectorFormTemplate({ form, mode = "create", targets = [], onChange }) {
   const editing = mode === "edit";
   const sshProfiles = sshProfileOptions(targets);
   const overSSH = form.connection_mode === "over_ssh";
+  const product = serverProductLabel(form);
   return (
     <>
       <Notice tone="good">
-        Redis keys can contain secrets. Start with Prompt permissions for write and delete actions until the workflow is trusted.
+        {product} keys can contain secrets. Start with Prompt permissions for write and delete actions until the workflow is trusted.
       </Notice>
       <Field>
         Connector name
         <Input value={form.name} onChange={(event) => onChange("name", event.target.value)} required />
+      </Field>
+      <Field>
+        Server product
+        <Select value={form.server_family || "redis"} onChange={(event) => onChange("server_family", event.target.value)}>
+          <option value="redis">Redis</option>
+          <option value="valkey">Valkey</option>
+        </Select>
       </Field>
       <Field>
         Connection mode
@@ -39,17 +48,17 @@ export function RedisConnectorFormTemplate({ form, mode = "create", targets = []
       ) : null}
       {overSSH ? (
         <Notice>
-          Host and port are resolved from the SSH server. Use 127.0.0.1:6379 when Redis only listens on the remote machine.
+          Host and port are resolved from the SSH server. Use 127.0.0.1:6379 when {product} only listens on the remote machine.
         </Notice>
       ) : (
         <Notice>
-          For Redis running on the same Linux host as AIPermission Docker, use host.docker.internal instead of localhost.
+          For {product} running on the same Linux host as AIPermission Docker, use host.docker.internal instead of localhost.
         </Notice>
       )}
       <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_120px_120px]">
         <Field>
           <span className="flex items-center justify-between gap-2">
-            <span>Redis host</span>
+            <span>{product} host</span>
             <HostPingButton host={form.host} port={form.port} mode={form.connection_mode} transportTargetRef={form.transport_target_ref} />
           </span>
           <Input value={form.host} onChange={(event) => onChange("host", event.target.value)} required />
@@ -75,7 +84,7 @@ export function RedisConnectorFormTemplate({ form, mode = "create", targets = []
       </div>
       <Field>
         Username
-        <Input value={form.username} onChange={(event) => onChange("username", event.target.value)} autoComplete="off" placeholder="optional Redis ACL username" />
+        <Input value={form.username} onChange={(event) => onChange("username", event.target.value)} autoComplete="off" placeholder={`optional ${product} ACL username`} />
       </Field>
       <Field>
         Password
@@ -84,7 +93,7 @@ export function RedisConnectorFormTemplate({ form, mode = "create", targets = []
           value={form.password}
           onChange={(event) => onChange("password", event.target.value)}
           autoComplete="new-password"
-          placeholder={editing ? "Leave blank to keep the current encrypted password" : "optional Redis password"}
+          placeholder={editing ? "Leave blank to keep the current encrypted password" : `optional ${product} password`}
         />
       </Field>
     </>

--- a/frontend/src/connectors/templates/redis/metadata.json
+++ b/frontend/src/connectors/templates/redis/metadata.json
@@ -1,7 +1,7 @@
 {
   "kind": "redis",
-  "label": "Redis",
-  "summary": "Key browsing, bounded reads, string writes, TTL updates, and destructive deletes through Redis credential profiles.",
+  "label": "Redis / Valkey",
+  "summary": "Redis-compatible key browsing, bounded reads, string writes, TTL updates, and destructive deletes through encrypted credential profiles.",
   "version": "0.2",
   "icon": "database",
   "badge_tone": "warn"

--- a/frontend/src/connectors/templates/redis/model.js
+++ b/frontend/src/connectors/templates/redis/model.js
@@ -2,11 +2,14 @@ import { apiDelete, apiPost, apiPut } from "../../../lib/api";
 import { createTargetWithProfile, updateTargetWithProfile } from "../target-profile-save";
 
 const emptyRedisCredentialForm = { target_id: "", profile_label: "default", username: "", password: "", risk_label: "cache access" };
+const defaultServerFamily = "redis";
+export const connectorProductLabel = "Redis / Valkey";
 
 export function emptyForm() {
   return {
     connector_kind: "redis",
     name: "redis-cache",
+    server_family: defaultServerFamily,
     connection_mode: "direct",
     host: "127.0.0.1",
     port: 6379,
@@ -25,6 +28,7 @@ export function formFromTarget({ target, profile }) {
     connector_kind: "redis",
     profile_id: selectedProfile.id ? String(selectedProfile.id) : "",
     name: target.name || "",
+    server_family: target.config?.server_family || defaultServerFamily,
     connection_mode: target.config?.connection_mode || "direct",
     host: target.config?.host || "127.0.0.1",
     port: target.config?.port || 6379,
@@ -104,8 +108,10 @@ export function credentialFormProps({ targets, formState, setFormState, formMode
   };
 }
 
-export async function saveCredential({ operation, row, formState }) {
+export async function saveCredential({ operation, row, formState, targets = [] }) {
   const form = formState.form;
+  const target = row?.target || targets.find((item) => Number(item.id) === Number(form.target_id));
+  const product = serverProductLabel(target);
   if (operation === "create") {
     await apiPost(`/api/connector-targets/${form.target_id}/profiles`, {
       kind: "username_password",
@@ -114,10 +120,10 @@ export async function saveCredential({ operation, row, formState }) {
       secret: form.password ? { password: form.password } : {},
       risk_label: form.risk_label,
     });
-    return { message: "Redis credential created." };
+    return { message: `${product} credential created.` };
   }
   if (operation === "update") {
-    if (!row) throw new Error("Redis credential is not loaded.");
+    if (!row) throw new Error(`${connectorProductLabel} credential is not loaded.`);
     const payload = {
       kind: row.profile?.kind || "username_password",
       label: form.profile_label,
@@ -128,9 +134,9 @@ export async function saveCredential({ operation, row, formState }) {
       payload.secret = { password: form.password };
     }
     await apiPut(`/api/connector-targets/${form.target_id}/profiles/${row.id}`, payload);
-    return { message: "Redis credential updated." };
+    return { message: `${product} credential updated.` };
   }
-  throw new Error("Unsupported Redis credential operation.");
+  throw new Error(`Unsupported ${connectorProductLabel} credential operation.`);
 }
 
 export async function deleteCredential({ row }) {
@@ -145,12 +151,13 @@ export function credentialRows({ targets }) {
         row_id: `${target.connector_kind}:${target.id}:${profile.id}`,
         connector_kind: target.connector_kind,
         resource_kind: "credential_profile",
-        connector_label: "Redis",
+        connector_label: serverProductLabel(target),
         id: profile.id,
         target_id: target.id,
         name: profile.label,
         kind: profile.kind,
         profile,
+        target,
         target_label: target.name,
         target_detail: targetEndpoint({ target }),
         metadata: credentialMetadata(profile),
@@ -187,12 +194,12 @@ export function targetEndpoint({ target }) {
 }
 
 export function targetDisplayName({ target }) {
-  if (!target) return "Redis target";
-  return target.target_name || target.name || "Redis target";
+  if (!target) return `${connectorProductLabel} target`;
+  return target.target_name || target.name || `${serverProductLabel(target)} target`;
 }
 
 export function targetSubtitle({ target }) {
-  return targetEndpoint({ target });
+  return `${serverProductLabel(target)} · ${targetEndpoint({ target })}`;
 }
 
 export function targetProfileLabel({ target }) {
@@ -208,14 +215,15 @@ export function recoverableRunningActions() {
 }
 
 export function deleteDialog({ target }) {
+  const product = serverProductLabel(target);
   return {
     title: target ? `Delete ${target.name}` : "Delete connector",
-    description: "Remove this Redis connector target, credential profiles, and token action permissions from aipermission.",
+    description: `Remove this ${product} connector target, credential profiles, and token action permissions from aipermission.`,
     details: [
       { label: "Connector", value: target?.name },
       { label: "Reference", value: target ? `${target.connector_kind}:${target.id}` : "" },
     ],
-    notice: "This removes the connector target and its credential profiles. It does not change the Redis server.",
+    notice: `This removes the connector target and its credential profiles. It does not change the ${product} server.`,
     actions: [
       { label: "Cancel", action: "close", variant: "outline" },
       { label: "Delete connector", pendingLabel: "Deleting...", removeKey: false },
@@ -247,7 +255,7 @@ async function createTarget({ form }) {
 
 async function updateTarget({ form, target }) {
   const profile = target?.profiles?.find((item) => Number(item.id) === Number(form.profile_id)) || (target?.profiles?.length === 1 ? target.profiles[0] : null);
-  if (!target || !profile) throw new Error("Redis connector profile is not loaded.");
+  if (!target || !profile) throw new Error(`${connectorProductLabel} connector profile is not loaded.`);
   const profilePayload = {
     kind: profile.kind || "username_password",
     label: form.profile_label,
@@ -272,12 +280,24 @@ async function updateTarget({ form, target }) {
 
 function redisTargetConfigFromForm(form) {
   return {
+    server_family: form.server_family === "valkey" ? "valkey" : defaultServerFamily,
     connection_mode: form.connection_mode || "direct",
     host: form.host || "127.0.0.1",
     port: Number(form.port) || 6379,
     database: Number(form.database) || 0,
     transport_target_ref: form.connection_mode === "over_ssh" ? form.transport_target_ref || "" : "",
   };
+}
+
+export function serverProductLabel(targetOrConfig) {
+  const config = targetOrConfig?.config || targetOrConfig || {};
+  return config.server_family === "valkey" ? "Valkey" : "Redis";
+}
+
+export function validateStringWrite({ key, value }) {
+  if (!String(key || "").trim()) return "Key is required.";
+  if (!String(value || "").trim()) return "Value is required.";
+  return "";
 }
 
 function credentialMetadata(profile) {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -297,8 +297,8 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.16"/);
-  assert.match(releaseSource, /Project Vault/);
+  assert.match(releaseSource, /appVersion = "0\.2\.17"/);
+  assert.match(releaseSource, /Redis \/ Valkey compatibility/);
   assert.match(releaseSource, /Security and dependency maintenance/);
   assert.match(releaseSource, /Projects and scoped visibility/);
   assert.match(releaseSource, /MCP target discovery only returns targets from projects enabled for the calling token/);

--- a/frontend/src/lib/connector-registry-runtime.test.js
+++ b/frontend/src/lib/connector-registry-runtime.test.js
@@ -33,17 +33,48 @@ test("connector template registry evaluates at runtime", async () => {
     await page.goto(baseURL, { waitUntil: "domcontentloaded" });
     const registryResult = await page.evaluate(async (expectedKinds) => {
       const registry = await import("/src/connectors/templates/registry.jsx");
+      const redisTemplate = registry.getConnectorTemplate("redis");
+      const redisModel = redisTemplate.model;
+      const valkeyTarget = {
+        id: 8,
+        connector_kind: "redis",
+        name: "cache",
+        config: { server_family: "valkey", connection_mode: "direct", host: "127.0.0.1", port: 6379, database: 0 },
+        profiles: [{ id: 9, label: "default", kind: "username_password", public: {}, risk_label: "cache access" }],
+      };
       return {
         expected: Object.fromEntries(expectedKinds.map((kind) => [kind, Boolean(registry.getConnectorTemplate(kind))])),
         models: Object.fromEntries(expectedKinds.map((kind) => [kind, Boolean(registry.getConnectorModel(kind)?.emptyForm)])),
         metadata: Object.fromEntries(expectedKinds.map((kind) => [kind, registry.getConnectorTemplate(kind)?.metadata?.kind])),
         missing: registry.getConnectorTemplate("__missing_connector__") === null,
+        redisValkey: {
+          catalogLabel: redisTemplate.metadata.label,
+          productLabel: redisModel.connectorProductLabel,
+          defaultFamily: redisModel.emptyForm().server_family,
+          valkeyLabel: redisModel.serverProductLabel(valkeyTarget),
+          formFamily: redisModel.formFromTarget({ target: valkeyTarget, profile: valkeyTarget.profiles[0] }).server_family,
+          credentialLabel: redisModel.credentialRows({ targets: [valkeyTarget] })[0].connector_label,
+          targetSubtitle: redisModel.targetSubtitle({ target: valkeyTarget }),
+          blankValueError: redisModel.validateStringWrite({ key: "smoke:key", value: "" }),
+          validValueError: redisModel.validateStringWrite({ key: "smoke:key", value: "ready" }),
+        },
       };
     }, connectorTemplateKinds);
     assert.deepEqual(registryResult.expected, Object.fromEntries(connectorTemplateKinds.map((kind) => [kind, true])));
     assert.deepEqual(registryResult.models, Object.fromEntries(connectorTemplateKinds.map((kind) => [kind, true])));
     assert.deepEqual(registryResult.metadata, Object.fromEntries(connectorTemplateKinds.map((kind) => [kind, kind])));
     assert.equal(registryResult.missing, true);
+    assert.deepEqual(registryResult.redisValkey, {
+      catalogLabel: "Redis / Valkey",
+      productLabel: "Redis / Valkey",
+      defaultFamily: "redis",
+      valkeyLabel: "Valkey",
+      formFamily: "valkey",
+      credentialLabel: "Valkey",
+      targetSubtitle: "Valkey · 127.0.0.1:6379/0 · direct",
+      blankValueError: "Value is required.",
+      validValueError: "",
+    });
     assert.deepEqual(pageErrors.map((error) => error.message), []);
   } finally {
     if (browser) {

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,25 @@
-export const appVersion = "0.2.16";
+export const appVersion = "0.2.17";
 
 export const changelogEntries = [
+  {
+    version: "0.2.17",
+    label: "Redis / Valkey compatibility",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "The built-in Redis connector now supports Valkey over both Direct and Over SSH profiles without introducing a duplicate connector kind or permission surface.",
+          "Server identity detection reports the configured and detected Redis-compatible product while preserving the existing key browser and MCP action catalog.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "RESP parsing now bounds line, bulk, array, nesting, aggregate-byte, and aggregate-value sizes before allocation.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.16",
     label: "Project Vault",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -8,8 +8,8 @@ credentials, or other connector secrets.
 
 The gateway is intentionally local-only. Run it on the developer machine and
 keep the URL on `localhost`; remote systems are connector targets, not places
-to host the gateway for LAN or internet users. SSH, Postgres, Redis, RabbitMQ,
-Docker, and Kubernetes are built-in connectors that use the same
+to host the gateway for LAN or internet users. SSH, Postgres, ClickHouse,
+Redis / Valkey, RabbitMQ, S3, Docker, and Kubernetes are built-in connectors that use the same
 target/profile/action permission model as future connectors.
 
 ![AIPermission demo: AI operates through approval-based connector access](https://raw.githubusercontent.com/aipermission/aipermission/main/docs/assets/demo/aipermission-demo.gif)
@@ -65,8 +65,8 @@ The generated MCP config contains a bearer token. Keep it private. For project-l
 - `get_vault_action_request`
 - `cancel_vault_action_request`
 
-All integration work goes through connector targets. SSH, Postgres, Redis,
-RabbitMQ, Docker, Kubernetes, and future connectors share the same model: target,
+All integration work goes through connector targets. SSH, Postgres, ClickHouse,
+Redis / Valkey, RabbitMQ, S3, Docker, Kubernetes, and future connectors share the same model: target,
 credential profile, connector action, token action permission, approval,
 history, and audit.
 
@@ -99,9 +99,12 @@ table, and bounded read-only query actions. Postgres targets can connect
 directly from the gateway or over an SSH connector profile when the database is
 reachable only from a remote server.
 
-For Redis, call `get_connector_actions(target_ref)` to discover bounded key
-browser actions such as `scan_keys`, `get_key`, `set_string`, `expire_key`, and
-`delete_keys`.
+For Redis or Valkey, call `get_connector_actions(target_ref)` to discover
+bounded key-browser actions such as `scan_keys`, `get_key`, `set_string`,
+`expire_key`, and `delete_keys`. Both products intentionally use the `redis`
+connector kind and target-ref prefix; no separate Valkey MCP tool family is
+required. The current connector uses RESP2 against one configured endpoint and
+does not provide Cluster or Sentinel routing.
 
 For RabbitMQ, call `get_connector_actions(target_ref)` to discover queue
 browser actions such as `overview`, `list_vhosts`, `list_queues`, `get_queue`,

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- add Valkey compatibility to the built-in Redis connector without creating a duplicate connector kind or permission pipeline
- expose Redis / Valkey product selection and server identity detection over Direct and Over SSH profiles
- harden RESP response parsing with bounded allocation limits
- align public docs, in-app changelog, and MCP package metadata for 0.2.17

## Validation

- `node scripts/secret-scan.js`
- `make release-check`
- `docker compose config --quiet`
- manual UI validation against Valkey 8
- real MCP smoke test covering help, ping, info, set, scan, read, TTL update, and delete

## Notes

- AIPermission remains local-only, single-user, and developer-focused.
- Redis and Valkey intentionally share the same `redis` connector kind, target references, permissions, history, audit, UI template, and MCP action catalog.