### PR TITLE
feat(kafka): add Kafka and Redpanda connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.18] - 2026-07-31
+
+### Added
+
+- Added one built-in Kafka / Redpanda connector with Direct and Over SSH
+  connection modes, multiple bootstrap brokers, optional TLS/custom CA, and
+  optional PLAIN or SCRAM SASL credential profiles.
+- Added read-focused actions for cluster metadata, topics, partitions,
+  consumer groups, committed offsets, lag, and bounded message samples.
+- Added a structured Kafka / Redpanda browser for topic and consumer-group
+  inspection without joining a consumer group or committing offsets.
+
+### Fixed
+
+- Scoped local UI session and CSRF cookies by frontend port so development and
+  stable localhost stacks can remain unlocked independently.
+
+### Security
+
+- Message sampling uses explicit partition assignment, strict record/byte/time
+  bounds, no automatic topic creation, and no consumer offset commits.
+
 ## [0.2.17] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ AIPermission is intentionally designed as a local developer gateway.
 
 - The gateway runs on the developer's own machine.
 - Remote systems are connector targets reached from that local gateway.
-- SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, and Kubernetes are
+- SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, and Kubernetes are
   built-in connector types, not separate product modes.
 - The web UI, REST API, and MCP API are not designed to be shared on a LAN.
 - The project does not support running the gateway as a remote hosted service.
@@ -119,7 +119,7 @@ Implemented:
 - Go backend with SQLite storage
 - React web UI
 - connector target/profile/action pipeline for SSH, Postgres, ClickHouse,
-  Redis / Valkey, RabbitMQ, S3, Docker, Kubernetes, and future local integrations
+  Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, Kubernetes, and future local integrations
 - local Projects for grouping connector targets, filtering History/Audit, and
   limiting which project target refs each MCP token can discover or call
 - [Project Vault](docs/project-vault.md) for encrypted project-scoped secret inventory, expiry/usage
@@ -147,6 +147,10 @@ Implemented:
 - built-in RabbitMQ connector with Direct and Over SSH connection modes, queue
   browsing, vhost metadata, binding inspection, bounded message peeking, and
   explicit message publishing
+- built-in Kafka / Redpanda connector with Direct and Over SSH connection
+  modes, TLS and SASL profiles, cluster/topic/group/lag inspection, and bounded
+  message samples that never join groups or commit offsets
+  ([setup guide](docs/setup/kafka-redpanda.md))
 - built-in S3 connector with Direct and Over SSH connection modes,
   S3-compatible bucket browsing, object metadata, bounded object
   upload/download, rename, and delete actions, plus MCP-friendly folder/prefix
@@ -175,7 +179,7 @@ Implemented:
 - persistent web console with live PTY streaming
 - UI bulk SSH command execution across selected connector targets with per-target history rows
 - MCP bridge with connector action tools for SSH, Postgres, ClickHouse, Redis / Valkey,
-  RabbitMQ, S3, Docker, Kubernetes, and future local integrations
+  RabbitMQ, Kafka / Redpanda, S3, Docker, Kubernetes, and future local integrations
 - approval dialog with Run / Decline / note
 - approval-context snapshots that stale old pending connector actions after
   permission, connector target, credential profile, connector metadata, or
@@ -226,7 +230,7 @@ To pin a specific release image, set `AIPERMISSION_VERSION` without the leading
 `v`:
 
 ```bash
-AIPERMISSION_VERSION=0.2.17 docker compose -f docker-compose.release.yml up -d
+AIPERMISSION_VERSION=0.2.18 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, clone the repository with Git's default text handling or make sure
@@ -375,7 +379,7 @@ get_connector_action_request(request_id)
 ```
 
 The MCP surface is connector-first. SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ,
-S3, Docker, Kubernetes, and future integrations use the same
+Kafka / Redpanda, S3, Docker, Kubernetes, and future integrations use the same
 target/profile/action permission pipeline. `list_connector_targets` also applies the token's enabled project
 scope before returning target refs. It is
 permission-scoped, not a live health check. Current reachability is learned when

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -9,8 +9,13 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.10.0
+	github.com/klauspost/compress v1.18.6
 	github.com/mutecomm/go-sqlcipher/v4 v4.4.2
+	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/pkg/sftp v1.13.11
+	github.com/twmb/franz-go v1.21.5
+	github.com/twmb/franz-go/pkg/kadm v1.18.0
+	github.com/twmb/franz-go/pkg/kfake v0.0.0-20260729023516-cc159eb5ddb9
 	golang.org/x/crypto v0.54.0
 )
 
@@ -23,13 +28,12 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/paulmach/orb v0.13.0 // indirect
-	github.com/pierrec/lz4/v4 v4.1.27 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/twmb/franz-go/pkg/kmsg v1.13.1 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -58,6 +58,14 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/twmb/franz-go v1.21.5 h1:cVYI2+JTTKSvohhy8bCOleYrS7G79ZBrLVFIJsoHm8M=
+github.com/twmb/franz-go v1.21.5/go.mod h1:rfoMTnVk7107fhTGxfEKIHP/e7tPe6oyij/ywzO0czk=
+github.com/twmb/franz-go/pkg/kadm v1.18.0 h1:WRf/LZmDdcDXwX7WMbtDU++v+b3NzYh2bCGoPMmzirw=
+github.com/twmb/franz-go/pkg/kadm v1.18.0/go.mod h1:XeLhGoLXLFzK8/ryv5FfpxPxGwj4oFEGpPJMB/x6KDE=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20260729023516-cc159eb5ddb9 h1:KFnXuPRZs950ZRZa0m3XDPSeL1aF20ulIdBGhgFLSV8=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20260729023516-cc159eb5ddb9/go.mod h1:9j4VxU2ng6tHgD4lIkNJ5OJ3D6vgPhhIp3tBa7dJgLA=
+github.com/twmb/franz-go/pkg/kmsg v1.13.1 h1:fG5kItwysTk5UXqVwb64EpQEy3TydF3vYYK21nUQ+bI=
+github.com/twmb/franz-go/pkg/kmsg v1.13.1/go.mod h1:+DPt4NC8RmI6hqb8G09+3giKObE6uD2Eya6CfqBpeJY=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=

--- a/backend/internal/api/connector_action_runtime.go
+++ b/backend/internal/api/connector_action_runtime.go
@@ -482,6 +482,13 @@ func (s *Server) redactedConnectorValue(ctx context.Context, runtime *databaseRu
 			out = append(out, s.redactForPersistence(ctx, runtime, item))
 		}
 		return out
+	case []map[string]any:
+		out := make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			redacted, _ := s.redactedConnectorValue(ctx, runtime, item, sensitiveFields).(map[string]any)
+			out = append(out, redacted)
+		}
+		return out
 	case map[string]any:
 		out := make(map[string]any, len(typed))
 		for key, item := range typed {

--- a/backend/internal/api/connector_actions_test.go
+++ b/backend/internal/api/connector_actions_test.go
@@ -448,7 +448,7 @@ func TestRunningConnectorActionResponseRedactsOutput(t *testing.T) {
 	}
 	redacted := server.redactConnectorActionResult(context.Background(), runtime, connectors.ActionResult{
 		Status:      connectors.ResultRunning,
-		Output:      map[string]any{"rows": []any{map[string]any{"session_token": "raw-token", "name": "safe"}}},
+		Output:      map[string]any{"rows": []map[string]any{{"session_token": "raw-token", "name": "safe"}}},
 		DisplayText: "Bearer raw-bearer-token",
 		Error:       "password=super-secret",
 	}, connectors.OutputHint{SensitiveFields: []string{"session_token"}})
@@ -489,8 +489,8 @@ func TestFinishConnectorActionRequestRedactsErrorAndHistory(t *testing.T) {
 		request.ID,
 		connectors.ResultFailed,
 		map[string]any{
-			"rows": []any{
-				map[string]any{
+			"rows": []map[string]any{
+				{
 					"customer_secret": "visible-only-if-buggy",
 					"token":           "token-value",
 					"access_token":    "access-token-value",

--- a/backend/internal/api/connector_target_handlers.go
+++ b/backend/internal/api/connector_target_handlers.go
@@ -145,6 +145,7 @@ func (s connectorTargetHandlers) prepareConnectorCredentialProfileInput(
 	connector connectors.Connector,
 	request connectorCredentialProfilePayload,
 	secretRequired bool,
+	previous *connectors.CredentialProfileView,
 ) (preparedConnectorCredentialProfileInput, bool) {
 	kind := strings.TrimSpace(request.Kind)
 	if !credentialKindSupported(connector, kind) {
@@ -168,6 +169,12 @@ func (s connectorTargetHandlers) prepareConnectorCredentialProfileInput(
 	if err := connectors.ValidateCredentialSchemaValues(schema.Schema, public, request.Secret, secretRequired); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return preparedConnectorCredentialProfileInput{}, false
+	}
+	if validator, ok := connector.(connectors.CredentialProfileValidator); ok {
+		if err := validator.ValidateCredentialProfile(kind, public, request.Secret, previous); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return preparedConnectorCredentialProfileInput{}, false
+		}
 	}
 	prepared := preparedConnectorCredentialProfileInput{
 		Kind:      kind,
@@ -359,7 +366,7 @@ func (s connectorTargetHandlers) createConnectorTargetWithProfile(w http.Respons
 		return
 	}
 	request.Target.Config = targetConfig
-	preparedProfile, ok := s.prepareConnectorCredentialProfileInput(w, r, runtime, connector, createProfileAdapterRequest(request.Profile), true)
+	preparedProfile, ok := s.prepareConnectorCredentialProfileInput(w, r, runtime, connector, createProfileAdapterRequest(request.Profile), true, nil)
 	if !ok {
 		return
 	}
@@ -621,7 +628,13 @@ func (s connectorTargetHandlers) updateConnectorTargetWithProfile(w http.Respons
 	if request.Target.ProjectID == 0 {
 		request.Target.ProjectID = existing.ProjectID
 	}
-	preparedProfile, ok := s.prepareConnectorCredentialProfileInput(w, r, runtime, connector, updateProfileAdapterRequest(request.Profile), request.Profile.Secret != nil)
+	existingProfile, err := store.GetCredentialProfile(r.Context(), id, profileID)
+	if err != nil {
+		handleConnectorTargetError(w, err)
+		return
+	}
+	existingProfileView := connectortargets.CredentialProfileView(existingProfile)
+	preparedProfile, ok := s.prepareConnectorCredentialProfileInput(w, r, runtime, connector, updateProfileAdapterRequest(request.Profile), request.Profile.Secret != nil, &existingProfileView)
 	if !ok {
 		return
 	}
@@ -792,7 +805,7 @@ func (s connectorTargetHandlers) createConnectorCredentialProfile(w http.Respons
 		writeError(w, http.StatusBadRequest, "unsupported connector kind")
 		return
 	}
-	preparedProfile, ok := s.prepareConnectorCredentialProfileInput(w, r, runtime, connector, createProfileAdapterRequest(request), true)
+	preparedProfile, ok := s.prepareConnectorCredentialProfileInput(w, r, runtime, connector, createProfileAdapterRequest(request), true, nil)
 	if !ok {
 		return
 	}
@@ -883,7 +896,8 @@ func (s connectorTargetHandlers) updateConnectorCredentialProfile(w http.Respons
 		}
 		request.Public = mergedPublic
 	}
-	preparedProfile, ok := s.prepareConnectorCredentialProfileInput(w, r, runtime, connector, updateProfileAdapterRequest(request), request.Secret != nil)
+	existingProfileView := connectortargets.CredentialProfileView(existingProfile)
+	preparedProfile, ok := s.prepareConnectorCredentialProfileInput(w, r, runtime, connector, updateProfileAdapterRequest(request), request.Secret != nil, &existingProfileView)
 	if !ok {
 		return
 	}

--- a/backend/internal/api/http_boundary.go
+++ b/backend/internal/api/http_boundary.go
@@ -44,7 +44,7 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "ui session required")
 		return
 	}
-	if unlocked && requiresUICSRF(r.Method, r.URL.Path) && !hasValidUICSRF(r) {
+	if unlocked && requiresUICSRF(r.Method, r.URL.Path) && !s.hasValidUICSRF(r) {
 		writeError(w, http.StatusForbidden, "csrf token required")
 		return
 	}

--- a/backend/internal/api/ui_session.go
+++ b/backend/internal/api/ui_session.go
@@ -41,7 +41,7 @@ func (s *Server) issueUISession(w http.ResponseWriter) error {
 	s.uiSessionMu.Unlock()
 
 	http.SetCookie(w, &http.Cookie{
-		Name:     uiSessionCookieName,
+		Name:     s.uiSessionCookieName(),
 		Value:    token,
 		Path:     "/",
 		HttpOnly: true,
@@ -55,7 +55,7 @@ func (s *Server) issueUISession(w http.ResponseWriter) error {
 		return err
 	}
 	http.SetCookie(w, &http.Cookie{
-		Name:     uiCSRFCookieName,
+		Name:     s.uiCSRFCookieName(),
 		Value:    base64.RawURLEncoding.EncodeToString(csrfBytes),
 		Path:     "/",
 		Secure:   true,
@@ -72,7 +72,7 @@ func (s *Server) clearUISessions(w http.ResponseWriter) {
 	s.uiSessionMu.Unlock()
 
 	http.SetCookie(w, &http.Cookie{
-		Name:     uiSessionCookieName,
+		Name:     s.uiSessionCookieName(),
 		Value:    "",
 		Path:     "/",
 		HttpOnly: true,
@@ -82,7 +82,7 @@ func (s *Server) clearUISessions(w http.ResponseWriter) {
 		Expires:  time.Unix(0, 0).UTC(),
 	})
 	http.SetCookie(w, &http.Cookie{
-		Name:     uiCSRFCookieName,
+		Name:     s.uiCSRFCookieName(),
 		Value:    "",
 		Path:     "/",
 		Secure:   true,
@@ -93,7 +93,7 @@ func (s *Server) clearUISessions(w http.ResponseWriter) {
 }
 
 func (s *Server) hasValidUISession(r *http.Request) bool {
-	cookie, err := r.Cookie(uiSessionCookieName)
+	cookie, err := r.Cookie(s.uiSessionCookieName())
 	if err != nil || strings.TrimSpace(cookie.Value) == "" {
 		return false
 	}
@@ -121,8 +121,8 @@ func (s *Server) hasValidUISession(r *http.Request) bool {
 	return true
 }
 
-func hasValidUICSRF(r *http.Request) bool {
-	cookie, err := r.Cookie(uiCSRFCookieName)
+func (s *Server) hasValidUICSRF(r *http.Request) bool {
+	cookie, err := r.Cookie(s.uiCSRFCookieName())
 	if err != nil || strings.TrimSpace(cookie.Value) == "" {
 		return false
 	}
@@ -144,6 +144,37 @@ func (s *Server) pruneUISessionsLocked(now time.Time) {
 func hashUISessionToken(token string) string {
 	sum := sha256.Sum256([]byte(token))
 	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func (s *Server) uiSessionCookieName() string {
+	return scopedUICookieName(uiSessionCookieName, s.config.FrontendPort)
+}
+
+func (s *Server) uiCSRFCookieName() string {
+	return scopedUICookieName(uiCSRFCookieName, s.config.FrontendPort)
+}
+
+func scopedUICookieName(base string, frontendPort string) string {
+	frontendPort = strings.TrimSpace(frontendPort)
+	if frontendPort == "" {
+		return base
+	}
+	var scope strings.Builder
+	for _, char := range frontendPort {
+		switch {
+		case char >= 'a' && char <= 'z',
+			char >= 'A' && char <= 'Z',
+			char >= '0' && char <= '9',
+			char == '-', char == '_':
+			scope.WriteRune(char)
+		default:
+			scope.WriteByte('_')
+		}
+	}
+	if scope.Len() == 0 {
+		return base
+	}
+	return base + "_" + scope.String()
 }
 
 func isUISessionExempt(path string) bool {

--- a/backend/internal/api/ui_session_test.go
+++ b/backend/internal/api/ui_session_test.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/aipermission/aipermission/backend/internal/config"
 )
 
 func TestUISessionCookiesUseSecureLocalBoundary(t *testing.T) {
@@ -28,4 +31,76 @@ func TestUISessionCookiesUseSecureLocalBoundary(t *testing.T) {
 			t.Fatalf("cleared cookie %s should use Secure flag", cookie.Name)
 		}
 	}
+}
+
+func TestUISessionCookiesAreScopedByFrontendPort(t *testing.T) {
+	first := &Server{
+		config:         config.Config{FrontendPort: "3210"},
+		activeDatabase: "default",
+		uiSessions:     map[string]uiSessionRecord{},
+	}
+	second := &Server{
+		config:         config.Config{FrontendPort: "3212"},
+		activeDatabase: "default",
+		uiSessions:     map[string]uiSessionRecord{},
+	}
+
+	firstResponse := httptest.NewRecorder()
+	if err := first.issueUISession(firstResponse); err != nil {
+		t.Fatalf("issue first ui session: %v", err)
+	}
+	secondResponse := httptest.NewRecorder()
+	if err := second.issueUISession(secondResponse); err != nil {
+		t.Fatalf("issue second ui session: %v", err)
+	}
+
+	firstCookies := cookiesByName(firstResponse.Result().Cookies())
+	secondCookies := cookiesByName(secondResponse.Result().Cookies())
+	firstSession := firstCookies["aipermission_ui_session_3210"]
+	secondSession := secondCookies["aipermission_ui_session_3212"]
+	if firstSession == nil || secondSession == nil {
+		t.Fatalf("expected port-scoped session cookies, got first=%v second=%v", firstCookies, secondCookies)
+	}
+	if firstCookies["aipermission_csrf_3210"] == nil || secondCookies["aipermission_csrf_3212"] == nil {
+		t.Fatalf("expected port-scoped csrf cookies, got first=%v second=%v", firstCookies, secondCookies)
+	}
+
+	firstRequest := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	firstRequest.AddCookie(firstSession)
+	firstRequest.AddCookie(secondSession)
+	if !first.hasValidUISession(firstRequest) {
+		t.Fatal("first instance should accept its own session cookie")
+	}
+	if !second.hasValidUISession(firstRequest) {
+		t.Fatal("second instance should accept its own session cookie without displacing the first")
+	}
+
+	firstCSRF := firstCookies["aipermission_csrf_3210"]
+	secondCSRF := secondCookies["aipermission_csrf_3212"]
+	firstMutation := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	firstMutation.AddCookie(firstCSRF)
+	firstMutation.AddCookie(secondCSRF)
+	firstMutation.Header.Set(uiCSRFHeaderName, firstCSRF.Value)
+	if !first.hasValidUICSRF(firstMutation) {
+		t.Fatal("first instance should accept its own csrf cookie")
+	}
+	if second.hasValidUICSRF(firstMutation) {
+		t.Fatal("second instance should reject the first instance csrf header")
+	}
+
+	secondMutation := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	secondMutation.AddCookie(firstCSRF)
+	secondMutation.AddCookie(secondCSRF)
+	secondMutation.Header.Set(uiCSRFHeaderName, secondCSRF.Value)
+	if !second.hasValidUICSRF(secondMutation) {
+		t.Fatal("second instance should accept its own csrf cookie")
+	}
+}
+
+func cookiesByName(cookies []*http.Cookie) map[string]*http.Cookie {
+	result := make(map[string]*http.Cookie, len(cookies))
+	for _, cookie := range cookies {
+		result[cookie.Name] = cookie
+	}
+	return result
 }

--- a/backend/internal/connectors/builtin/registry.go
+++ b/backend/internal/connectors/builtin/registry.go
@@ -7,6 +7,7 @@ import (
 	clickhouseconnector "github.com/aipermission/aipermission/backend/internal/connectors/clickhouse"
 	dockerconnector "github.com/aipermission/aipermission/backend/internal/connectors/docker"
 	_ "github.com/aipermission/aipermission/backend/internal/connectors/docker/apiadapter"
+	kafkaconnector "github.com/aipermission/aipermission/backend/internal/connectors/kafka"
 	kubernetesconnector "github.com/aipermission/aipermission/backend/internal/connectors/kubernetes"
 	_ "github.com/aipermission/aipermission/backend/internal/connectors/kubernetes/apiadapter"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
@@ -22,6 +23,7 @@ func RegisterAll(registry *connectors.Registry) error {
 	for _, connector := range []connectors.Connector{
 		clickhouseconnector.New(),
 		dockerconnector.New(),
+		kafkaconnector.New(),
 		kubernetesconnector.New(),
 		postgresconnector.New(),
 		rabbitmqconnector.New(),

--- a/backend/internal/connectors/builtin/registry_test.go
+++ b/backend/internal/connectors/builtin/registry_test.go
@@ -8,6 +8,7 @@ import (
 	clickhouseconnector "github.com/aipermission/aipermission/backend/internal/connectors/clickhouse"
 	"github.com/aipermission/aipermission/backend/internal/connectors/connectortest"
 	dockerconnector "github.com/aipermission/aipermission/backend/internal/connectors/docker"
+	kafkaconnector "github.com/aipermission/aipermission/backend/internal/connectors/kafka"
 	kubernetesconnector "github.com/aipermission/aipermission/backend/internal/connectors/kubernetes"
 	postgresconnector "github.com/aipermission/aipermission/backend/internal/connectors/postgres"
 	rabbitmqconnector "github.com/aipermission/aipermission/backend/internal/connectors/rabbitmq"
@@ -36,6 +37,13 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	}
 	if docker.Label() != dockerconnector.Label {
 		t.Fatalf("docker label = %q", docker.Label())
+	}
+	kafka, ok := registry.Get(kafkaconnector.Kind)
+	if !ok {
+		t.Fatal("expected kafka connector")
+	}
+	if kafka.Label() != kafkaconnector.Label {
+		t.Fatalf("kafka label = %q", kafka.Label())
 	}
 	kubernetes, ok := registry.Get(kubernetesconnector.Kind)
 	if !ok {
@@ -83,7 +91,7 @@ func TestNewRegistryIncludesBuiltInConnectors(t *testing.T) {
 	}
 
 	infos := registry.List()
-	if len(infos) != 8 || infos[0].Kind != clickhouseconnector.Kind || infos[1].Kind != dockerconnector.Kind || infos[2].Kind != kubernetesconnector.Kind || infos[3].Kind != postgresconnector.Kind || infos[4].Kind != rabbitmqconnector.Kind || infos[5].Kind != redisconnector.Kind || infos[6].Kind != s3connector.Kind || infos[7].Kind != sshconnector.Kind {
+	if len(infos) != 9 || infos[0].Kind != clickhouseconnector.Kind || infos[1].Kind != dockerconnector.Kind || infos[2].Kind != kafkaconnector.Kind || infos[3].Kind != kubernetesconnector.Kind || infos[4].Kind != postgresconnector.Kind || infos[5].Kind != rabbitmqconnector.Kind || infos[6].Kind != redisconnector.Kind || infos[7].Kind != s3connector.Kind || infos[8].Kind != sshconnector.Kind {
 		t.Fatalf("unexpected connector list: %#v", infos)
 	}
 }
@@ -211,6 +219,28 @@ func builtInDeterminismSamples(t *testing.T, kind string) (connectors.TargetView
 				kubernetesconnector.ActionDescribe:       {"resource_type": "deployment", "namespace": "production", "name": "api"},
 				kubernetesconnector.ActionLogs:           {"namespace": "production", "pod": "api-123", "container": "api", "tail": 100},
 				kubernetesconnector.ActionRolloutRestart: {"namespace": "production", "deployment": "api"},
+			}
+	case kafkaconnector.Kind:
+		return connectors.TargetView{
+				ID:            9,
+				Ref:           "kafka:9:90",
+				ConnectorKind: kafkaconnector.Kind,
+				Name:          "events",
+				Config:        map[string]any{"server_family": "redpanda", "connection_mode": "direct", "bootstrap_brokers": "127.0.0.1:9092", "tls_enabled": false},
+			}, connectors.CredentialProfileView{
+				ID:            90,
+				TargetID:      9,
+				ConnectorKind: kafkaconnector.Kind,
+				Kind:          "sasl",
+				Label:         "monitor",
+				Public:        map[string]any{"mechanism": "none"},
+			}, map[string]map[string]any{
+				kafkaconnector.ActionClusterInfo:           {},
+				kafkaconnector.ActionListTopics:            {"include_internal": false},
+				kafkaconnector.ActionDescribeTopic:         {"topic": "events"},
+				kafkaconnector.ActionListConsumerGroups:    {},
+				kafkaconnector.ActionDescribeConsumerGroup: {"group": "workers"},
+				kafkaconnector.ActionReadMessages:          {"topic": "events", "partition": 0, "start_position": "recent", "offset": "0", "max_records": 20, "max_bytes": 262144, "wait_seconds": 2},
 			}
 	case postgresconnector.Kind:
 		return connectors.TargetView{

--- a/backend/internal/connectors/connector.go
+++ b/backend/internal/connectors/connector.go
@@ -45,6 +45,14 @@ type TestableConnector interface {
 	TestConnection(ctx context.Context, runtime RuntimeContext) (TestResult, error)
 }
 
+// CredentialProfileValidator is an optional connector contract for semantic
+// validation that cannot be expressed by the primitive credential schema.
+// Previous is nil for creates. On updates, connectors may use its public
+// metadata to decide whether omitted secret material can safely be preserved.
+type CredentialProfileValidator interface {
+	ValidateCredentialProfile(kind string, public, secret map[string]any, previous *CredentialProfileView) error
+}
+
 // CredentialProvisioner is an optional connector contract for operator-driven
 // credential profile provisioning. Core owns profile persistence and vault
 // writes; the connector owns external service changes such as creating or

--- a/backend/internal/connectors/kafka/client.go
+++ b/backend/internal/connectors/kafka/client.go
@@ -1,0 +1,306 @@
+package kafka
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/sasl"
+	"github.com/twmb/franz-go/pkg/sasl/plain"
+	"github.com/twmb/franz-go/pkg/sasl/scram"
+)
+
+const clientID = "aipermission-kafka-connector"
+
+func newClient(ctx context.Context, runtime connectors.RuntimeContext, extraOptions ...kgo.Opt) (*kgo.Client, error) {
+	config, err := parseClientConfig(ctx, runtime)
+	if err != nil {
+		return nil, err
+	}
+	transport, ok := runtime.Capability(connectors.NetworkTransportCapabilityName).(connectors.NetworkTransport)
+	if !ok || transport == nil {
+		return nil, fmt.Errorf("network transport capability is unavailable")
+	}
+
+	opts := []kgo.Opt{
+		kgo.ClientID(clientID),
+		kgo.SeedBrokers(config.Brokers...),
+		kgo.RequestTimeoutOverhead(5 * time.Second),
+		kgo.DialTimeout(10 * time.Second),
+		kgo.FetchMaxBytes(1048576),
+		kgo.FetchMaxPartitionBytes(1048576),
+		kgo.MaxConcurrentFetches(1),
+		kgo.BrokerMaxReadBytes(2097152),
+		kgo.WithDecompressor(boundedDecompressor{maxBytes: maxDecompressedBatchBytes}),
+		kgo.Dialer(func(dialCtx context.Context, _, address string) (net.Conn, error) {
+			host, port, err := splitBrokerAddress(address)
+			if err != nil {
+				return nil, err
+			}
+			connection, err := transport.DialConnectorTCP(dialCtx, connectors.NetworkDialRequest{
+				Mode:               config.ConnectionMode,
+				Host:               host,
+				Port:               port,
+				TransportTargetRef: config.TransportTargetRef,
+			})
+			if err != nil {
+				return nil, err
+			}
+			if !config.TLSEnabled {
+				return connection, nil
+			}
+			serverName := config.TLSServerName
+			if serverName == "" {
+				serverName = host
+			}
+			tlsConnection := tls.Client(connection, &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				ServerName: serverName,
+				RootCAs:    config.RootCAs,
+			})
+			if err := tlsConnection.HandshakeContext(dialCtx); err != nil {
+				_ = connection.Close()
+				return nil, fmt.Errorf("Kafka TLS handshake failed: %w", err)
+			}
+			return tlsConnection, nil
+		}),
+	}
+	if config.Mechanism != nil {
+		opts = append(opts, kgo.SASL(config.Mechanism))
+	}
+	opts = append(opts, extraOptions...)
+	return kgo.NewClient(opts...)
+}
+
+type clientConfig struct {
+	Brokers            []string
+	ConnectionMode     string
+	TransportTargetRef string
+	TLSEnabled         bool
+	TLSServerName      string
+	RootCAs            *x509.CertPool
+	Mechanism          sasl.Mechanism
+}
+
+func parseClientConfig(ctx context.Context, runtime connectors.RuntimeContext) (clientConfig, error) {
+	brokers, err := parseBrokerList(stringValue(runtime.Target.Config, "bootstrap_brokers", ""))
+	if err != nil {
+		return clientConfig{}, err
+	}
+	mode := stringValue(runtime.Target.Config, "connection_mode", "direct")
+	if mode != "direct" && mode != "over_ssh" {
+		return clientConfig{}, fmt.Errorf("unsupported connection mode %q", mode)
+	}
+	transportRef := strings.TrimSpace(stringValue(runtime.Target.Config, "transport_target_ref", ""))
+	if mode == "over_ssh" && transportRef == "" {
+		return clientConfig{}, fmt.Errorf("transport_target_ref is required for over_ssh mode")
+	}
+	tlsEnabled := boolValue(runtime.Target.Config, "tls_enabled", false)
+	var roots *x509.CertPool
+	if pem := strings.TrimSpace(stringValue(runtime.Target.Config, "tls_ca_pem", "")); pem != "" {
+		if !tlsEnabled {
+			return clientConfig{}, fmt.Errorf("tls_enabled is required when tls_ca_pem is configured")
+		}
+		roots, err = x509.SystemCertPool()
+		if err != nil || roots == nil {
+			roots = x509.NewCertPool()
+		}
+		if !roots.AppendCertsFromPEM([]byte(pem)) {
+			return clientConfig{}, fmt.Errorf("tls_ca_pem does not contain a valid PEM certificate")
+		}
+	}
+	mechanismName := stringValue(runtime.Profile.Public, "mechanism", "none")
+	var mechanism sasl.Mechanism
+	if mechanismName != "none" {
+		username := strings.TrimSpace(stringValue(runtime.Profile.Public, "username", ""))
+		if username == "" {
+			return clientConfig{}, fmt.Errorf("username is required for SASL mechanism %s", mechanismName)
+		}
+		if runtime.Secrets == nil {
+			return clientConfig{}, fmt.Errorf("credential secret access is unavailable")
+		}
+		password, secretErr := runtime.Secrets.GetSecret(ctx, "password")
+		if secretErr != nil {
+			return clientConfig{}, fmt.Errorf("read Kafka credential password: %w", secretErr)
+		}
+		if password == "" {
+			return clientConfig{}, fmt.Errorf("password is required for SASL mechanism %s", mechanismName)
+		}
+		switch mechanismName {
+		case "plain":
+			if !tlsEnabled && !boolValue(runtime.Target.Config, "allow_insecure_plain_sasl", false) {
+				return clientConfig{}, fmt.Errorf("PLAIN SASL requires TLS unless insecure PLAIN is explicitly allowed on this connector")
+			}
+			mechanism = plain.Auth{User: username, Pass: password}.AsMechanism()
+		case "scram_sha_256":
+			mechanism = scram.Auth{User: username, Pass: password}.AsSha256Mechanism()
+		case "scram_sha_512":
+			mechanism = scram.Auth{User: username, Pass: password}.AsSha512Mechanism()
+		default:
+			return clientConfig{}, fmt.Errorf("unsupported SASL mechanism %q", mechanismName)
+		}
+	}
+	return clientConfig{
+		Brokers:            brokers,
+		ConnectionMode:     mode,
+		TransportTargetRef: transportRef,
+		TLSEnabled:         tlsEnabled,
+		TLSServerName:      strings.TrimSpace(stringValue(runtime.Target.Config, "tls_server_name", "")),
+		RootCAs:            roots,
+		Mechanism:          mechanism,
+	}, nil
+}
+
+func parseBrokerList(value string) ([]string, error) {
+	fields := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\r' || r == '\t' || r == ' '
+	})
+	seen := map[string]bool{}
+	brokers := make([]string, 0, len(fields))
+	for _, field := range fields {
+		host, port, err := splitBrokerAddress(field)
+		if err != nil {
+			return nil, err
+		}
+		address := net.JoinHostPort(host, strconv.Itoa(port))
+		if !seen[address] {
+			seen[address] = true
+			brokers = append(brokers, address)
+		}
+	}
+	if len(brokers) == 0 {
+		return nil, fmt.Errorf("at least one bootstrap broker is required")
+	}
+	if len(brokers) > 20 {
+		return nil, fmt.Errorf("bootstrap broker count must not exceed 20")
+	}
+	return brokers, nil
+}
+
+func splitBrokerAddress(address string) (string, int, error) {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return "", 0, fmt.Errorf("broker address is empty")
+	}
+	host, portText, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", 0, fmt.Errorf("broker %q must use host:port format: %w", address, err)
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "", 0, fmt.Errorf("broker %q has an empty host", address)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port < 1 || port > 65535 {
+		return "", 0, fmt.Errorf("broker %q has an invalid port", address)
+	}
+	return host, port, nil
+}
+
+func clientBrokerMetadata(ctx context.Context, client *kgo.Client) (kadm.Metadata, error) {
+	requestCtx, admin, cancel := newAdminRequest(ctx, client, 15*time.Second)
+	defer cancel()
+	return admin.BrokerMetadata(requestCtx)
+}
+
+func newAdminRequest(ctx context.Context, client *kgo.Client, timeout time.Duration) (context.Context, *kadm.Client, context.CancelFunc) {
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	return requestCtx, kadm.NewClient(client), cancel
+}
+
+func testFailure(err error) connectors.TestResult {
+	message := err.Error()
+	status := connectors.TestUnknownError
+	lower := strings.ToLower(message)
+	switch {
+	case strings.Contains(lower, "tls"), strings.Contains(lower, "certificate"), strings.Contains(lower, "x509"):
+		status = connectors.TestFailedTLS
+	case strings.Contains(lower, "sasl"), strings.Contains(lower, "authentication"), strings.Contains(lower, "credential"):
+		status = connectors.TestFailedAuth
+	case strings.Contains(lower, "authorization"), strings.Contains(lower, "not authorized"):
+		status = connectors.TestFailedPermission
+	case errors.Is(err, context.DeadlineExceeded), strings.Contains(lower, "dial"), strings.Contains(lower, "connection refused"), strings.Contains(lower, "no such host"):
+		status = connectors.TestFailedNetwork
+	}
+	return connectors.TestResult{Status: status, Message: message}
+}
+
+func stringValue(values map[string]any, key, fallback string) string {
+	value, ok := values[key]
+	if !ok || value == nil {
+		return fallback
+	}
+	text := strings.TrimSpace(fmt.Sprint(value))
+	if text == "" {
+		return fallback
+	}
+	return text
+}
+
+func boolValue(values map[string]any, key string, fallback bool) bool {
+	value, ok := values[key]
+	if !ok || value == nil {
+		return fallback
+	}
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		parsed, err := strconv.ParseBool(typed)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func intValue(values map[string]any, key string, fallback int) int {
+	value, ok := values[key]
+	if !ok || value == nil {
+		return fallback
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case string:
+		parsed, err := strconv.Atoi(typed)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func int64Value(values map[string]any, key string, fallback int64) int64 {
+	value, ok := values[key]
+	if !ok || value == nil {
+		return fallback
+	}
+	switch typed := value.(type) {
+	case int:
+		return int64(typed)
+	case int64:
+		return typed
+	case float64:
+		return int64(typed)
+	case string:
+		parsed, err := strconv.ParseInt(typed, 10, 64)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}

--- a/backend/internal/connectors/kafka/decompressor.go
+++ b/backend/internal/connectors/kafka/decompressor.go
@@ -1,0 +1,116 @@
+package kafka
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/klauspost/compress/s2"
+	"github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+const maxDecompressedBatchBytes = 2 << 20
+
+var xerialSnappyPrefix = []byte{130, 83, 78, 65, 80, 80, 89, 0}
+
+type boundedDecompressor struct {
+	maxBytes int64
+}
+
+func (d boundedDecompressor) Decompress(src []byte, codec kgo.CompressionCodecType) ([]byte, error) {
+	if d.maxBytes < 1 {
+		return nil, errors.New("invalid Kafka decompression limit")
+	}
+	switch codec {
+	case kgo.CodecNone:
+		if int64(len(src)) > d.maxBytes {
+			return nil, d.tooLarge()
+		}
+		return src, nil
+	case kgo.CodecGzip:
+		reader, err := gzip.NewReader(bytes.NewReader(src))
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Close()
+		return d.readBounded(reader)
+	case kgo.CodecSnappy:
+		return d.decodeSnappy(src)
+	case kgo.CodecLz4:
+		return d.readBounded(lz4.NewReader(bytes.NewReader(src)))
+	case kgo.CodecZstd:
+		reader, err := zstd.NewReader(
+			bytes.NewReader(src),
+			zstd.WithDecoderConcurrency(1),
+			zstd.WithDecoderLowmem(true),
+			zstd.WithDecoderMaxMemory(uint64(d.maxBytes)),
+		)
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Close()
+		return d.readBounded(reader)
+	default:
+		return nil, fmt.Errorf("unsupported Kafka compression codec %d", codec)
+	}
+}
+
+func (d boundedDecompressor) readBounded(reader io.Reader) ([]byte, error) {
+	var output bytes.Buffer
+	if _, err := io.Copy(&output, io.LimitReader(reader, d.maxBytes+1)); err != nil {
+		return nil, err
+	}
+	if int64(output.Len()) > d.maxBytes {
+		return nil, d.tooLarge()
+	}
+	return output.Bytes(), nil
+}
+
+func (d boundedDecompressor) decodeSnappy(src []byte) ([]byte, error) {
+	if len(src) > 16 && bytes.HasPrefix(src, xerialSnappyPrefix) {
+		src = src[16:]
+		output := make([]byte, 0)
+		for len(src) > 0 {
+			if len(src) < 4 {
+				return nil, errors.New("malformed xerial snappy framing")
+			}
+			chunkSize := binary.BigEndian.Uint32(src[:4])
+			src = src[4:]
+			if uint64(chunkSize) > uint64(len(src)) {
+				return nil, errors.New("malformed xerial snappy chunk")
+			}
+			size := int(chunkSize)
+			decodedLength, err := s2.DecodedLen(src[:size])
+			if err != nil {
+				return nil, err
+			}
+			if int64(decodedLength) > d.maxBytes-int64(len(output)) {
+				return nil, d.tooLarge()
+			}
+			decoded, err := s2.Decode(nil, src[:size])
+			if err != nil {
+				return nil, err
+			}
+			output = append(output, decoded...)
+			src = src[size:]
+		}
+		return output, nil
+	}
+	decodedLength, err := s2.DecodedLen(src)
+	if err != nil {
+		return nil, err
+	}
+	if int64(decodedLength) > d.maxBytes {
+		return nil, d.tooLarge()
+	}
+	return s2.Decode(nil, src)
+}
+
+func (d boundedDecompressor) tooLarge() error {
+	return fmt.Errorf("Kafka record batch exceeds the %d-byte decompression limit", d.maxBytes)
+}

--- a/backend/internal/connectors/kafka/kafka.go
+++ b/backend/internal/connectors/kafka/kafka.go
@@ -1,0 +1,377 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+)
+
+const (
+	Kind    = "kafka"
+	Label   = "Kafka / Redpanda"
+	Version = "0.2"
+
+	ActionClusterInfo           = "cluster_info"
+	ActionListTopics            = "list_topics"
+	ActionDescribeTopic         = "describe_topic"
+	ActionListConsumerGroups    = "list_consumer_groups"
+	ActionDescribeConsumerGroup = "describe_consumer_group"
+	ActionReadMessages          = "read_messages"
+)
+
+type Connector struct{}
+
+func New() *Connector { return &Connector{} }
+
+func (*Connector) Kind() string    { return Kind }
+func (*Connector) Label() string   { return Label }
+func (*Connector) Version() string { return Version }
+
+func (*Connector) TargetSchema() connectors.Schema {
+	return connectors.Schema{Fields: []connectors.Field{
+		{Name: "server_family", Label: "Server family", Type: connectors.FieldSelect, Required: true, Default: "kafka", Options: []connectors.FieldOption{
+			{Value: "kafka", Label: "Apache Kafka"},
+			{Value: "redpanda", Label: "Redpanda"},
+		}},
+		{Name: "connection_mode", Label: "Connection mode", Type: connectors.FieldSelect, Required: true, Default: "direct", Options: []connectors.FieldOption{
+			{Value: "direct", Label: "Direct from this gateway"},
+			{Value: "over_ssh", Label: "Over an SSH connector profile"},
+		}},
+		{Name: "bootstrap_brokers", Label: "Bootstrap brokers", Type: connectors.FieldMultiline, Required: true, Description: "One host:port per line or a comma-separated list."},
+		{Name: "transport_target_ref", Label: "SSH transport profile", Type: connectors.FieldString},
+		{Name: "tls_enabled", Label: "Use TLS", Type: connectors.FieldBoolean, Default: false},
+		{Name: "allow_insecure_plain_sasl", Label: "Allow PLAIN SASL without TLS", Type: connectors.FieldBoolean, Default: false, Description: "Explicitly permit plaintext PLAIN credentials on a trusted private network."},
+		{Name: "tls_server_name", Label: "TLS server name", Type: connectors.FieldString},
+		{Name: "tls_ca_pem", Label: "Custom CA certificate", Type: connectors.FieldFileText},
+	}}
+}
+
+func (*Connector) CredentialSchemas() []connectors.CredentialSchema {
+	return []connectors.CredentialSchema{{
+		Kind:        "sasl",
+		Label:       "SASL profile",
+		Description: "Optional PLAIN or SCRAM credentials. Select None for brokers without SASL.",
+		Schema: connectors.Schema{Fields: []connectors.Field{
+			{Name: "mechanism", Label: "SASL mechanism", Type: connectors.FieldSelect, Required: true, Default: "none", Options: []connectors.FieldOption{
+				{Value: "none", Label: "None"},
+				{Value: "plain", Label: "PLAIN"},
+				{Value: "scram_sha_256", Label: "SCRAM-SHA-256"},
+				{Value: "scram_sha_512", Label: "SCRAM-SHA-512"},
+			}},
+			{Name: "username", Label: "Username", Type: connectors.FieldString},
+			{Name: "password", Label: "Password", Type: connectors.FieldSecret, Secret: true},
+		}},
+	}}
+}
+
+func (*Connector) GetHelp(_ context.Context, target connectors.TargetView) (connectors.ConnectorHelp, error) {
+	family := familyLabel(stringValue(target.Config, "server_family", "kafka"))
+	return connectors.ConnectorHelp{
+		Title:       family + " connector",
+		Summary:     "Inspect cluster metadata, topics, consumer groups, lag, and bounded message samples without joining a consumer group or committing offsets.",
+		Connector:   Label,
+		ConnectorID: Kind,
+		Usage: []string{
+			"Call list_topics before describe_topic or read_messages.",
+			"Use describe_consumer_group to inspect members, committed offsets, and lag.",
+			"read_messages uses explicit partition assignment and never commits consumer offsets.",
+		},
+		Warnings: []string{
+			"Message keys, values, and headers can contain secrets or personal data. Read only what the operator approved.",
+			"Read results are bounded, but they are persisted in local encrypted history.",
+		},
+	}, nil
+}
+
+func (*Connector) GetActionList(context.Context, connectors.TargetView, connectors.CredentialProfileView) ([]connectors.ActionDefinition, error) {
+	return readActionDefinitions(), nil
+}
+
+func (*Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) (connectors.PreparedAction, error) {
+	action, ok := readActionDefinition(req.ActionName)
+	if !ok {
+		return connectors.PreparedAction{}, fmt.Errorf("unsupported Kafka action %q", req.ActionName)
+	}
+	input, err := connectors.NormalizeSchemaValues(action.InputSchema, req.Input)
+	if err != nil {
+		return connectors.PreparedAction{}, err
+	}
+	if err := canonicalizeReadInput(req.ActionName, input); err != nil {
+		return connectors.PreparedAction{}, err
+	}
+	if err := validateReadInput(req.ActionName, input); err != nil {
+		return connectors.PreparedAction{}, err
+	}
+	summary := action.Label
+	switch req.ActionName {
+	case ActionDescribeTopic:
+		summary = "Describe topic " + stringValue(input, "topic", "")
+	case ActionDescribeConsumerGroup:
+		summary = "Describe consumer group " + stringValue(input, "group", "")
+	case ActionReadMessages:
+		summary = fmt.Sprintf("Read up to %d messages from %s partition %d", intValue(input, "max_records", 20), stringValue(input, "topic", ""), intValue(input, "partition", 0))
+	}
+	return connectors.PreparedAction{
+		ConnectorKind: Kind,
+		TargetRef:     req.Target.Ref,
+		ProfileID:     req.Profile.ID,
+		ActionName:    req.ActionName,
+		Risk:          action.Risk,
+		Title:         action.Label,
+		Summary:       summary,
+		Preview:       copyMap(input),
+		Payload:       copyMap(input),
+		ContextMaterial: map[string]any{
+			"target_config":   req.Target.Config,
+			"profile_public":  req.Profile.Public,
+			"secret_revision": req.Profile.SecretRevision,
+		},
+	}, nil
+}
+
+func (*Connector) ValidateCredentialProfile(kind string, public, secret map[string]any, previous *connectors.CredentialProfileView) error {
+	if kind != "sasl" {
+		return fmt.Errorf("unsupported Kafka credential kind %q", kind)
+	}
+	mechanism := stringValue(public, "mechanism", "none")
+	if mechanism == "none" {
+		return nil
+	}
+	if strings.TrimSpace(stringValue(public, "username", "")) == "" {
+		return fmt.Errorf("username is required for SASL mechanism %s", mechanism)
+	}
+	if strings.TrimSpace(stringValue(secret, "password", "")) != "" {
+		return nil
+	}
+	if previous != nil && stringValue(previous.Public, "mechanism", "none") != "none" {
+		return nil
+	}
+	return fmt.Errorf("password is required when enabling SASL")
+}
+
+func (c *Connector) ExecuteAction(ctx context.Context, runtime connectors.RuntimeContext, action connectors.PreparedAction) (connectors.ActionResult, error) {
+	if action.ConnectorKind != Kind {
+		return connectors.ActionResult{}, fmt.Errorf("prepared action connector kind %q is not %q", action.ConnectorKind, Kind)
+	}
+	if action.ActionName == ActionReadMessages {
+		partition, err := checkedInt32(int64(intValue(action.Payload, "partition", 0)), "partition")
+		if err != nil {
+			return failedResult(err), nil
+		}
+		return executeReadMessages(ctx, runtime, readMessagesRequest{
+			Topic:       stringValue(action.Payload, "topic", ""),
+			Partition:   partition,
+			Start:       stringValue(action.Payload, "start_position", "recent"),
+			Offset:      int64Value(action.Payload, "offset", 0),
+			MaxRecords:  intValue(action.Payload, "max_records", 20),
+			MaxBytes:    intValue(action.Payload, "max_bytes", 262144),
+			WaitSeconds: intValue(action.Payload, "wait_seconds", 2),
+		})
+	}
+	client, err := newClient(ctx, runtime)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	defer client.Close()
+
+	switch action.ActionName {
+	case ActionClusterInfo:
+		return executeClusterInfo(ctx, client)
+	case ActionListTopics:
+		return executeListTopics(ctx, client, boolValue(action.Payload, "include_internal", false))
+	case ActionDescribeTopic:
+		return executeDescribeTopic(ctx, client, stringValue(action.Payload, "topic", ""))
+	case ActionListConsumerGroups:
+		return executeListConsumerGroups(ctx, client)
+	case ActionDescribeConsumerGroup:
+		return executeDescribeConsumerGroup(ctx, client, stringValue(action.Payload, "group", ""))
+	default:
+		return connectors.ActionResult{}, fmt.Errorf("unsupported Kafka action %q", action.ActionName)
+	}
+}
+
+func (c *Connector) TestConnection(ctx context.Context, runtime connectors.RuntimeContext) (connectors.TestResult, error) {
+	client, err := newClient(ctx, runtime)
+	if err != nil {
+		return testFailure(err), nil
+	}
+	defer client.Close()
+	metadata, err := clientBrokerMetadata(ctx, client)
+	if err != nil {
+		return testFailure(err), nil
+	}
+	return connectors.TestResult{
+		Status:  connectors.TestOK,
+		Message: fmt.Sprintf("%s cluster is reachable through %d broker(s).", familyLabel(stringValue(runtime.Target.Config, "server_family", "kafka")), len(metadata.Brokers)),
+		Details: map[string]any{"cluster_id": metadata.Cluster, "controller_id": metadata.Controller, "broker_count": len(metadata.Brokers)},
+	}, nil
+}
+
+func readActionDefinitions() []connectors.ActionDefinition {
+	return []connectors.ActionDefinition{
+		{Name: ActionClusterInfo, Label: "Cluster info", Description: "Read cluster id, controller, and bounded broker endpoint metadata.", Category: "cluster", Risk: connectors.RiskRead, InputSchema: connectors.Schema{}, OutputHint: connectors.OutputHint{Format: "json", MaxRows: 200, MaxBytes: 262144}},
+		{Name: ActionListTopics, Label: "List topics", Description: "List visible topics with partition and replication metadata.", Category: "topics", Risk: connectors.RiskRead, InputSchema: connectors.Schema{Fields: []connectors.Field{
+			{Name: "include_internal", Label: "Include internal topics", Type: connectors.FieldBoolean, Default: false},
+		}}, OutputHint: connectors.OutputHint{Format: "table", MaxRows: 1000, MaxBytes: 524288}},
+		{Name: ActionDescribeTopic, Label: "Describe topic", Description: "Read partition leaders, replicas, ISR, and end offsets for one topic.", Category: "topics", Risk: connectors.RiskRead, InputSchema: connectors.Schema{Fields: []connectors.Field{
+			{Name: "topic", Label: "Topic", Type: connectors.FieldString, Required: true},
+		}}, OutputHint: connectors.OutputHint{Format: "json", MaxRows: 1000, MaxBytes: 524288}},
+		{Name: ActionListConsumerGroups, Label: "List consumer groups", Description: "List visible consumer groups and their current states.", Category: "consumer_groups", Risk: connectors.RiskRead, InputSchema: connectors.Schema{}, OutputHint: connectors.OutputHint{Format: "table", MaxRows: 1000, MaxBytes: 524288}},
+		{Name: ActionDescribeConsumerGroup, Label: "Describe consumer group", Description: "Read group members, assignments, committed offsets, and bounded lag details.", Category: "consumer_groups", Risk: connectors.RiskRead, InputSchema: connectors.Schema{Fields: []connectors.Field{
+			{Name: "group", Label: "Consumer group", Type: connectors.FieldString, Required: true},
+		}}, OutputHint: connectors.OutputHint{Format: "json", MaxRows: 2000, MaxBytes: 1048576}},
+		{Name: ActionReadMessages, Label: "Read messages", Description: "Read a bounded sample from one explicit topic partition without joining a group or committing offsets.", Category: "messages", Risk: connectors.RiskRead, InputSchema: connectors.Schema{Fields: []connectors.Field{
+			{Name: "topic", Label: "Topic", Type: connectors.FieldString, Required: true},
+			{Name: "partition", Label: "Partition", Type: connectors.FieldNumber, Required: true, Default: 0},
+			{Name: "start_position", Label: "Start position", Type: connectors.FieldSelect, Required: true, Default: "recent", Options: []connectors.FieldOption{
+				{Value: "recent", Label: "Recent messages"},
+				{Value: "earliest", Label: "Earliest available"},
+				{Value: "offset", Label: "Explicit offset"},
+			}},
+			{Name: "offset", Label: "Offset", Type: connectors.FieldString, Default: "0"},
+			{Name: "max_records", Label: "Maximum records", Type: connectors.FieldNumber, Default: 20},
+			{Name: "max_bytes", Label: "Maximum payload bytes", Type: connectors.FieldNumber, Default: 262144},
+			{Name: "wait_seconds", Label: "Wait seconds", Type: connectors.FieldNumber, Default: 2},
+		}}, OutputHint: connectors.OutputHint{Format: "json", MaxRows: 100, MaxBytes: 524288}},
+	}
+}
+
+func readActionDefinition(name string) (connectors.ActionDefinition, bool) {
+	for _, action := range readActionDefinitions() {
+		if action.Name == name {
+			return action, true
+		}
+	}
+	return connectors.ActionDefinition{}, false
+}
+
+func validateReadInput(action string, input map[string]any) error {
+	switch action {
+	case ActionDescribeTopic, ActionReadMessages:
+		if strings.TrimSpace(stringValue(input, "topic", "")) == "" {
+			return fmt.Errorf("topic is required")
+		}
+	case ActionDescribeConsumerGroup:
+		if strings.TrimSpace(stringValue(input, "group", "")) == "" {
+			return fmt.Errorf("group is required")
+		}
+	}
+	if action == ActionReadMessages {
+		if partition := intValue(input, "partition", 0); partition < 0 || partition > 1000000 {
+			return fmt.Errorf("partition must be between 0 and 1000000")
+		}
+		if records := intValue(input, "max_records", 20); records < 1 || records > 100 {
+			return fmt.Errorf("max_records must be between 1 and 100")
+		}
+		if bytes := intValue(input, "max_bytes", 262144); bytes < 1 || bytes > 1048576 {
+			return fmt.Errorf("max_bytes must be between 1 and 1048576")
+		}
+		if wait := intValue(input, "wait_seconds", 2); wait < 1 || wait > 10 {
+			return fmt.Errorf("wait_seconds must be between 1 and 10")
+		}
+		if stringValue(input, "start_position", "recent") == "offset" && int64Value(input, "offset", 0) < 0 {
+			return fmt.Errorf("offset must be zero or greater")
+		}
+	}
+	return nil
+}
+
+func canonicalizeReadInput(action string, input map[string]any) error {
+	for _, field := range []string{"topic", "group"} {
+		if value, ok := input[field]; ok {
+			input[field] = strings.TrimSpace(fmt.Sprint(value))
+		}
+	}
+	if action != ActionReadMessages {
+		return nil
+	}
+	for _, field := range []string{"partition", "max_records", "max_bytes", "wait_seconds"} {
+		value, err := exactInt(input[field], field)
+		if err != nil {
+			return err
+		}
+		input[field] = value
+	}
+	if stringValue(input, "start_position", "recent") != "offset" {
+		input["offset"] = "0"
+	} else {
+		offset, err := exactInteger(input["offset"], "offset")
+		if err != nil {
+			return err
+		}
+		input["offset"] = strconv.FormatInt(offset, 10)
+	}
+	return nil
+}
+
+func exactInteger(value any, field string) (int64, error) {
+	switch typed := value.(type) {
+	case int:
+		return int64(typed), nil
+	case int64:
+		return typed, nil
+	case float64:
+		if math.IsNaN(typed) || math.IsInf(typed, 0) || math.Trunc(typed) != typed || math.Abs(typed) > 9007199254740991 {
+			return 0, fmt.Errorf("%s must be an exact integer", field)
+		}
+		return int64(typed), nil
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("%s must be an exact base-10 integer", field)
+		}
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("%s must be an exact integer", field)
+	}
+}
+
+func exactInt(value any, field string) (int, error) {
+	exact, err := exactInteger(value, field)
+	if err != nil {
+		return 0, err
+	}
+	converted, err := strconv.Atoi(strconv.FormatInt(exact, 10))
+	if err != nil {
+		return 0, fmt.Errorf("%s exceeds the supported integer range", field)
+	}
+	return converted, nil
+}
+
+func checkedInt32(value int64, field string) (int32, error) {
+	const (
+		minInt32 = -1 << 31
+		maxInt32 = 1<<31 - 1
+	)
+	if value < minInt32 || value > maxInt32 {
+		return 0, fmt.Errorf("%s exceeds the supported 32-bit integer range", field)
+	}
+	return int32(value), nil
+}
+
+func failedResult(err error) connectors.ActionResult {
+	return connectors.ActionResult{Status: connectors.ResultFailed, Error: err.Error(), DisplayText: err.Error()}
+}
+
+func completedResult(output any, display string) connectors.ActionResult {
+	return connectors.ActionResult{Status: connectors.ResultCompleted, Output: output, DisplayText: display}
+}
+
+func copyMap(input map[string]any) map[string]any {
+	output := make(map[string]any, len(input))
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}
+
+func familyLabel(value string) string {
+	if value == "redpanda" {
+		return "Redpanda"
+	}
+	return "Kafka"
+}

--- a/backend/internal/connectors/kafka/kafka_test.go
+++ b/backend/internal/connectors/kafka/kafka_test.go
@@ -1,0 +1,398 @@
+package kafka
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	"github.com/klauspost/compress/s2"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestTargetAndCredentialSchemasExposeKafkaRedpandaAndSASL(t *testing.T) {
+	target := New().TargetSchema()
+	if len(target.Fields) == 0 || target.Fields[0].Name != "server_family" {
+		t.Fatalf("server family field missing: %#v", target.Fields)
+	}
+	if !reflect.DeepEqual(target.Fields[0].Options, []connectors.FieldOption{
+		{Value: "kafka", Label: "Apache Kafka"},
+		{Value: "redpanda", Label: "Redpanda"},
+	}) {
+		t.Fatalf("server family options = %#v", target.Fields[0].Options)
+	}
+	credentials := New().CredentialSchemas()
+	if len(credentials) != 1 || credentials[0].Kind != "sasl" {
+		t.Fatalf("credential schemas = %#v", credentials)
+	}
+	if !connectors.SchemaContainsSecret(credentials[0].Schema) {
+		t.Fatal("SASL password must be a secret field")
+	}
+}
+
+func TestPrepareActionNormalizesAndBoundsMessageReads(t *testing.T) {
+	request := connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "kafka:1:2", Config: map[string]any{"server_family": "redpanda"}},
+		Profile:    connectors.CredentialProfileView{ID: 2, Public: map[string]any{"mechanism": "none"}},
+		ActionName: ActionReadMessages,
+		Input: map[string]any{
+			"topic":          "events",
+			"partition":      2,
+			"start_position": "recent",
+			"max_records":    100,
+			"max_bytes":      1048576,
+			"wait_seconds":   10,
+		},
+	}
+	prepared, err := New().PrepareAction(context.Background(), request)
+	if err != nil {
+		t.Fatalf("prepare action: %v", err)
+	}
+	if prepared.Risk != connectors.RiskRead || prepared.Payload["topic"] != "events" {
+		t.Fatalf("prepared = %#v", prepared)
+	}
+	if prepared.Payload["offset"] != "0" || prepared.Payload["partition"] != 2 {
+		t.Fatalf("prepared numeric values are not canonical: %#v", prepared.Payload)
+	}
+
+	request.Input["max_records"] = 101
+	if _, err := New().PrepareAction(context.Background(), request); err == nil {
+		t.Fatal("expected max_records bound error")
+	}
+	request.Input["max_records"] = 20.5
+	if _, err := New().PrepareAction(context.Background(), request); err == nil || !strings.Contains(err.Error(), "exact integer") {
+		t.Fatalf("expected exact integer error, got %v", err)
+	}
+	request.Input["max_records"] = 20
+	request.Input["start_position"] = "offset"
+	request.Input["offset"] = "9223372036854775806"
+	request.Input["topic"] = "  events  "
+	prepared, err = New().PrepareAction(context.Background(), request)
+	if err != nil {
+		t.Fatalf("prepare exact offset: %v", err)
+	}
+	if prepared.Payload["offset"] != "9223372036854775806" || prepared.Payload["topic"] != "events" {
+		t.Fatalf("exact offset or identifier drifted: %#v", prepared.Payload)
+	}
+	request.Input["start_position"] = "recent"
+	request.Input["offset"] = ""
+	prepared, err = New().PrepareAction(context.Background(), request)
+	if err != nil {
+		t.Fatalf("prepare non-offset read with empty offset: %v", err)
+	}
+	if prepared.Payload["offset"] != "0" {
+		t.Fatalf("non-offset read should canonicalize offset to zero: %#v", prepared.Payload)
+	}
+}
+
+func TestKafkaIntegerConversionsRejectNarrowingOverflow(t *testing.T) {
+	if _, err := exactInt("9223372036854775807", "max_bytes"); strconv.IntSize == 32 && err == nil {
+		t.Fatal("expected platform integer overflow error")
+	}
+	if _, err := checkedInt32(1<<31, "partition"); err == nil {
+		t.Fatal("expected 32-bit overflow error")
+	}
+	if value, err := checkedInt32(1_048_576, "max_bytes"); err != nil || value != 1_048_576 {
+		t.Fatalf("checked int32 = %d, %v", value, err)
+	}
+}
+
+func TestKafkaHelpUsesSharedConnectorIdentityFields(t *testing.T) {
+	help, err := New().GetHelp(context.Background(), connectors.TargetView{Ref: "kafka:1:2"})
+	if err != nil {
+		t.Fatalf("get help: %v", err)
+	}
+	if help.Connector != Label || help.ConnectorID != Kind {
+		t.Fatalf("help connector identity = %#v", help)
+	}
+}
+
+func TestKafkaCredentialValidationRequiresPasswordWhenEnablingSASL(t *testing.T) {
+	connector := New()
+	public := map[string]any{"mechanism": "scram_sha_256", "username": "reader"}
+	if err := connector.ValidateCredentialProfile("sasl", public, nil, nil); err == nil {
+		t.Fatal("expected password requirement on create")
+	}
+	previousNone := &connectors.CredentialProfileView{Public: map[string]any{"mechanism": "none"}}
+	if err := connector.ValidateCredentialProfile("sasl", public, nil, previousNone); err == nil {
+		t.Fatal("expected password requirement when enabling SASL")
+	}
+	previousSASL := &connectors.CredentialProfileView{Public: map[string]any{"mechanism": "scram_sha_512"}}
+	if err := connector.ValidateCredentialProfile("sasl", public, nil, previousSASL); err != nil {
+		t.Fatalf("preserving an existing SASL password should be valid: %v", err)
+	}
+}
+
+func TestPlainSASLRequiresTLSOrExplicitOptIn(t *testing.T) {
+	runtime := testRuntime([]string{"127.0.0.1:9092"}, &recordingDirectTransport{})
+	runtime.Profile.Public = map[string]any{"mechanism": "plain", "username": "reader"}
+	runtime.Secrets = staticSecretAccessor{"password": "test-password"}
+	if _, err := parseClientConfig(context.Background(), runtime); err == nil || !strings.Contains(err.Error(), "requires TLS") {
+		t.Fatalf("expected TLS requirement, got %v", err)
+	}
+	runtime.Target.Config["allow_insecure_plain_sasl"] = true
+	if _, err := parseClientConfig(context.Background(), runtime); err != nil {
+		t.Fatalf("explicit insecure PLAIN opt-in should be accepted: %v", err)
+	}
+}
+
+func TestBoundedDecompressorRejectsExpandedBatch(t *testing.T) {
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(bytes.Repeat([]byte("x"), 4096)); err != nil {
+		t.Fatalf("compress fixture: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close compressor: %v", err)
+	}
+	_, err := (boundedDecompressor{maxBytes: 1024}).Decompress(compressed.Bytes(), kgo.CodecGzip)
+	if err == nil || !strings.Contains(err.Error(), "decompression limit") {
+		t.Fatalf("expected bounded decompression error, got %v", err)
+	}
+}
+
+func TestBoundedDecompressorReadsXerialSnappyAndRejectsMalformedChunks(t *testing.T) {
+	source := []byte("bounded xerial snappy payload")
+	compressed := s2.EncodeSnappy(nil, source)
+	framed := append([]byte{}, xerialSnappyPrefix...)
+	framed = append(framed, 0, 0, 0, 1, 0, 0, 0, 1)
+	size := make([]byte, 4)
+	binary.BigEndian.PutUint32(size, uint32(len(compressed)))
+	framed = append(framed, size...)
+	framed = append(framed, compressed...)
+
+	decoded, err := (boundedDecompressor{maxBytes: 1024}).Decompress(framed, kgo.CodecSnappy)
+	if err != nil {
+		t.Fatalf("decode xerial snappy: %v", err)
+	}
+	if !bytes.Equal(decoded, source) {
+		t.Fatalf("decoded xerial payload = %q", decoded)
+	}
+
+	malformed := append([]byte{}, xerialSnappyPrefix...)
+	malformed = append(malformed, 0, 0, 0, 1, 0, 0, 0, 1)
+	binary.BigEndian.PutUint32(size, uint32(len(compressed)+1))
+	malformed = append(malformed, size...)
+	malformed = append(malformed, compressed...)
+	if _, err := (boundedDecompressor{maxBytes: 1024}).Decompress(malformed, kgo.CodecSnappy); err == nil || !strings.Contains(err.Error(), "malformed xerial") {
+		t.Fatalf("expected malformed xerial chunk error, got %v", err)
+	}
+}
+
+func TestDisplayBytesDistinguishesTombstonesFromEmptyValues(t *testing.T) {
+	value, encoding := displayBytes(nil)
+	if value != nil || encoding != "null" {
+		t.Fatalf("tombstone = %#v %q", value, encoding)
+	}
+	value, encoding = displayBytes([]byte{})
+	if value != "" || encoding != "utf8" {
+		t.Fatalf("empty value = %#v %q", value, encoding)
+	}
+}
+
+func TestReadMessageResultDoesNotTruncateAtSnapshotBoundary(t *testing.T) {
+	req := readMessagesRequest{Topic: "events", Partition: 0, MaxRecords: 10, MaxBytes: 1024}
+	result := buildReadMessagesResult(req, 0, 1, []*kgo.Record{
+		{Topic: "events", Partition: 0, Offset: 0, Value: []byte("inside")},
+		{Topic: "events", Partition: 0, Offset: 1, Value: []byte("after-snapshot")},
+	})
+	if result.Status != connectors.ResultCompleted {
+		t.Fatalf("result = %#v", result)
+	}
+	output := result.Output.(map[string]any)
+	if output["truncated"] != false || output["count"] != 1 {
+		t.Fatalf("snapshot-bounded output = %#v", output)
+	}
+	if _, exists := output["continuation_offset"]; exists {
+		t.Fatalf("snapshot boundary should not expose continuation: %#v", output)
+	}
+}
+
+func TestReadMessageResultFailsWhenOneRecordCannotAdvanceByteBound(t *testing.T) {
+	req := readMessagesRequest{Topic: "events", Partition: 0, MaxRecords: 10, MaxBytes: 3}
+	result := buildReadMessagesResult(req, 0, 1, []*kgo.Record{
+		{Topic: "events", Partition: 0, Offset: 0, Value: []byte("four")},
+	})
+	if result.Status != connectors.ResultFailed || !strings.Contains(result.Error, "increase max_bytes") {
+		t.Fatalf("oversized record result = %#v", result)
+	}
+}
+
+func TestReadTimeoutIsAnEmptyCompletedResult(t *testing.T) {
+	req := readMessagesRequest{Topic: "events", Partition: 2, WaitSeconds: 3}
+	result := completedReadTimeout(req, 5, 9)
+	if result.Status != connectors.ResultCompleted {
+		t.Fatalf("timeout result = %#v", result)
+	}
+	output := result.Output.(map[string]any)
+	if output["timed_out"] != true || output["count"] != 0 || output["truncated"] != false {
+		t.Fatalf("timeout output = %#v", output)
+	}
+}
+
+func TestParseBrokerListRequiresExplicitPortsAndDeduplicates(t *testing.T) {
+	brokers, err := parseBrokerList("broker-a:9092,\nbroker-a:9092 broker-b:9093")
+	if err != nil {
+		t.Fatalf("parse brokers: %v", err)
+	}
+	if !reflect.DeepEqual(brokers, []string{"broker-a:9092", "broker-b:9093"}) {
+		t.Fatalf("brokers = %#v", brokers)
+	}
+	if _, err := parseBrokerList("broker-a"); err == nil {
+		t.Fatal("expected missing port error")
+	}
+}
+
+func TestReadActionsUseGenericTransportAndDoNotCommitOffsets(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(2), kfake.SeedTopics(2, "events"))
+	if err != nil {
+		t.Fatalf("new fake cluster: %v", err)
+	}
+	defer cluster.Close()
+
+	producer, err := kgo.NewClient(kgo.SeedBrokers(cluster.ListenAddrs()...), kgo.RecordPartitioner(kgo.ManualPartitioner()))
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	results := producer.ProduceSync(context.Background(),
+		&kgo.Record{Topic: "events", Partition: 0, Key: []byte("one"), Value: []byte(`{"ok":1}`)},
+		&kgo.Record{Topic: "events", Partition: 0, Key: []byte{0xff}, Value: []byte{0x00, 0xff}},
+	)
+	producer.Close()
+	if err := results.FirstErr(); err != nil {
+		t.Fatalf("produce fixtures: %v", err)
+	}
+
+	transport := &recordingDirectTransport{}
+	runtime := testRuntime(cluster.ListenAddrs(), transport)
+	result, err := New().ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+		ConnectorKind: Kind,
+		ActionName:    ActionReadMessages,
+		Payload: map[string]any{
+			"topic": "events", "partition": 0, "start_position": "earliest",
+			"offset": "0", "max_records": 10, "max_bytes": 262144, "wait_seconds": 2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute read: %v", err)
+	}
+	if result.Status != connectors.ResultCompleted {
+		t.Fatalf("result = %#v", result)
+	}
+	output := result.Output.(map[string]any)
+	records, ok := output["records"].([]map[string]any)
+	if !ok || len(records) != 2 || records[1]["value_encoding"] != "base64" {
+		t.Fatalf("records = %#v", records)
+	}
+	if len(transport.Requests()) < 2 {
+		t.Fatalf("expected bootstrap and metadata broker dials, got %#v", transport.Requests())
+	}
+
+	consumer, err := kgo.NewClient(kgo.SeedBrokers(cluster.ListenAddrs()...))
+	if err != nil {
+		t.Fatalf("new consumer: %v", err)
+	}
+	defer consumer.Close()
+	committed, _ := kadm.NewClient(consumer).FetchOffsets(context.Background(), "audit-check")
+	if len(committed) != 0 {
+		t.Fatalf("read action unexpectedly committed offsets: %#v", committed)
+	}
+}
+
+func TestConnectionAndTopicMetadataAgainstKafkaProtocol(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.ClusterID("aipermission-test"), kfake.SeedTopics(3, "orders"))
+	if err != nil {
+		t.Fatalf("new fake cluster: %v", err)
+	}
+	defer cluster.Close()
+	runtime := testRuntime(cluster.ListenAddrs(), &recordingDirectTransport{})
+
+	testResult, err := New().TestConnection(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if testResult.Status != connectors.TestOK || testResult.Details["cluster_id"] != "aipermission-test" {
+		t.Fatalf("test result = %#v", testResult)
+	}
+	result, err := New().ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+		ConnectorKind: Kind,
+		ActionName:    ActionDescribeTopic,
+		Payload:       map[string]any{"topic": "orders"},
+	})
+	if err != nil {
+		t.Fatalf("describe topic: %v", err)
+	}
+	output := result.Output.(map[string]any)
+	if output["partition_count"] != 3 {
+		t.Fatalf("output = %#v", output)
+	}
+}
+
+func testRuntime(brokers []string, transport connectors.NetworkTransport) connectors.RuntimeContext {
+	return connectors.RuntimeContext{
+		Target: connectors.TargetView{
+			ID: 1, Ref: "kafka:1:2", ConnectorKind: Kind, Name: "events",
+			Config: map[string]any{
+				"server_family": "redpanda", "connection_mode": "direct",
+				"bootstrap_brokers": brokers[0], "tls_enabled": false,
+			},
+		},
+		Profile: connectors.CredentialProfileView{
+			ID: 2, TargetID: 1, ConnectorKind: Kind, Kind: "sasl", Label: "monitor",
+			Public: map[string]any{"mechanism": "none"},
+		},
+		Capabilities: testCapabilities{transport: transport},
+	}
+}
+
+type testCapabilities struct{ transport connectors.NetworkTransport }
+
+type staticSecretAccessor map[string]string
+
+func (s staticSecretAccessor) GetSecret(_ context.Context, name string) (string, error) {
+	value, ok := s[name]
+	if !ok {
+		return "", fmt.Errorf("secret %s not found", name)
+	}
+	return value, nil
+}
+
+func (c testCapabilities) RuntimeCapability(name string) connectors.RuntimeCapability {
+	if name == connectors.NetworkTransportCapabilityName {
+		return c.transport
+	}
+	return nil
+}
+
+type recordingDirectTransport struct {
+	mu       sync.Mutex
+	requests []connectors.NetworkDialRequest
+}
+
+func (*recordingDirectTransport) ConnectorRuntimeCapability() string {
+	return connectors.NetworkTransportCapabilityName
+}
+
+func (t *recordingDirectTransport) DialConnectorTCP(ctx context.Context, request connectors.NetworkDialRequest) (net.Conn, error) {
+	t.mu.Lock()
+	t.requests = append(t.requests, request)
+	t.mu.Unlock()
+	return (&net.Dialer{Timeout: 3 * time.Second}).DialContext(ctx, "tcp", net.JoinHostPort(request.Host, fmt.Sprint(request.Port)))
+}
+
+func (t *recordingDirectTransport) Requests() []connectors.NetworkDialRequest {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]connectors.NetworkDialRequest(nil), t.requests...)
+}

--- a/backend/internal/connectors/kafka/read_actions.go
+++ b/backend/internal/connectors/kafka/read_actions.go
@@ -1,0 +1,475 @@
+package kafka
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+	"unicode/utf8"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+const (
+	maxClusterBrokers       = 200
+	maxTopicRows            = 1000
+	maxTopicPartitions      = 1000
+	maxConsumerGroupRows    = 1000
+	maxConsumerGroupMembers = 500
+	maxMemberAssignments    = 500
+	maxConsumerLagRows      = 2000
+	maxMetadataOutputBytes  = 512 << 10
+	maxMessageOutputBytes   = 500 << 10
+)
+
+func executeClusterInfo(ctx context.Context, client *kgo.Client) (connectors.ActionResult, error) {
+	metadata, err := clientBrokerMetadata(ctx, client)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	brokers := make([]map[string]any, 0, min(len(metadata.Brokers), maxClusterBrokers))
+	usedBytes := 0
+	truncated := false
+	for _, broker := range metadata.Brokers {
+		if !appendBoundedRow(&brokers, map[string]any{"id": broker.NodeID, "host": broker.Host, "port": broker.Port}, &usedBytes, maxClusterBrokers, maxMetadataOutputBytes) {
+			truncated = true
+			break
+		}
+	}
+	output := map[string]any{
+		"cluster_id":    metadata.Cluster,
+		"controller_id": metadata.Controller,
+		"broker_count":  len(metadata.Brokers),
+		"brokers_shown": len(brokers),
+		"brokers":       brokers,
+		"truncated":     truncated,
+	}
+	return completedResult(output, fmt.Sprintf("Read cluster metadata from %d broker(s).", len(brokers))), nil
+}
+
+func executeListTopics(ctx context.Context, client *kgo.Client, includeInternal bool) (connectors.ActionResult, error) {
+	requestCtx, admin, cancel := newAdminRequest(ctx, client, 15*time.Second)
+	defer cancel()
+	topics, err := admin.ListTopicsWithInternal(requestCtx)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	if err := topics.Error(); err != nil {
+		return failedResult(err), nil
+	}
+	rows := make([]map[string]any, 0, min(len(topics), maxTopicRows))
+	usedBytes := 0
+	totalVisible := 0
+	truncated := false
+	for _, topic := range topics.Sorted() {
+		if topic.IsInternal && !includeInternal {
+			continue
+		}
+		totalVisible++
+		if !appendBoundedRow(&rows, map[string]any{
+			"name":               topic.Topic,
+			"internal":           topic.IsInternal,
+			"partition_count":    len(topic.Partitions),
+			"replication_factor": topic.Partitions.NumReplicas(),
+		}, &usedBytes, maxTopicRows, maxMetadataOutputBytes) {
+			truncated = true
+		}
+	}
+	return completedResult(map[string]any{"topics": rows, "count": len(rows), "total_visible_count": totalVisible, "include_internal": includeInternal, "truncated": truncated}, fmt.Sprintf("Listed %d topic(s).", len(rows))), nil
+}
+
+func executeDescribeTopic(ctx context.Context, client *kgo.Client, topicName string) (connectors.ActionResult, error) {
+	requestCtx, admin, cancel := newAdminRequest(ctx, client, 15*time.Second)
+	defer cancel()
+	metadata, err := admin.ListTopics(requestCtx, topicName)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	topic, ok := metadata[topicName]
+	if !ok || topic.Err != nil {
+		if ok && topic.Err != nil {
+			return failedResult(topic.Err), nil
+		}
+		return failedResult(fmt.Errorf("topic %q was not found or is not visible", topicName)), nil
+	}
+	offsets, err := admin.ListEndOffsets(requestCtx, topicName)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	partitions := make([]map[string]any, 0, min(len(topic.Partitions), maxTopicPartitions))
+	usedBytes := 0
+	truncated := false
+	for _, partition := range topic.Partitions.Sorted() {
+		row := map[string]any{
+			"partition":        partition.Partition,
+			"leader":           partition.Leader,
+			"leader_epoch":     partition.LeaderEpoch,
+			"replicas":         partition.Replicas,
+			"in_sync_replicas": partition.ISR,
+			"offline_replicas": partition.OfflineReplicas,
+		}
+		if offset, found := offsets.Lookup(topicName, partition.Partition); found && offset.Err == nil {
+			row["end_offset"] = strconv.FormatInt(offset.Offset, 10)
+		}
+		if !appendBoundedRow(&partitions, row, &usedBytes, maxTopicPartitions, maxMetadataOutputBytes) {
+			truncated = true
+		}
+	}
+	output := map[string]any{
+		"name":               topic.Topic,
+		"id":                 topic.ID.String(),
+		"internal":           topic.IsInternal,
+		"partition_count":    len(topic.Partitions),
+		"partitions_shown":   len(partitions),
+		"replication_factor": topic.Partitions.NumReplicas(),
+		"partitions":         partitions,
+		"truncated":          truncated,
+	}
+	return completedResult(output, fmt.Sprintf("Described topic %s with %d partition(s).", topicName, len(partitions))), nil
+}
+
+func executeListConsumerGroups(ctx context.Context, client *kgo.Client) (connectors.ActionResult, error) {
+	requestCtx, admin, cancel := newAdminRequest(ctx, client, 15*time.Second)
+	defer cancel()
+	groups, err := admin.ListGroups(requestCtx)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	rows := make([]map[string]any, 0, min(len(groups), maxConsumerGroupRows))
+	usedBytes := 0
+	truncated := false
+	for _, group := range groups.Sorted() {
+		if !appendBoundedRow(&rows, map[string]any{
+			"name":          group.Group,
+			"state":         group.State,
+			"protocol_type": group.ProtocolType,
+			"coordinator":   group.Coordinator,
+		}, &usedBytes, maxConsumerGroupRows, maxMetadataOutputBytes) {
+			truncated = true
+		}
+	}
+	return completedResult(map[string]any{"consumer_groups": rows, "count": len(rows), "total_visible_count": len(groups), "truncated": truncated}, fmt.Sprintf("Listed %d consumer group(s).", len(rows))), nil
+}
+
+func executeDescribeConsumerGroup(ctx context.Context, client *kgo.Client, groupName string) (connectors.ActionResult, error) {
+	requestCtx, admin, cancel := newAdminRequest(ctx, client, 20*time.Second)
+	defer cancel()
+	lags, err := admin.Lag(requestCtx, groupName)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	lag, ok := lags[groupName]
+	if !ok {
+		return failedResult(fmt.Errorf("consumer group %q was not found or is not visible", groupName)), nil
+	}
+	if err := lag.Error(); err != nil {
+		return failedResult(err), nil
+	}
+	members := make([]map[string]any, 0, min(len(lag.Members), maxConsumerGroupMembers))
+	memberBytes := 0
+	truncated := false
+	for _, member := range lag.Members {
+		memberRow := map[string]any{
+			"member_id":   member.MemberID,
+			"client_id":   member.ClientID,
+			"client_host": member.ClientHost,
+		}
+		if member.InstanceID != nil {
+			memberRow["instance_id"] = *member.InstanceID
+		}
+		if assignment, assignmentOK := member.Assigned.AsConsumer(); assignmentOK {
+			topics := make([]map[string]any, 0, len(assignment.Topics))
+			for _, assignedTopic := range assignment.Topics {
+				if len(topics) >= maxMemberAssignments {
+					truncated = true
+					break
+				}
+				topics = append(topics, map[string]any{"topic": assignedTopic.Topic, "partitions": assignedTopic.Partitions})
+			}
+			memberRow["assignments"] = topics
+		}
+		if !appendBoundedRow(&members, memberRow, &memberBytes, maxConsumerGroupMembers, maxMetadataOutputBytes/2) {
+			truncated = true
+		}
+	}
+	partitionLag := make([]map[string]any, 0, min(len(lag.Lag), maxConsumerLagRows))
+	lagBytes := 0
+	var totalLag int64
+	lagComplete := true
+	for _, item := range lag.Lag.Sorted() {
+		if item.Err != nil {
+			lagComplete = false
+			if !appendBoundedRow(&partitionLag, map[string]any{
+				"topic": item.Topic, "partition": item.Partition, "error": item.Err.Error(),
+			}, &lagBytes, maxConsumerLagRows, maxMetadataOutputBytes/2) {
+				truncated = true
+			}
+			continue
+		}
+		if item.Lag > 0 {
+			totalLag += item.Lag
+		}
+		row := map[string]any{
+			"topic":            item.Topic,
+			"partition":        item.Partition,
+			"committed_offset": strconv.FormatInt(item.Commit.At, 10),
+			"end_offset":       strconv.FormatInt(item.End.Offset, 10),
+			"lag":              strconv.FormatInt(item.Lag, 10),
+		}
+		if item.Member != nil {
+			row["member_id"] = item.Member.MemberID
+		}
+		if !appendBoundedRow(&partitionLag, row, &lagBytes, maxConsumerLagRows, maxMetadataOutputBytes/2) {
+			truncated = true
+		}
+	}
+	output := map[string]any{
+		"name":          lag.Group,
+		"state":         lag.State,
+		"protocol_type": lag.ProtocolType,
+		"protocol":      lag.Protocol,
+		"coordinator":   lag.Coordinator.NodeID,
+		"member_count":  len(lag.Members),
+		"members_shown": len(members),
+		"total_lag":     strconv.FormatInt(totalLag, 10),
+		"lag_complete":  lagComplete,
+		"members":       members,
+		"partitions":    partitionLag,
+		"truncated":     truncated,
+	}
+	return completedResult(output, fmt.Sprintf("Described consumer group %s with total lag %d.", groupName, totalLag)), nil
+}
+
+type readMessagesRequest struct {
+	Topic       string
+	Partition   int32
+	Start       string
+	Offset      int64
+	MaxRecords  int
+	MaxBytes    int
+	WaitSeconds int
+}
+
+func executeReadMessages(ctx context.Context, runtime connectors.RuntimeContext, req readMessagesRequest) (connectors.ActionResult, error) {
+	metadataClient, err := newClient(ctx, runtime)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	startOffset, endOffset, err := resolveReadOffsets(ctx, metadataClient, req)
+	metadataClient.Close()
+	if err != nil {
+		return failedResult(err), nil
+	}
+	if startOffset >= endOffset {
+		output := map[string]any{"topic": req.Topic, "partition": req.Partition, "start_offset": strconv.FormatInt(startOffset, 10), "end_offset": strconv.FormatInt(endOffset, 10), "records": []any{}, "count": 0, "truncated": false}
+		return completedResult(output, "No messages are currently available in the requested range."), nil
+	}
+	fetchMaxBytes, err := checkedInt32(int64(req.MaxBytes), "max_bytes")
+	if err != nil {
+		return failedResult(err), nil
+	}
+	brokerMaxReadBytes, err := checkedInt32(int64(req.MaxBytes)+65536, "broker_max_read_bytes")
+	if err != nil {
+		return failedResult(err), nil
+	}
+
+	reader, err := newClient(
+		ctx,
+		runtime,
+		kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{req.Topic: {req.Partition: kgo.NewOffset().At(startOffset)}}),
+		kgo.FetchMaxBytes(fetchMaxBytes),
+		kgo.FetchMaxPartitionBytes(fetchMaxBytes),
+		kgo.MaxConcurrentFetches(1),
+		kgo.BrokerMaxReadBytes(brokerMaxReadBytes),
+	)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	defer reader.Close()
+	readCtx, cancel := context.WithTimeout(ctx, time.Duration(req.WaitSeconds)*time.Second)
+	defer cancel()
+	fetches := reader.PollFetches(readCtx)
+	if fetchErrs := fetches.Errors(); len(fetchErrs) > 0 {
+		timedOut := ctx.Err() == nil && readCtx.Err() != nil
+		for _, fetchErr := range fetchErrs {
+			timedOut = timedOut && errors.Is(fetchErr.Err, readCtx.Err())
+		}
+		if timedOut {
+			return completedReadTimeout(req, startOffset, endOffset), nil
+		}
+		return failedResult(fetchErrs[0].Err), nil
+	}
+	return buildReadMessagesResult(req, startOffset, endOffset, fetches.Records()), nil
+}
+
+func completedReadTimeout(req readMessagesRequest, startOffset, endOffset int64) connectors.ActionResult {
+	return completedResult(map[string]any{
+		"topic":        req.Topic,
+		"partition":    req.Partition,
+		"start_offset": strconv.FormatInt(startOffset, 10),
+		"end_offset":   strconv.FormatInt(endOffset, 10),
+		"records":      []map[string]any{},
+		"count":        0,
+		"bytes":        0,
+		"truncated":    false,
+		"timed_out":    true,
+	}, fmt.Sprintf("No messages arrived from %s partition %d within %d second(s).", req.Topic, req.Partition, req.WaitSeconds))
+}
+
+func buildReadMessagesResult(req readMessagesRequest, startOffset, endOffset int64, records []*kgo.Record) connectors.ActionResult {
+	rows := make([]map[string]any, 0, req.MaxRecords)
+	totalBytes := 0
+	serializedBytes := 0
+	truncated := false
+	nextOffset := startOffset
+	for _, record := range records {
+		if record.Offset >= endOffset {
+			break
+		}
+		if len(rows) >= req.MaxRecords {
+			truncated = true
+			break
+		}
+		recordBytes := len(record.Key) + len(record.Value)
+		for _, header := range record.Headers {
+			recordBytes += len(header.Key) + len(header.Value)
+		}
+		if recordBytes > req.MaxBytes {
+			return failedResult(fmt.Errorf("Kafka message at offset %d uses %d payload bytes, exceeding max_bytes %d; increase max_bytes to read this record", record.Offset, recordBytes, req.MaxBytes))
+		}
+		if totalBytes+recordBytes > req.MaxBytes {
+			truncated = true
+			break
+		}
+		totalBytes += recordBytes
+		headers := make([]map[string]any, 0, len(record.Headers))
+		for _, header := range record.Headers {
+			value, encoding := displayBytes(header.Value)
+			headers = append(headers, map[string]any{"key": header.Key, "value": value, "encoding": encoding})
+		}
+		key, keyEncoding := displayBytes(record.Key)
+		value, valueEncoding := displayBytes(record.Value)
+		row := map[string]any{
+			"topic":          record.Topic,
+			"partition":      record.Partition,
+			"offset":         strconv.FormatInt(record.Offset, 10),
+			"timestamp":      record.Timestamp.UTC().Format(time.RFC3339Nano),
+			"key":            key,
+			"key_encoding":   keyEncoding,
+			"value":          value,
+			"value_encoding": valueEncoding,
+			"headers":        headers,
+		}
+		encoded, marshalErr := json.Marshal(row)
+		if marshalErr != nil {
+			return failedResult(fmt.Errorf("serialize Kafka message sample: %w", marshalErr))
+		}
+		if len(encoded)+1 > maxMessageOutputBytes {
+			return failedResult(fmt.Errorf("Kafka message at offset %d exceeds the bounded output limit", record.Offset))
+		}
+		if serializedBytes+len(encoded)+1 > maxMessageOutputBytes {
+			truncated = true
+			break
+		}
+		serializedBytes += len(encoded) + 1
+		rows = append(rows, row)
+		nextOffset = record.Offset + 1
+	}
+	if nextOffset < endOffset {
+		truncated = true
+	}
+	output := map[string]any{
+		"topic":        req.Topic,
+		"partition":    req.Partition,
+		"start_offset": strconv.FormatInt(startOffset, 10),
+		"end_offset":   strconv.FormatInt(endOffset, 10),
+		"records":      rows,
+		"count":        len(rows),
+		"bytes":        totalBytes,
+		"truncated":    truncated,
+	}
+	if truncated {
+		output["continuation_offset"] = strconv.FormatInt(nextOffset, 10)
+	}
+	return completedResult(output, fmt.Sprintf("Read %d message(s) from %s partition %d without committing offsets.", len(rows), req.Topic, req.Partition))
+}
+
+func resolveReadOffsets(ctx context.Context, client *kgo.Client, req readMessagesRequest) (int64, int64, error) {
+	requestCtx, admin, cancel := newAdminRequest(ctx, client, 15*time.Second)
+	defer cancel()
+	earliest, end, err := partitionBounds(requestCtx, admin, req.Topic, req.Partition)
+	if err != nil {
+		return 0, 0, err
+	}
+	switch req.Start {
+	case "offset":
+		if req.Offset < earliest || req.Offset > end {
+			return 0, 0, fmt.Errorf("offset must be between the earliest available offset %d and end offset %d", earliest, end)
+		}
+		return req.Offset, end, nil
+	case "earliest":
+		return earliest, end, nil
+	case "recent":
+		start := end - int64(req.MaxRecords)
+		if start < earliest {
+			start = earliest
+		}
+		return start, end, nil
+	default:
+		return 0, 0, fmt.Errorf("unsupported start_position %q", req.Start)
+	}
+}
+
+func partitionBounds(ctx context.Context, admin *kadm.Client, topic string, partition int32) (int64, int64, error) {
+	starts, err := admin.ListStartOffsets(ctx, topic)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read earliest offset: %w", err)
+	}
+	ends, err := admin.ListEndOffsets(ctx, topic)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read end offset: %w", err)
+	}
+	start, startOK := starts.Lookup(topic, partition)
+	end, endOK := ends.Lookup(topic, partition)
+	if !startOK || !endOK {
+		return 0, 0, fmt.Errorf("topic %q partition %d was not found or is not visible", topic, partition)
+	}
+	if start.Err != nil {
+		return 0, 0, fmt.Errorf("read earliest offset: %w", start.Err)
+	}
+	if end.Err != nil {
+		return 0, 0, fmt.Errorf("read end offset: %w", end.Err)
+	}
+	return start.Offset, end.Offset, nil
+}
+
+func displayBytes(value []byte) (any, string) {
+	if value == nil {
+		return nil, "null"
+	}
+	if len(value) == 0 {
+		return "", "utf8"
+	}
+	if utf8.Valid(value) {
+		return string(value), "utf8"
+	}
+	return base64.StdEncoding.EncodeToString(value), "base64"
+}
+
+func appendBoundedRow(rows *[]map[string]any, row map[string]any, usedBytes *int, maxRows, maxBytes int) bool {
+	if len(*rows) >= maxRows {
+		return false
+	}
+	encoded, err := json.Marshal(row)
+	if err != nil || *usedBytes+len(encoded)+1 > maxBytes {
+		return false
+	}
+	*usedBytes += len(encoded) + 1
+	*rows = append(*rows, row)
+	return true
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 AIPermission has published its first public release candidate and is moving
 into the connector-native 0.2 line. The local-only permission gateway is usable
-today with built-in SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, and
+today with built-in SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, and
 Kubernetes connectors; the next releases focus on
 dogfooding polish, small safety improvements, clearer contributor paths, and
 additional connector kinds such as API, queues, and storage that share one
@@ -54,7 +54,7 @@ AIPermission is intentionally:
 - Local-only.
 - Single-user.
 - Developer-focused.
-- Connector-based, with built-in SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ,
+- Connector-based, with built-in SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, Kafka / Redpanda,
   S3, Docker, and Kubernetes.
 - Human-in-the-loop.
 

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -2,7 +2,7 @@
 
 The MCP surface is connector-first. AIPermission does not expose separate
 product-specific MCP wrappers for SSH, database, cache, queue, or container
-products. SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, Kubernetes,
+products. SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, Kubernetes,
 and future integrations are reached through the same connector target/action
 pipeline.
 
@@ -67,7 +67,7 @@ runs locally through the gateway; AIPermission does not host a remote connector
 service.
 
 Clients should discover targets and actions at runtime. Do not hardcode SSH,
-Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, or Kubernetes as special MCP
+Postgres, ClickHouse, Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, or Kubernetes as special MCP
 modes; future connector kinds use the same tools and `target_ref` shape.
 
 Project Vault tools are a separate project-capability surface because they
@@ -228,6 +228,13 @@ queue listing, queue detail reads, binding listing, and bounded message peeking
 with `ack_requeue_true`, plus explicit `publish_message` writes. Message
 payload previews and published payloads may contain secrets or customer data;
 prefer approval-required access until the workflow is trusted.
+
+Kafka / Redpanda actions in 0.2.18 include cluster metadata, topic listing and
+description, consumer-group listing and lag description, and bounded message
+samples from an explicit topic partition. `read_messages` does not join a
+consumer group, commit offsets, or enable automatic topic creation. Message
+keys, values, and headers may contain secrets or customer data; keep the action
+in approval-required mode unless that read workflow is explicitly trusted.
 
 S3 actions include bucket metadata, bounded object listing, object metadata,
 bounded object download/upload, object rename, and explicit delete. Object

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -30,11 +30,12 @@ target + credential profile + action
   -> history + audit
 ```
 
-SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, and Kubernetes are
+SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, and Kubernetes are
 built-in connectors that share the same target/profile, permission, approval,
 history, and audit model. SSH owns a live terminal and file-transfer surface;
 Postgres and ClickHouse own structured database actions; Redis / Valkey owns bounded
-key-browser actions; RabbitMQ owns queue browsing and bounded message previews.
+key-browser actions; RabbitMQ owns queue browsing and bounded message previews;
+Kafka / Redpanda owns stream metadata, lag, and bounded partition reads.
 Future connectors should add their own execution surface without adding a new
 permission or audit pipeline.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ Start here:
 - [Docker Runtime](setup/docker-runtime.md)
 - [Database Migration](setup/database-migration.md)
 - [MCP Client Setup](setup/mcp-client-setup.md)
+- [Kafka / Redpanda Connector](setup/kafka-redpanda.md)
 
 ## Providers
 

--- a/docs/mvp/scope.md
+++ b/docs/mvp/scope.md
@@ -12,7 +12,7 @@ The MVP is not a DevOps platform. It does not own production operations. It give
 
 The MVP does not introduce first-class management modules for every external
 system. It introduces one connector pipeline. SSH, Postgres, ClickHouse, Redis / Valkey,
-RabbitMQ, S3, Docker, Kubernetes, and future integrations are connector kinds that provide
+RabbitMQ, Kafka / Redpanda, S3, Docker, Kubernetes, and future integrations are connector kinds that provide
 their own actions while sharing the same target/profile/action permission model.
 If an allowed SSH target has the needed CLI tools and access, the AI can operate
 at command level through the SSH connector `exec` action. If a structured
@@ -40,7 +40,7 @@ The gateway itself is local-only. It is not designed to run on a remote server f
   read-only query actions
 - built-in ClickHouse connector with native-protocol metadata inspection and
   bounded read-only analytics SQL
-- built-in Redis / Valkey, RabbitMQ, S3, Docker, and Kubernetes connectors for scoped
+- built-in Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, and Kubernetes connectors for scoped
   cache, queue, object storage, container runtime, and cluster visibility
   through the shared connector pipeline
 - API token creation and revocation

--- a/docs/project-principles.md
+++ b/docs/project-principles.md
@@ -8,7 +8,7 @@ part of the security model, not marketing copy.
 - Local-only
 - Single-user
 - Developer-focused
-- Connector-based, with built-in SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ,
+- Connector-based, with built-in SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, Kafka / Redpanda,
   S3, Docker, and Kubernetes
 - Human-in-the-loop
 

--- a/docs/setup/kafka-redpanda.md
+++ b/docs/setup/kafka-redpanda.md
@@ -1,0 +1,54 @@
+# Kafka / Redpanda Connector
+
+AIPermission uses one `kafka` connector kind for Apache Kafka and Redpanda.
+Both products use the same target/profile/action permission, approval, history,
+and audit pipeline.
+
+## Connection
+
+Create a connector and choose:
+
+- **Server family:** Apache Kafka or Redpanda.
+- **Connection mode:** Direct from the local gateway, or Over SSH through an
+  existing SSH connector profile.
+- **Bootstrap brokers:** one `host:port` per line or a comma-separated list.
+- **TLS:** optional TLS, certificate server-name override, and custom CA PEM.
+- **SASL profile:** None, PLAIN, SCRAM-SHA-256, or SCRAM-SHA-512.
+
+Kafka clients connect to the bootstrap broker first and then use broker
+addresses advertised by cluster metadata. In Direct mode, every advertised
+address must be reachable from the gateway container. In Over SSH mode, every
+advertised address is dialed through the selected SSH profile and must resolve
+from that remote host.
+
+PLAIN SASL is rejected without TLS by default because it exposes the password
+on the broker connection. A connector can explicitly allow insecure PLAIN only
+for a trusted private network; TLS or SCRAM remains the recommended setup.
+
+For a broker running on the same machine as AIPermission Docker, use
+`host.docker.internal` rather than `localhost` in a Direct target.
+
+## Read Actions
+
+The 0.2.18 read surface provides:
+
+- `cluster_info`
+- `list_topics`
+- `describe_topic`
+- `list_consumer_groups`
+- `describe_consumer_group`
+- `read_messages`
+
+`read_messages` uses explicit topic/partition assignment. It does not join a
+consumer group, commit offsets, or enable automatic topic creation. Record
+count, returned serialized output, decompressed record batches, concurrent
+fetches, and wait time are bounded. Large samples return a
+`continuation_offset` instead of silently expanding the gateway response.
+
+Message keys, values, and headers can contain secrets or customer data. Keep
+message reads in Prompt mode unless the workflow is explicitly trusted. The
+returned sample is stored in the encrypted local History like every other
+connector action result.
+
+Use a least-privilege broker account. AIPermission bounds its own behavior, but
+broker ACLs remain the primary authorization boundary.

--- a/docs/skills/aipermission-docs/SKILL.md
+++ b/docs/skills/aipermission-docs/SKILL.md
@@ -138,7 +138,7 @@ Use the established aipermission naming:
 - `gateway` is the local backend that owns credentials, policy, execution, approvals, and audit.
 - `MCP client` means Cursor, Windsurf, or another AI tool integration.
 - `API token` means the gateway access token used by MCP/API clients.
-- `connector target` means a saved SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, Kubernetes, or future integration target.
+- `connector target` means a saved SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, Kubernetes, or future integration target.
 - `server` is acceptable only when specifically describing an SSH connector target.
 - `database` means a configured Postgres or ClickHouse connector target/profile.
 - `execution rule` means `always_run`, `approval_required`, or `blocked`.

--- a/docs/skills/aipermission-operator/SKILL.md
+++ b/docs/skills/aipermission-operator/SKILL.md
@@ -53,6 +53,10 @@ Peek a RabbitMQ queue after the operator approved payload inspection. Publish
 RabbitMQ messages only when the operator explicitly asked for a write.
 ```
 
+For Kafka / Redpanda, discover topics before describing partitions or reading
+messages. Keep message reads bounded, prefer Prompt because payloads can be
+sensitive, and remember that read actions never join groups or commit offsets.
+
 Avoid vague reasons:
 
 ```text

--- a/docs/whatis-aipermission.md
+++ b/docs/whatis-aipermission.md
@@ -14,7 +14,7 @@ Related central notes:
 operate on connector targets without receiving SSH private keys, SSH passwords,
 database credentials, API credentials, or other connector secrets.
 
-The current model ships with SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3,
+The current model ships with SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3,
 Docker, and Kubernetes connectors. SSH provides live terminal/file-transfer
 actions, Postgres and ClickHouse provide structured metadata and bounded
 read-only query actions, Redis / Valkey provides bounded
@@ -271,7 +271,7 @@ get_vault_action_request(request_id)
 cancel_vault_action_request(request_id)
 ```
 
-SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, S3, Docker, Kubernetes, and future integrations are exposed as
+SSH, Postgres, ClickHouse, Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, Kubernetes, and future integrations are exposed as
 connector actions instead of separate product-specific MCP tools.
 
 Project Vault is project-capability-scoped rather than connector-action-scoped.

--- a/frontend/src/connectors/templates/_shared/network-transport-fields.jsx
+++ b/frontend/src/connectors/templates/_shared/network-transport-fields.jsx
@@ -55,7 +55,7 @@ export function NetworkTransportFields({
   );
 }
 
-function sshProfileOptions(targets) {
+export function sshProfileOptions(targets) {
   return (targets || [])
     .filter((target) => target.connector_kind === "ssh")
     .flatMap((target) =>

--- a/frontend/src/connectors/templates/kafka/console-helpers.js
+++ b/frontend/src/connectors/templates/kafka/console-helpers.js
@@ -1,0 +1,14 @@
+export function connectorActionError(item, fallback = "Kafka action failed.") {
+  if (!item || item.status === "failed" || item.status === "canceled" || item.status === "stale") {
+    return item?.error || item?.display_text || fallback;
+  }
+  return "";
+}
+
+export function requestIsCurrent(versions, channel, version, targetRef, currentTargetRef) {
+  return versions.get(channel) === version && targetRef === currentTargetRef;
+}
+
+export function detailMatchesSelection(identity, view, selectedName) {
+  return Boolean(selectedName) && identity === `${view}:${selectedName}`;
+}

--- a/frontend/src/connectors/templates/kafka/console.jsx
+++ b/frontend/src/connectors/templates/kafka/console.jsx
@@ -1,0 +1,284 @@
+import { Activity, Database, Eye, RefreshCcw, Search, Users } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Badge } from "../../../components/ui/badge";
+import { Button } from "../../../components/ui/button";
+import { CopyButton } from "../../../components/ui/copy-button";
+import { Input, Select } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+import { TerminalBlock } from "../../../components/ui/terminal-block";
+import { apiPost } from "../../../lib/api";
+import { connectorActionError, detailMatchesSelection, requestIsCurrent } from "./console-helpers";
+
+const defaultRead = Object.freeze({ partition: "0", start_position: "recent", offset: "0", max_records: "20" });
+
+export function KafkaConnectorConsoleTemplate({ target, approvals, theme, session, onNewStructuredSession, onRefreshActivity }) {
+  const activeSession = session || { active: false, startedAt: "" };
+  const product = target.config?.server_family === "redpanda" ? "Redpanda" : "Kafka";
+  const [view, setView] = useState("topics");
+  const [query, setQuery] = useState("");
+  const [topics, setTopics] = useState([]);
+  const [groups, setGroups] = useState([]);
+  const [selectedName, setSelectedName] = useState("");
+  const [detail, setDetail] = useState(null);
+  const [detailIdentity, setDetailIdentity] = useState("");
+  const [messages, setMessages] = useState(null);
+  const [readForm, setReadForm] = useState(defaultRead);
+  const [state, setState] = useState({ state: "idle", error: "", message: "" });
+  const requestVersions = useRef(new Map());
+  const currentTargetRef = useRef(target.ref);
+  const panelClass = theme === "light" ? "bg-white text-stone-900" : "bg-[#1e1e1e] text-stone-100";
+  const mutedClass = theme === "light" ? "text-stone-500" : "text-stone-400";
+  const borderClass = theme === "light" ? "border-stone-200" : "border-stone-700";
+  const subtlePanelClass = theme === "light" ? "bg-stone-50" : "bg-[#252526]";
+  const inputClass = theme === "light" ? "border-stone-300 bg-white text-stone-900" : "border-stone-700 bg-[#1a1a1a] text-stone-100";
+  const hoverClass = theme === "light" ? "hover:bg-stone-50" : "hover:bg-stone-800/60";
+  const activeClass = theme === "light" ? "border-emerald-200 bg-emerald-50 text-emerald-950" : "border-emerald-700 bg-emerald-950/40 text-emerald-100";
+  const latestAction = useMemo(() => (approvals?.data || []).find((item) => item.target_ref === target.ref) || null, [approvals?.data, target.ref]);
+  const items = view === "topics" ? topics : groups;
+  const filteredItems = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return items;
+    return items.filter((item) => String(item.name || "").toLowerCase().includes(needle));
+  }, [items, query]);
+  const activeDetail = detailMatchesSelection(detailIdentity, view, selectedName) ? detail : null;
+
+  useEffect(() => {
+    currentTargetRef.current = target.ref;
+    requestVersions.current.clear();
+    setView("topics");
+    setQuery("");
+    setTopics([]);
+    setGroups([]);
+    setSelectedName("");
+    setDetail(null);
+    setDetailIdentity("");
+    setMessages(null);
+    setReadForm(defaultRead);
+    setState({ state: "idle", error: "", message: "" });
+  }, [target.ref, activeSession.startedAt]);
+
+  useEffect(() => {
+    if (!activeSession.active) return;
+    void refreshList("topics");
+  }, [activeSession.active, activeSession.startedAt, target.ref]);
+
+  async function runAction(actionName, input, reason, busy = "loading", channel = actionName) {
+    const version = (requestVersions.current.get(channel) || 0) + 1;
+    const requestTargetRef = target.ref;
+    requestVersions.current.set(channel, version);
+    setState({ state: busy, error: "", message: "" });
+    try {
+      const item = await apiPost("/api/connector-actions/local-run", {
+        target_ref: target.ref,
+        action_name: actionName,
+        input,
+        reason,
+      });
+      if (!requestIsCurrent(requestVersions.current, channel, version, requestTargetRef, currentTargetRef.current)) return null;
+      const actionError = connectorActionError(item, `${product} action failed.`);
+      if (actionError) throw new Error(actionError);
+      const message = item.display_text || "";
+      try {
+        await onRefreshActivity?.();
+      } catch (refreshError) {
+        if (!requestIsCurrent(requestVersions.current, channel, version, requestTargetRef, currentTargetRef.current)) return null;
+        setState({ state: "idle", error: `Action completed, but activity refresh failed: ${refreshError.message || "unknown error"}`, message });
+        return item.output || {};
+      }
+      if (!requestIsCurrent(requestVersions.current, channel, version, requestTargetRef, currentTargetRef.current)) return null;
+      setState({ state: "idle", error: "", message });
+      return item.output || {};
+    } catch (error) {
+      if (!requestIsCurrent(requestVersions.current, channel, version, requestTargetRef, currentTargetRef.current)) return null;
+      setState({ state: "idle", error: error.message || `${product} action failed.`, message: "" });
+      return null;
+    }
+  }
+
+  async function refreshList(nextView = view) {
+    if (!activeSession.active) return;
+    const topicMode = nextView === "topics";
+    const output = await runAction(
+      topicMode ? "list_topics" : "list_consumer_groups",
+      topicMode ? { include_internal: false } : {},
+      `manual ${product} browser ${topicMode ? "topic" : "consumer group"} list`,
+      "loading",
+      `list:${nextView}`,
+    );
+    if (!output) return;
+    if (topicMode) setTopics(Array.isArray(output.topics) ? output.topics : []);
+    else setGroups(Array.isArray(output.consumer_groups) ? output.consumer_groups : []);
+  }
+
+  async function changeView(nextView) {
+    setView(nextView);
+    setSelectedName("");
+    setDetail(null);
+    setDetailIdentity("");
+    setMessages(null);
+    if ((nextView === "topics" ? topics : groups).length === 0) await refreshList(nextView);
+  }
+
+  async function selectItem(item) {
+    if (selectedName === item.name) {
+      setSelectedName("");
+      setDetail(null);
+      setDetailIdentity("");
+      setMessages(null);
+      return;
+    }
+    setSelectedName(item.name);
+    setDetail(null);
+    setDetailIdentity("");
+    setMessages(null);
+    await loadDetail(item.name, view);
+  }
+
+  async function loadDetail(name, detailView = view) {
+    const output = await runAction(
+      detailView === "topics" ? "describe_topic" : "describe_consumer_group",
+      detailView === "topics" ? { topic: name } : { group: name },
+      `manual ${product} browser ${detailView === "topics" ? "topic" : "consumer group"} detail`,
+      "reading",
+      "detail",
+    );
+    if (output) {
+      setDetail(output);
+      setDetailIdentity(`${detailView}:${name}`);
+      if (detailView === "topics" && Array.isArray(output.partitions) && output.partitions.length > 0) {
+        setReadForm((current) => ({ ...current, partition: String(output.partitions[0].partition) }));
+      }
+    }
+    return output;
+  }
+
+  async function readMessages() {
+    if (!selectedName) return;
+    const input = {
+      topic: selectedName,
+      partition: Number(readForm.partition),
+      start_position: readForm.start_position,
+      max_records: Number(readForm.max_records),
+      max_bytes: 262144,
+      wait_seconds: 2,
+    };
+    if (readForm.start_position === "offset") input.offset = readForm.offset;
+    const output = await runAction("read_messages", input, `manual ${product} browser bounded message sample`, "reading", "messages");
+    if (output) setMessages(output);
+  }
+
+  if (!activeSession.active) {
+    return (
+      <div className={`grid h-full min-h-0 place-items-center p-6 ${panelClass}`}>
+        <div className="grid max-w-lg gap-4 text-center">
+          <Database className={`mx-auto h-8 w-8 ${mutedClass}`} />
+          <div>
+            <p className="font-semibold">No active {product} session</p>
+            <p className={`mt-1 text-sm ${mutedClass}`}>Start a structured session to browse topics, consumer groups, lag, and bounded message samples.</p>
+          </div>
+          <Button type="button" className="mx-auto" onClick={onNewStructuredSession}>New session</Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] ${panelClass}`}>
+      <div className="grid min-h-0 gap-4 overflow-y-auto p-4 xl:grid-cols-[360px_minmax(0,1fr)] xl:overflow-hidden">
+        <section className={`grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden rounded-lg border ${borderClass} ${subtlePanelClass}`}>
+          <div className={`grid grid-cols-2 gap-1 border-b p-2 ${borderClass}`} role="tablist" aria-label={`${product} browser view`}>
+            <Button type="button" role="tab" aria-selected={view === "topics"} variant={view === "topics" ? "default" : "outline"} className="h-9" onClick={() => void changeView("topics")}>
+              <Database className="h-4 w-4" />Topics
+            </Button>
+            <Button type="button" role="tab" aria-selected={view === "groups"} variant={view === "groups" ? "default" : "outline"} className="h-9" onClick={() => void changeView("groups")}>
+              <Users className="h-4 w-4" />Groups
+            </Button>
+          </div>
+          <div className={`grid grid-cols-[minmax(0,1fr)_auto] gap-2 border-b p-3 ${borderClass}`}>
+            <div className="relative">
+              <Search className={`pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 ${mutedClass}`} />
+              <Input className={`pl-9 ${inputClass}`} value={query} onChange={(event) => setQuery(event.target.value)} placeholder={`Filter ${view}`} aria-label={`Filter ${view}`} />
+            </div>
+            <Button type="button" variant="outline" className="h-9 w-9 px-0" title={`Refresh ${view}`} onClick={() => void refreshList()} disabled={state.state !== "idle"}>
+              <RefreshCcw className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="min-h-0 overflow-auto p-2">
+            {filteredItems.map((item) => (
+              <button
+                key={item.name}
+                type="button"
+                className={`mb-1 grid w-full gap-1 rounded-md border px-3 py-2 text-left transition ${selectedName === item.name ? activeClass : `${borderClass} ${hoverClass}`}`}
+                onClick={() => void selectItem(item)}
+                aria-pressed={selectedName === item.name}
+              >
+                <span className="truncate font-mono text-xs font-semibold" title={item.name}>{item.name}</span>
+                <span className={`truncate text-xs ${selectedName === item.name ? "" : mutedClass}`}>
+                  {view === "topics"
+                    ? `${item.partition_count || 0} partitions · replication ${item.replication_factor || 0}`
+                    : `${item.state || "unknown"} · ${item.protocol_type || "unknown"}`}
+                </span>
+              </button>
+            ))}
+            {filteredItems.length === 0 ? <Notice>{state.state === "loading" ? `Loading ${view}...` : `No ${view} found.`}</Notice> : null}
+          </div>
+        </section>
+
+        <section className={`grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden rounded-lg border ${borderClass}`}>
+          <div className={`flex items-center justify-between gap-3 border-b p-3 ${borderClass} ${subtlePanelClass}`}>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold">{selectedName || (view === "topics" ? "Topic detail" : "Consumer group detail")}</p>
+              <p className={`truncate text-xs ${mutedClass}`}>
+                {selectedName ? (view === "topics" ? "Partitions, offsets, and bounded message samples" : "Members, assignments, committed offsets, and lag") : `Select one of the ${view} on the left.`}
+              </p>
+            </div>
+            {activeDetail ? <CopyButton value={JSON.stringify({ detail: activeDetail, messages }, null, 2)} variant="outline" className="h-8 px-2 text-xs">JSON</CopyButton> : null}
+          </div>
+          <div className="grid min-h-0 gap-4 overflow-y-auto p-4 lg:grid-cols-2 lg:overflow-hidden">
+            <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-2">
+              <p className={`text-xs font-semibold uppercase ${mutedClass}`}>{view === "topics" ? "Topic metadata" : "Group and lag"}</p>
+              <TerminalBlock surface="log" className="min-h-0 text-xs">{activeDetail ? JSON.stringify(activeDetail, null, 2) : "No item selected."}</TerminalBlock>
+            </div>
+            <div className="grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] gap-2">
+              <p className={`text-xs font-semibold uppercase ${mutedClass}`}>{view === "topics" ? "Message sample" : "Assignments"}</p>
+              {view === "topics" ? (
+                <div className="grid gap-2 sm:grid-cols-[100px_140px_110px_minmax(0,1fr)_auto]">
+                  <Select className={inputClass} value={readForm.partition} onChange={(event) => setReadForm({ ...readForm, partition: event.target.value })} aria-label="Partition">
+                    {(activeDetail?.partitions || []).map((partition) => <option value={partition.partition} key={partition.partition}>p{partition.partition}</option>)}
+                  </Select>
+                  <Select className={inputClass} value={readForm.start_position} onChange={(event) => setReadForm({ ...readForm, start_position: event.target.value })} aria-label="Start position">
+                    <option value="recent">Recent</option>
+                    <option value="earliest">Earliest</option>
+                    <option value="offset">Offset</option>
+                  </Select>
+                  <Input className={inputClass} type="number" min="0" value={readForm.start_position === "offset" ? readForm.offset : readForm.max_records} onChange={(event) => setReadForm({ ...readForm, [readForm.start_position === "offset" ? "offset" : "max_records"]: event.target.value })} aria-label={readForm.start_position === "offset" ? "Offset" : "Maximum records"} />
+                  <span />
+                  <Button type="button" className="h-9" disabled={!selectedName || state.state !== "idle"} onClick={() => void readMessages()}>
+                    <Eye className="h-4 w-4" />Read
+                  </Button>
+                </div>
+              ) : <span />}
+              <TerminalBlock surface="log" className="min-h-0 text-xs">
+                {view === "topics"
+                  ? (messages ? JSON.stringify(messages, null, 2) : "No messages read in this session.")
+                  : (activeDetail ? JSON.stringify({ members: activeDetail.members || [], partitions: activeDetail.partitions || [] }, null, 2) : "No consumer group selected.")}
+              </TerminalBlock>
+            </div>
+          </div>
+          <div className={`grid gap-2 border-t p-3 ${borderClass}`} aria-live="polite">
+            <Notice tone="warn">Message values, keys, and headers can contain secrets. Samples are bounded and never commit consumer offsets.</Notice>
+            {state.error ? <Notice tone="bad">{state.error}</Notice> : null}
+            {state.message ? <Notice tone="good">{state.message}</Notice> : null}
+          </div>
+        </section>
+      </div>
+      <div className={`flex min-w-0 items-center justify-between gap-3 border-t px-3 py-2 text-xs ${borderClass}`}>
+        <span className={`truncate font-mono ${mutedClass}`}>{target.ref}</span>
+        <span className={`flex items-center gap-2 truncate ${mutedClass}`}>
+          {latestAction ? <Badge tone={latestAction.status === "completed" ? "good" : latestAction.status === "failed" ? "bad" : "warn"}>{latestAction.action_name}</Badge> : <Activity className="h-3.5 w-3.5" />}
+          {String(target.config?.bootstrap_brokers || "").split(/[\s,]+/).filter(Boolean).join(", ")}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/connectors/templates/kafka/credential-form.jsx
+++ b/frontend/src/connectors/templates/kafka/credential-form.jsx
@@ -1,0 +1,41 @@
+import { Database, Plus } from "lucide-react";
+import { Button } from "../../../components/ui/button";
+import { Field, Input, Select } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+import { targetEndpoint } from "./model-helpers";
+import { KafkaSASLFields } from "./sasl-fields";
+
+export function KafkaCredentialFormTemplate({ targets, form, formMode = "create", state, onChange, onSubmit }) {
+  const kafkaTargets = targets.filter((target) => target.connector_kind === "kafka");
+  const editing = formMode === "edit";
+  return (
+    <form className="grid gap-4" onSubmit={onSubmit}>
+      {kafkaTargets.length === 0 ? <Notice tone="warn">Create a Kafka / Redpanda connector before adding a credential profile.</Notice> : null}
+      <Field>
+        Connector target
+        <Select value={form.target_id} onChange={(event) => onChange({ ...form, target_id: event.target.value })} disabled={editing} required>
+          <option value="" disabled>Select Kafka / Redpanda target</option>
+          {kafkaTargets.map((target) => <option value={target.id} key={target.id}>{target.name} · {targetEndpoint(target)}</option>)}
+        </Select>
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange({ ...form, profile_label: event.target.value })} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange({ ...form, risk_label: event.target.value })} />
+        </Field>
+      </div>
+      <KafkaSASLFields form={form} editing={editing} onChange={(name, value) => onChange({ ...form, [name]: value })} />
+      {form.sasl_mechanism === "plain" ? <Notice tone="warn">The target must use TLS or explicitly allow insecure PLAIN on a trusted private network.</Notice> : null}
+      {state.state === "error" ? <Notice tone="bad">{state.error}</Notice> : null}
+      <Button type="submit" disabled={state.state === "saving" || kafkaTargets.length === 0}>
+        <Plus className="h-4 w-4" />
+        {state.state === "saving" ? "Saving..." : editing ? "Save Kafka credential" : "Create Kafka credential"}
+      </Button>
+      <Notice><Database className="mr-2 inline h-4 w-4" />SASL passwords stay in the encrypted local database and are never returned in connector lists.</Notice>
+    </form>
+  );
+}

--- a/frontend/src/connectors/templates/kafka/form.jsx
+++ b/frontend/src/connectors/templates/kafka/form.jsx
@@ -1,0 +1,128 @@
+import { Field, Input, Select, Textarea } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+import { sshProfileOptions } from "../_shared/network-transport-fields";
+import { HostPingButton } from "../host-ping-button";
+import { KafkaSASLFields } from "./sasl-fields";
+
+export function KafkaConnectorFormTemplate({ form, mode = "create", targets = [], onChange }) {
+  const editing = mode === "edit";
+  const overSSH = form.connection_mode === "over_ssh";
+  const sshProfiles = sshProfileOptions(targets);
+  return (
+    <>
+      <Notice tone="good">
+        Kafka and Redpanda share one connector. Start with read actions in Prompt mode; message samples can contain sensitive application data.
+      </Notice>
+      <Field>
+        Connector name
+        <Input value={form.name} onChange={(event) => onChange("name", event.target.value)} required />
+      </Field>
+      <Field>
+        Server family
+        <Select value={form.server_family} onChange={(event) => onChange("server_family", event.target.value)}>
+          <option value="kafka">Apache Kafka</option>
+          <option value="redpanda">Redpanda</option>
+        </Select>
+      </Field>
+      <Field>
+        Connection mode
+        <Select value={form.connection_mode} onChange={(event) => onChange("connection_mode", event.target.value)}>
+          <option value="direct">Direct from this gateway</option>
+          <option value="over_ssh">Over an SSH connector profile</option>
+        </Select>
+      </Field>
+      {overSSH ? (
+        <Field>
+          SSH transport profile
+          <Select value={form.transport_target_ref} onChange={(event) => onChange("transport_target_ref", event.target.value)} required>
+            <option value="" disabled>Select SSH profile</option>
+            {sshProfiles.map((profile) => <option value={profile.ref} key={profile.ref}>{profile.label}</option>)}
+          </Select>
+        </Field>
+      ) : null}
+      <Notice>
+        {overSSH
+          ? "Every broker address advertised by the cluster is reached through the selected SSH transport. Broker hostnames must resolve on that remote host."
+          : "The gateway must reach bootstrap and advertised broker addresses. For a broker on the Docker host, use host.docker.internal instead of localhost."}
+      </Notice>
+      <Field>
+        <span className="flex items-center justify-between gap-2">
+          <span>Bootstrap brokers</span>
+          <HostPingButton
+            host={firstBrokerHost(form.bootstrap_brokers)}
+            port={firstBrokerPort(form.bootstrap_brokers)}
+            mode={form.connection_mode}
+            transportTargetRef={form.transport_target_ref}
+          />
+        </span>
+        <Textarea
+          className="min-h-24 font-mono text-xs"
+          value={form.bootstrap_brokers}
+          onChange={(event) => onChange("bootstrap_brokers", event.target.value)}
+          placeholder={"broker-1:9092\nbroker-2:9092"}
+          required
+        />
+        <span className="text-xs text-stone-500">One host:port per line, or a comma-separated list.</span>
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          TLS
+          <Select value={form.tls_enabled ? "enabled" : "disabled"} onChange={(event) => onChange("tls_enabled", event.target.value === "enabled")}>
+            <option value="disabled">Disabled</option>
+            <option value="enabled">Enabled</option>
+          </Select>
+        </Field>
+        <Field>
+          TLS server name
+          <Input value={form.tls_server_name} onChange={(event) => onChange("tls_server_name", event.target.value)} disabled={!form.tls_enabled} placeholder="Optional certificate hostname override" />
+        </Field>
+      </div>
+      {!form.tls_enabled && form.sasl_mechanism === "plain" ? (
+        <Field>
+          PLAIN without TLS
+          <Select
+            value={form.allow_insecure_plain_sasl ? "allowed" : "blocked"}
+            onChange={(event) => onChange("allow_insecure_plain_sasl", event.target.value === "allowed")}
+          >
+            <option value="blocked">Blocked</option>
+            <option value="allowed">Allow on this trusted network</option>
+          </Select>
+          <span className="text-xs text-amber-600">PLAIN sends credentials without transport encryption. Prefer TLS or SCRAM.</span>
+        </Field>
+      ) : null}
+      {form.tls_enabled ? (
+        <Field>
+          Custom CA certificate
+          <Textarea className="min-h-24 font-mono text-xs" value={form.tls_ca_pem} onChange={(event) => onChange("tls_ca_pem", event.target.value)} placeholder="Optional PEM certificate chain" />
+        </Field>
+      ) : null}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field>
+          Profile label
+          <Input value={form.profile_label} onChange={(event) => onChange("profile_label", event.target.value)} required />
+        </Field>
+        <Field>
+          Risk label
+          <Input value={form.risk_label} onChange={(event) => onChange("risk_label", event.target.value)} />
+        </Field>
+      </div>
+      <KafkaSASLFields form={form} editing={editing} onChange={onChange} />
+    </>
+  );
+}
+
+function firstBrokerHost(value) {
+  const broker = firstBroker(value);
+  const separator = broker.lastIndexOf(":");
+  return separator > 0 ? broker.slice(0, separator).replace(/^\[|\]$/g, "") : broker;
+}
+
+function firstBrokerPort(value) {
+  const broker = firstBroker(value);
+  const separator = broker.lastIndexOf(":");
+  return separator > 0 ? Number(broker.slice(separator + 1)) || 9092 : 9092;
+}
+
+function firstBroker(value) {
+  return String(value || "").split(/[\s,]+/).find(Boolean) || "127.0.0.1:9092";
+}

--- a/frontend/src/connectors/templates/kafka/index.jsx
+++ b/frontend/src/connectors/templates/kafka/index.jsx
@@ -1,0 +1,15 @@
+import { KafkaConnectorConsoleTemplate } from "./console";
+import { KafkaCredentialFormTemplate } from "./credential-form";
+import { KafkaConnectorFormTemplate } from "./form";
+import { KafkaConnectorRowActionsTemplate } from "./list-item";
+import { KafkaConnectorOperationsTemplate } from "./operations";
+import * as model from "./model";
+
+export default Object.freeze({
+  Console: KafkaConnectorConsoleTemplate,
+  CredentialForm: KafkaCredentialFormTemplate,
+  Form: KafkaConnectorFormTemplate,
+  model,
+  Operations: KafkaConnectorOperationsTemplate,
+  RowActions: KafkaConnectorRowActionsTemplate,
+});

--- a/frontend/src/connectors/templates/kafka/list-item.jsx
+++ b/frontend/src/connectors/templates/kafka/list-item.jsx
@@ -1,0 +1,3 @@
+export function KafkaConnectorRowActionsTemplate() {
+  return null;
+}

--- a/frontend/src/connectors/templates/kafka/metadata.json
+++ b/frontend/src/connectors/templates/kafka/metadata.json
@@ -1,0 +1,8 @@
+{
+  "kind": "kafka",
+  "label": "Kafka / Redpanda",
+  "summary": "Kafka-compatible cluster, topic, consumer group, lag, and bounded message inspection through direct or SSH-transported profiles.",
+  "version": "0.2",
+  "icon": "database",
+  "badge_tone": "warn"
+}

--- a/frontend/src/connectors/templates/kafka/model-helpers.js
+++ b/frontend/src/connectors/templates/kafka/model-helpers.js
@@ -1,0 +1,16 @@
+export function credentialPayload(form, existingKind = "sasl") {
+  const payload = {
+    kind: existingKind || "sasl",
+    label: form.profile_label,
+    public: { mechanism: form.sasl_mechanism || "none", username: form.sasl_mechanism === "none" ? "" : form.username || "" },
+    risk_label: form.risk_label || "stream read",
+  };
+  if (form.sasl_mechanism === "none") payload.secret = { password: "" };
+  else if (form.password) payload.secret = { password: form.password };
+  else if ((form.existing_sasl_mechanism || "none") === "none") throw new Error("Password is required when enabling SASL.");
+  return payload;
+}
+
+export function targetEndpoint(target) {
+  return String(target?.config?.bootstrap_brokers || "no brokers").split(/[\s,]+/).filter(Boolean).join(", ");
+}

--- a/frontend/src/connectors/templates/kafka/model.js
+++ b/frontend/src/connectors/templates/kafka/model.js
@@ -1,0 +1,213 @@
+import { apiDelete, apiPost, apiPut } from "../../../lib/api";
+import { createTargetWithProfile, updateTargetWithProfile } from "../target-profile-save";
+import { credentialPayload, targetEndpoint as brokerEndpoint } from "./model-helpers";
+
+export { credentialPayload } from "./model-helpers";
+
+const defaultRiskLabel = "stream read";
+
+export function emptyForm() {
+  return {
+    connector_kind: "kafka",
+    name: "event-stream",
+    server_family: "kafka",
+    connection_mode: "direct",
+    bootstrap_brokers: "127.0.0.1:9092",
+    transport_target_ref: "",
+    tls_enabled: false,
+    allow_insecure_plain_sasl: false,
+    tls_server_name: "",
+    tls_ca_pem: "",
+    profile_label: "monitor",
+    sasl_mechanism: "none",
+    existing_sasl_mechanism: "none",
+    username: "",
+    password: "",
+    risk_label: defaultRiskLabel,
+  };
+}
+
+export function formFromTarget({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : {});
+  return {
+    connector_kind: "kafka",
+    profile_id: selectedProfile.id ? String(selectedProfile.id) : "",
+    name: target.name || "",
+    server_family: target.config?.server_family || "kafka",
+    connection_mode: target.config?.connection_mode || "direct",
+    bootstrap_brokers: target.config?.bootstrap_brokers || "127.0.0.1:9092",
+    transport_target_ref: target.config?.transport_target_ref || "",
+    tls_enabled: Boolean(target.config?.tls_enabled),
+    allow_insecure_plain_sasl: Boolean(target.config?.allow_insecure_plain_sasl),
+    tls_server_name: target.config?.tls_server_name || "",
+    tls_ca_pem: target.config?.tls_ca_pem || "",
+    profile_label: selectedProfile.label || "monitor",
+    sasl_mechanism: selectedProfile.public?.mechanism || "none",
+    existing_sasl_mechanism: selectedProfile.public?.mechanism || "none",
+    username: selectedProfile.public?.username || "",
+    password: "",
+    risk_label: selectedProfile.risk_label || defaultRiskLabel,
+  };
+}
+
+export function activeCredential() { return null; }
+
+export function syncForm({ form }) {
+  if (form.connector_kind !== "kafka") return form;
+  const next = { ...form };
+  if (next.connection_mode === "direct") next.transport_target_ref = "";
+  if (!next.tls_enabled) {
+    next.tls_server_name = "";
+    next.tls_ca_pem = "";
+  }
+  if (next.sasl_mechanism === "none") {
+    next.username = "";
+    next.password = "";
+  }
+  return next;
+}
+
+export function submitDisabled({ state }) { return state.state === "saving"; }
+export function submitLabel({ state, mode }) {
+  if (state.state === "saving") return "Saving...";
+  return mode === "edit" ? "Save changes" : "Create connector";
+}
+export async function save({ mode, form, target }) {
+  if (mode === "edit") return updateTarget({ form, target });
+  return createTarget({ form });
+}
+export async function deleteTarget({ target }) { await apiDelete(`/api/connector-targets/${target.id}`); }
+
+export function emptyCredentialState({ targets = [] } = {}) {
+  const firstTarget = targets.find((target) => target.connector_kind === "kafka");
+  return { form: { target_id: String(firstTarget?.id || ""), profile_label: "monitor", sasl_mechanism: "none", existing_sasl_mechanism: "none", username: "", password: "", risk_label: defaultRiskLabel } };
+}
+export function credentialStateFromRow({ row }) {
+  return { form: {
+    target_id: String(row.target_id || ""),
+    profile_label: row.name,
+    sasl_mechanism: row.profile?.public?.mechanism || "none",
+    existing_sasl_mechanism: row.profile?.public?.mechanism || "none",
+    username: row.profile?.public?.username || "",
+    password: "",
+    risk_label: row.profile?.risk_label || defaultRiskLabel,
+  } };
+}
+export function credentialFormProps({ targets, formState, setFormState, formMode, state, onSubmit }) {
+  return {
+    form: formState.form, formMode, targets, state,
+    onChange: (form) => setFormState({ form }),
+    onSubmit: (event) => onSubmit(event, formMode === "edit" ? "update" : "create"),
+  };
+}
+export async function saveCredential({ operation, row, formState }) {
+  const form = formState.form;
+  const payload = credentialPayload(form, row?.profile?.kind);
+  if (operation === "create") {
+    await apiPost(`/api/connector-targets/${form.target_id}/profiles`, payload);
+    return { message: "Kafka credential created." };
+  }
+  if (operation === "update") {
+    if (!row) throw new Error("Kafka credential is not loaded.");
+    await apiPut(`/api/connector-targets/${form.target_id}/profiles/${row.id}`, payload);
+    return { message: "Kafka credential updated." };
+  }
+  throw new Error("Unsupported Kafka credential operation.");
+}
+export async function deleteCredential({ row }) { await apiDelete(`/api/connector-targets/${row.target_id}/profiles/${row.id}`); }
+export function credentialRows({ targets }) {
+  return targets.flatMap((target) => (target.profiles || [])
+    .filter(() => target.connector_kind === "kafka")
+    .map((profile) => ({
+      row_id: `${target.connector_kind}:${target.id}:${profile.id}`,
+      connector_kind: target.connector_kind,
+      resource_kind: "credential_profile",
+      connector_label: "Kafka / Redpanda",
+      id: profile.id,
+      target_id: target.id,
+      name: profile.label,
+      kind: profile.kind,
+      profile,
+      target_label: target.name,
+      target_detail: targetEndpoint({ target }),
+      metadata: credentialMetadata(profile),
+      delete_disabled: "",
+    })));
+}
+export async function test({ target, profile }) {
+  const selectedProfile = profile || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!selectedProfile) throw new Error("Connector profile is not loaded.");
+  const data = await apiPost(`/api/connector-targets/${target.id}/profiles/${selectedProfile.id}/test`, {});
+  return { ok: data.ok, error: data.message || null, data };
+}
+export function canEdit() { return true; }
+export function canDelete() { return true; }
+export function credentialHint() { return null; }
+export function targetEndpoint({ target }) {
+  return targetEndpointValue(target);
+}
+function targetEndpointValue(target) {
+  const brokers = brokerEndpoint(target);
+  const mode = target.config?.connection_mode === "over_ssh" ? "over ssh" : "direct";
+  return `${brokers} · ${mode}`;
+}
+export function targetDisplayName({ target }) { return target?.target_name || target?.name || "Kafka target"; }
+export function targetSubtitle({ target }) { return targetEndpoint({ target }); }
+export function targetProfileLabel({ target }) { return target?.profile_label || "monitor"; }
+export function usesLiveConsole() { return false; }
+export function recoverableRunningActions() { return []; }
+export function deleteDialog({ target }) {
+  return {
+    title: target ? `Delete ${target.name}` : "Delete connector",
+    description: "Remove this Kafka / Redpanda target, credential profiles, and token action permissions from aipermission.",
+    details: [
+      { label: "Connector", value: target?.name },
+      { label: "Reference", value: target ? `${target.connector_kind}:${target.id}` : "" },
+    ],
+    notice: "This does not change the Kafka or Redpanda cluster.",
+    actions: [
+      { label: "Cancel", action: "close", variant: "outline" },
+      { label: "Delete connector", pendingLabel: "Deleting...", removeKey: false },
+    ],
+  };
+}
+export function operationFromError() { return null; }
+
+async function createTarget({ form }) {
+  await createTargetWithProfile({
+    projectID: form.project_id,
+    targetPayload: { connector_kind: "kafka", name: form.name, config: targetConfig(form) },
+    profilePayload: credentialPayload(form),
+  });
+}
+async function updateTarget({ form, target }) {
+  const profile = target?.profiles?.find((item) => Number(item.id) === Number(form.profile_id)) || (target?.profiles?.length === 1 ? target.profiles[0] : null);
+  if (!target || !profile) throw new Error("Kafka connector profile is not loaded.");
+  await updateTargetWithProfile({
+    projectID: form.project_id,
+    targetID: target.id,
+    previousTarget: target,
+    profileID: profile.id,
+    targetPayload: { name: form.name, config: targetConfig(form) },
+    profilePayload: credentialPayload(form, profile.kind),
+  });
+}
+function targetConfig(form) {
+  return {
+    server_family: form.server_family === "redpanda" ? "redpanda" : "kafka",
+    connection_mode: form.connection_mode || "direct",
+    bootstrap_brokers: form.bootstrap_brokers || "127.0.0.1:9092",
+    transport_target_ref: form.connection_mode === "over_ssh" ? form.transport_target_ref || "" : "",
+    tls_enabled: Boolean(form.tls_enabled),
+    allow_insecure_plain_sasl: Boolean(form.allow_insecure_plain_sasl),
+    tls_server_name: form.tls_enabled ? form.tls_server_name || "" : "",
+    tls_ca_pem: form.tls_enabled ? form.tls_ca_pem || "" : "",
+  };
+}
+function credentialMetadata(profile) {
+  const mechanism = profile.public?.mechanism || "none";
+  const items = [`SASL: ${mechanism}`];
+  if (profile.public?.username) items.push(`username: ${profile.public.username}`);
+  if (profile.risk_label) items.push(`risk: ${profile.risk_label}`);
+  return items;
+}

--- a/frontend/src/connectors/templates/kafka/operations.jsx
+++ b/frontend/src/connectors/templates/kafka/operations.jsx
@@ -1,0 +1,3 @@
+export function KafkaConnectorOperationsTemplate() {
+  return null;
+}

--- a/frontend/src/connectors/templates/kafka/sasl-fields.jsx
+++ b/frontend/src/connectors/templates/kafka/sasl-fields.jsx
@@ -1,0 +1,38 @@
+import { Field, Input, Select } from "../../../components/ui/form";
+
+export function KafkaSASLFields({ form, editing = false, onChange }) {
+  const secured = form.sasl_mechanism !== "none";
+  const passwordRequired = secured && (!editing || (form.existing_sasl_mechanism || "none") === "none");
+  return (
+    <>
+      <Field>
+        SASL mechanism
+        <Select value={form.sasl_mechanism} onChange={(event) => onChange("sasl_mechanism", event.target.value)}>
+          <option value="none">None</option>
+          <option value="plain">PLAIN</option>
+          <option value="scram_sha_256">SCRAM-SHA-256</option>
+          <option value="scram_sha_512">SCRAM-SHA-512</option>
+        </Select>
+      </Field>
+      {secured ? (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Field>
+            Username
+            <Input value={form.username} onChange={(event) => onChange("username", event.target.value)} autoComplete="off" required />
+          </Field>
+          <Field>
+            {editing ? "New password" : "Password"}
+            <Input
+              type="password"
+              value={form.password}
+              onChange={(event) => onChange("password", event.target.value)}
+              autoComplete="new-password"
+              required={passwordRequired}
+              placeholder={editing ? "Leave blank to keep the encrypted password" : ""}
+            />
+          </Field>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,3 +1,5 @@
+import { scopedUICookieName } from "./ui-cookie.js";
+
 const viteEnv = import.meta.env || {};
 
 export const apiUrl =
@@ -126,7 +128,7 @@ function browserOrigin() {
 }
 
 function csrfHeaders(base = {}) {
-  const token = readCookie("aipermission_csrf");
+  const token = readCookie(scopedUICookieName("aipermission_csrf"));
   if (!token) return base;
   return { ...base, "X-AIPermission-CSRF": token };
 }

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -297,7 +297,8 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.17"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.18"/);
+  assert.match(releaseSource, /Kafka \/ Redpanda read browser/);
   assert.match(releaseSource, /Redis \/ Valkey compatibility/);
   assert.match(releaseSource, /Security and dependency maintenance/);
   assert.match(releaseSource, /Projects and scoped visibility/);

--- a/frontend/src/lib/kafka-console.test.js
+++ b/frontend/src/lib/kafka-console.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { connectorActionError, detailMatchesSelection, requestIsCurrent } from "../connectors/templates/kafka/console-helpers.js";
+import { credentialPayload } from "../connectors/templates/kafka/model-helpers.js";
+
+test("Kafka action helpers surface failed HTTP 200 responses", () => {
+  assert.equal(connectorActionError({ status: "failed", error: "broker denied access" }), "broker denied access");
+  assert.equal(connectorActionError({ status: "completed", output: {} }), "");
+});
+
+test("Kafka action helpers reject stale target and channel responses", () => {
+  const versions = new Map([["detail", 2]]);
+  assert.equal(requestIsCurrent(versions, "detail", 2, "kafka:1:1", "kafka:1:1"), true);
+  assert.equal(requestIsCurrent(versions, "detail", 1, "kafka:1:1", "kafka:1:1"), false);
+  assert.equal(requestIsCurrent(versions, "detail", 2, "kafka:1:1", "kafka:2:2"), false);
+});
+
+test("Kafka detail helpers bind responses to the selected view and item", () => {
+  assert.equal(detailMatchesSelection("topics:events", "topics", "events"), true);
+  assert.equal(detailMatchesSelection("topics:events", "groups", "events"), false);
+  assert.equal(detailMatchesSelection("topics:events", "topics", "orders"), false);
+});
+
+test("Kafka credential edits preserve an existing SASL password", () => {
+  const form = {
+    profile_label: "monitor",
+    sasl_mechanism: "scram_sha_512",
+    existing_sasl_mechanism: "scram_sha_512",
+    username: "reader",
+    password: "",
+    risk_label: "stream read",
+  };
+  assert.equal(credentialPayload(form).secret, undefined);
+});
+
+test("Kafka credential payload requires a password when SASL is enabled", () => {
+  const form = {
+    profile_label: "monitor",
+    sasl_mechanism: "plain",
+    existing_sasl_mechanism: "none",
+    username: "reader",
+    password: "",
+    risk_label: "stream read",
+  };
+  assert.throws(() => credentialPayload(form), /Password is required/);
+  assert.deepEqual(credentialPayload({ ...form, password: "test-password" }).secret, { password: "test-password" });
+});

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,26 @@
-export const appVersion = "0.2.17";
+export const appVersion = "0.2.18";
 
 export const changelogEntries = [
+  {
+    version: "0.2.18",
+    label: "Kafka / Redpanda read browser",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Kafka and Redpanda now share one connector kind with Direct and Over SSH transport, multiple bootstrap brokers, TLS/custom CA, and optional PLAIN or SCRAM SASL profiles.",
+          "The browser and generic MCP action catalog expose cluster metadata, topics, partitions, consumer groups, lag, and bounded message samples.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "Message reads use explicit partition assignment with record, byte, and time bounds; they do not join consumer groups, commit offsets, or enable automatic topic creation.",
+          "Stable and development localhost stacks now use frontend-port-scoped UI cookies so they can remain unlocked independently.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.17",
     label: "Redis / Valkey compatibility",

--- a/frontend/src/lib/ui-cookie.js
+++ b/frontend/src/lib/ui-cookie.js
@@ -1,0 +1,16 @@
+export function scopedUICookieName(base, location = browserLocation()) {
+  const port = location?.port || defaultPort(location?.protocol);
+  if (!port) return base;
+  const scope = String(port).replace(/[^A-Za-z0-9_-]/g, "_");
+  return scope ? `${base}_${scope}` : base;
+}
+
+function browserLocation() {
+  return typeof window === "undefined" ? null : window.location;
+}
+
+function defaultPort(protocol) {
+  if (protocol === "http:") return "80";
+  if (protocol === "https:") return "443";
+  return "";
+}

--- a/frontend/src/lib/ui-cookie.test.js
+++ b/frontend/src/lib/ui-cookie.test.js
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { scopedUICookieName } from "./ui-cookie.js";
+
+test("scopes UI cookie names by frontend port", () => {
+  assert.equal(scopedUICookieName("aipermission_csrf", { protocol: "http:", port: "3210" }), "aipermission_csrf_3210");
+  assert.equal(scopedUICookieName("aipermission_csrf", { protocol: "http:", port: "3212" }), "aipermission_csrf_3212");
+});
+
+test("uses the standard protocol port when location omits it", () => {
+  assert.equal(scopedUICookieName("aipermission_csrf", { protocol: "http:", port: "" }), "aipermission_csrf_80");
+  assert.equal(scopedUICookieName("aipermission_csrf", { protocol: "https:", port: "" }), "aipermission_csrf_443");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3733,7 +3733,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.15",
+      "version": "0.2.18",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -9,7 +9,7 @@ credentials, or other connector secrets.
 The gateway is intentionally local-only. Run it on the developer machine and
 keep the URL on `localhost`; remote systems are connector targets, not places
 to host the gateway for LAN or internet users. SSH, Postgres, ClickHouse,
-Redis / Valkey, RabbitMQ, S3, Docker, and Kubernetes are built-in connectors that use the same
+Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, and Kubernetes are built-in connectors that use the same
 target/profile/action permission model as future connectors.
 
 ![AIPermission demo: AI operates through approval-based connector access](https://raw.githubusercontent.com/aipermission/aipermission/main/docs/assets/demo/aipermission-demo.gif)
@@ -66,7 +66,7 @@ The generated MCP config contains a bearer token. Keep it private. For project-l
 - `cancel_vault_action_request`
 
 All integration work goes through connector targets. SSH, Postgres, ClickHouse,
-Redis / Valkey, RabbitMQ, S3, Docker, Kubernetes, and future connectors share the same model: target,
+Redis / Valkey, RabbitMQ, Kafka / Redpanda, S3, Docker, Kubernetes, and future connectors share the same model: target,
 credential profile, connector action, token action permission, approval,
 history, and audit.
 
@@ -111,6 +111,12 @@ browser actions such as `overview`, `list_vhosts`, `list_queues`, `get_queue`,
 `list_bindings`, `peek_messages`, and `publish_message`. Message payload
 previews and published payloads can contain secrets or customer data; use short
 reasons and prefer approval-required access until the workflow is trusted.
+
+For Kafka or Redpanda, call `get_connector_actions(target_ref)` to discover
+cluster, topic, consumer-group, lag, and bounded message-read actions. Message
+reads use explicit partition assignment, never join a consumer group, and
+never commit offsets. Payloads can contain sensitive application data, so keep
+these reads in Prompt mode until the workflow is trusted.
 
 For Docker, call `get_connector_actions(target_ref)` to discover bounded
 actions such as `docker_version`, `list_containers`, `list_images`,

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/resources/aipermission-operator/SKILL.md
+++ b/packages/mcp/resources/aipermission-operator/SKILL.md
@@ -53,6 +53,10 @@ Peek a RabbitMQ queue after the operator approved payload inspection. Publish
 RabbitMQ messages only when the operator explicitly asked for a write.
 ```
 
+For Kafka / Redpanda, discover topics before describing partitions or reading
+messages. Keep message reads bounded, prefer Prompt because payloads can be
+sensitive, and remember that read actions never join groups or commit offsets.
+
 Avoid vague reasons:
 
 ```text

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- add a read-focused Kafka / Redpanda connector with Direct and Over SSH transport
- add bounded topic, consumer-group, lag, and message inspection
- add a structured browser console and SASL/TLS credential forms
- isolate UI sessions by local frontend port

## Validation

- `make release-check`
- full Docker dev stack build on `http://localhost:3212`
- `/api/status` reports the gateway running