### PR TITLE
feat(kafka): add guarded write controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.19] - 2026-07-31
+
+### Added
+
+- Added guarded Kafka / Redpanda `publish_message` writes with explicit
+  partition selection, bounded keys, values, and headers, all-in-sync-replica
+  acknowledgements, and no automatic topic creation.
+- Added destructive `set_consumer_group_offset` control for one explicit topic
+  partition, including a best-effort inactive-group guard, valid log-range
+  validation, post-commit verification, and post-commit group-state reporting.
+- Added local browser dialogs with explicit confirmation for publishing
+  messages and changing inactive consumer-group offsets. Browser actions use
+  the shared connector execution, history, and audit path; MCP calls continue
+  to use token permissions and Prompt/Always policy.
+
+### Security
+
+- Publish approval previews expose content lengths instead of raw message
+  bytes. Raw keys, values, and headers remain only in the encrypted execution
+  envelope and are redacted from displayed request input.
+- Offset changes require an inactive consumer group immediately before commit
+  and are classified destructive. Kafka cannot provide an atomic member-join
+  lock across that interval, so Prompt remains the recommended rule.
+
 ## [0.2.18] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ Implemented:
   explicit message publishing
 - built-in Kafka / Redpanda connector with Direct and Over SSH connection
   modes, TLS and SASL profiles, cluster/topic/group/lag inspection, and bounded
-  message samples that never join groups or commit offsets
+  message samples that never join groups or commit offsets, plus guarded
+  single-message publishing and inactive-group offset controls
   ([setup guide](docs/setup/kafka-redpanda.md))
 - built-in S3 connector with Direct and Over SSH connection modes,
   S3-compatible bucket browsing, object metadata, bounded object
@@ -230,7 +231,7 @@ To pin a specific release image, set `AIPERMISSION_VERSION` without the leading
 `v`:
 
 ```bash
-AIPERMISSION_VERSION=0.2.18 docker compose -f docker-compose.release.yml up -d
+AIPERMISSION_VERSION=0.2.19 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, clone the repository with Git's default text handling or make sure
@@ -410,6 +411,13 @@ as `overview`, `list_vhosts`, `list_queues`, `get_queue`, `list_bindings`, and
 `peek_messages`, and `publish_message`. Treat message payload previews and
 message publishing as sensitive queue access; previews use bounded
 count/truncation limits and `ack_requeue_true`.
+
+For Kafka or Redpanda, discover cluster/topic/group reads, bounded partition
+samples, guarded single-message publishing, and classic consumer-group offset
+controls through the same generic tools. Publish request displays redact raw
+keys, values, and headers. Offset changes reject active and modern-protocol
+groups; failed publishes can have an unknown delivery outcome, so inspect
+before retrying.
 
 For S3, call `get_connector_actions(target_ref)` to discover actions such as
 `bucket_info`, `list_objects`, `get_object_metadata`, `download_object`,

--- a/backend/internal/api/connector_action_runtime.go
+++ b/backend/internal/api/connector_action_runtime.go
@@ -333,7 +333,7 @@ func (s *Server) insertPreparedConnectorActionRequest(
 		Summary:              s.redactForPersistence(ctx, runtime, prepared.Action.Summary),
 		Preview:              s.redactConnectorActionPreview(ctx, runtime, prepared.Action.Preview, prepared.ActionDefinition.OutputHint),
 		Source:               prepared.Requested.Source,
-		Input:                s.redactConnectorActionInput(ctx, runtime, prepared.Requested.Input),
+		Input:                s.redactConnectorActionInput(ctx, runtime, prepared.Requested.Input, prepared.ActionDefinition.SensitiveInputFields),
 		EncryptedPayloadJSON: payload,
 		Reason:               s.redactForPersistence(ctx, runtime, prepared.Requested.Reason),
 		Status:               status,
@@ -512,11 +512,18 @@ func (s *Server) redactConnectorActionResult(ctx context.Context, runtime *datab
 	return result
 }
 
-func (s *Server) redactConnectorActionInput(ctx context.Context, runtime *databaseRuntime, input map[string]any) map[string]any {
+func (s *Server) redactConnectorActionInput(ctx context.Context, runtime *databaseRuntime, input map[string]any, sensitiveInputFields []string) map[string]any {
 	if input == nil {
 		return map[string]any{}
 	}
-	redacted, ok := s.redactedConnectorValue(ctx, runtime, input, connectorSensitiveOutputFields()).(map[string]any)
+	fields := connectorSensitiveOutputFields()
+	for _, field := range sensitiveInputFields {
+		normalized := normalizeConnectorOutputField(field)
+		if normalized != "" {
+			fields[normalized] = true
+		}
+	}
+	redacted, ok := s.redactedConnectorValue(ctx, runtime, input, fields).(map[string]any)
 	if !ok || redacted == nil {
 		return map[string]any{}
 	}
@@ -595,13 +602,14 @@ func connectorApprovalContext(prepared actions.PreparedRequest, token tokens.Tok
 		return "", "", err
 	}
 	actionDefinition := map[string]any{
-		"name":         prepared.ActionDefinition.Name,
-		"label":        prepared.ActionDefinition.Label,
-		"description":  prepared.ActionDefinition.Description,
-		"category":     prepared.ActionDefinition.Category,
-		"risk":         prepared.ActionDefinition.Risk,
-		"input_schema": prepared.ActionDefinition.InputSchema,
-		"output_hint":  prepared.ActionDefinition.OutputHint,
+		"name":                   prepared.ActionDefinition.Name,
+		"label":                  prepared.ActionDefinition.Label,
+		"description":            prepared.ActionDefinition.Description,
+		"category":               prepared.ActionDefinition.Category,
+		"risk":                   prepared.ActionDefinition.Risk,
+		"input_schema":           prepared.ActionDefinition.InputSchema,
+		"sensitive_input_fields": prepared.ActionDefinition.SensitiveInputFields,
+		"output_hint":            prepared.ActionDefinition.OutputHint,
 	}
 	actionDefinitionHashMaterial, err := json.Marshal(actionDefinition)
 	if err != nil {

--- a/backend/internal/api/connector_actions_test.go
+++ b/backend/internal/api/connector_actions_test.go
@@ -146,6 +146,15 @@ func TestConnectorApprovalContextHashesConnectorAndActionDefinition(t *testing.T
 	if actionHash == baseHash {
 		t.Fatalf("action definition drift should change approval hash")
 	}
+	sensitiveFieldsChanged := prepared
+	sensitiveFieldsChanged.ActionDefinition.SensitiveInputFields = []string{"sql"}
+	_, sensitiveFieldsHash, err := connectorApprovalContext(sensitiveFieldsChanged, token, permission, "2026-06-12T12:00:00Z")
+	if err != nil {
+		t.Fatalf("approval context with sensitive input field change: %v", err)
+	}
+	if sensitiveFieldsHash == baseHash {
+		t.Fatalf("sensitive input field drift should change approval hash")
+	}
 	profileChanged := prepared
 	profileChanged.Profile.SecretRevision = "secret-revision-b"
 	_, profileHash, err := connectorApprovalContext(profileChanged, token, permission, "2026-06-12T12:00:00Z")
@@ -342,18 +351,17 @@ func TestInsertConnectorActionRequestRedactsDisplayedInputOnly(t *testing.T) {
 		t.Fatalf("resolve target/profile: %v", err)
 	}
 	rawInput := map[string]any{
-		"sql":          "select 'password=super-secret' as value",
-		"access_token": "raw-access-token",
-		"nested":       map[string]any{"authorization": "Bearer raw-bearer-token"},
+		"sql":            "select 'password=super-secret' as value",
+		"access_token":   "raw-access-token",
+		"opaque_message": "arbitrary-publish-content",
+		"nested":         map[string]any{"authorization": "Bearer raw-bearer-token"},
 	}
 	prepared := actions.PreparedRequest{
 		Target:  targetView,
 		Profile: profileView,
 		ActionDefinition: connectors.ActionDefinition{
-			Name: postgresconnector.ActionQueryReadonly,
-			OutputHint: connectors.OutputHint{
-				SensitiveFields: []string{"access_token"},
-			},
+			Name:                 postgresconnector.ActionQueryReadonly,
+			SensitiveInputFields: []string{"access_token", "opaque_message"},
 		},
 		Action: connectors.PreparedAction{
 			ConnectorKind: postgresconnector.Kind,
@@ -386,12 +394,12 @@ func TestInsertConnectorActionRequestRedactsDisplayedInputOnly(t *testing.T) {
 	).Scan(&inputJSON, &reason, &encryptedPayload); err != nil {
 		t.Fatalf("read connector action request: %v", err)
 	}
-	for _, secret := range []string{"super-secret", "raw-access-token", "raw-bearer-token", "raw-reason-token", "reason-secret"} {
+	for _, secret := range []string{"super-secret", "raw-access-token", "arbitrary-publish-content", "raw-bearer-token", "raw-reason-token", "reason-secret"} {
 		if strings.Contains(inputJSON, secret) || strings.Contains(reason, secret) {
 			t.Fatalf("persisted connector request leaked %q: input=%s reason=%s", secret, inputJSON, reason)
 		}
 	}
-	if !strings.Contains(inputJSON, `"access_token":"[REDACTED]"`) || !strings.Contains(inputJSON, `"authorization":"[REDACTED]"`) || !strings.Contains(inputJSON, `password=[REDACTED]`) {
+	if !strings.Contains(inputJSON, `"access_token":"[REDACTED]"`) || !strings.Contains(inputJSON, `"opaque_message":"[REDACTED]"`) || !strings.Contains(inputJSON, `"authorization":"[REDACTED]"`) || !strings.Contains(inputJSON, `password=[REDACTED]`) {
 		t.Fatalf("input was not redacted as expected: %s", inputJSON)
 	}
 	var historyInputJSON string
@@ -411,12 +419,18 @@ func TestInsertConnectorActionRequestRedactsDisplayedInputOnly(t *testing.T) {
 	if mcpResponse.Input["access_token"] != "[REDACTED]" || approvalResponse.Input["access_token"] != "[REDACTED]" {
 		t.Fatalf("response input was not redacted: mcp=%#v approval=%#v", mcpResponse.Input, approvalResponse.Input)
 	}
+	if mcpResponse.Input["opaque_message"] != "[REDACTED]" || approvalResponse.Input["opaque_message"] != "[REDACTED]" {
+		t.Fatalf("action-declared sensitive input was not redacted: mcp=%#v approval=%#v", mcpResponse.Input, approvalResponse.Input)
+	}
 	var decryptedPayload connectorActionExecutionEnvelope
 	if err := secretVault.DecryptJSON(encryptedPayload, &decryptedPayload); err != nil {
 		t.Fatalf("decrypt execution payload: %v", err)
 	}
 	if decryptedPayload.Input["access_token"] != "raw-access-token" || !strings.Contains(decryptedPayload.Input["sql"].(string), "super-secret") {
 		t.Fatalf("encrypted execution payload should preserve raw input: %#v", decryptedPayload)
+	}
+	if decryptedPayload.Input["opaque_message"] != "arbitrary-publish-content" {
+		t.Fatalf("encrypted execution payload should preserve action-sensitive input: %#v", decryptedPayload)
 	}
 	if decryptedPayload.Payload["access_token"] != "raw-access-token" || !strings.Contains(decryptedPayload.Payload["sql"].(string), "super-secret") {
 		t.Fatalf("encrypted execution payload should preserve raw action payload: %#v", decryptedPayload)

--- a/backend/internal/connectors/README.md
+++ b/backend/internal/connectors/README.md
@@ -84,6 +84,11 @@ masked even when their names are connector-specific. The gateway also masks a
 small default set such as `password`, `token`, `secret`, `api_key`, and
 `authorization`, but connector-specific names must be explicit.
 
+Use `ActionDefinition.SensitiveInputFields` for non-credential action inputs
+whose values may contain customer data or secrets, such as a message key,
+payload, or headers. Core persists and returns redacted input values while
+keeping the exact execution payload only in the encrypted request envelope.
+
 Approval-required requests hash the connector kind/version, action definition,
 target/profile public metadata, profile revision, encrypted secret revision,
 permission rule, token validity, and prepared payload. If any of that context

--- a/backend/internal/connectors/builtin/registry_test.go
+++ b/backend/internal/connectors/builtin/registry_test.go
@@ -235,12 +235,14 @@ func builtInDeterminismSamples(t *testing.T, kind string) (connectors.TargetView
 				Label:         "monitor",
 				Public:        map[string]any{"mechanism": "none"},
 			}, map[string]map[string]any{
-				kafkaconnector.ActionClusterInfo:           {},
-				kafkaconnector.ActionListTopics:            {"include_internal": false},
-				kafkaconnector.ActionDescribeTopic:         {"topic": "events"},
-				kafkaconnector.ActionListConsumerGroups:    {},
-				kafkaconnector.ActionDescribeConsumerGroup: {"group": "workers"},
-				kafkaconnector.ActionReadMessages:          {"topic": "events", "partition": 0, "start_position": "recent", "offset": "0", "max_records": 20, "max_bytes": 262144, "wait_seconds": 2},
+				kafkaconnector.ActionClusterInfo:            {},
+				kafkaconnector.ActionListTopics:             {"include_internal": false},
+				kafkaconnector.ActionDescribeTopic:          {"topic": "events"},
+				kafkaconnector.ActionListConsumerGroups:     {},
+				kafkaconnector.ActionDescribeConsumerGroup:  {"group": "workers"},
+				kafkaconnector.ActionReadMessages:           {"topic": "events", "partition": 0, "start_position": "recent", "offset": "0", "max_records": 20, "max_bytes": 262144, "wait_seconds": 2},
+				kafkaconnector.ActionPublishMessage:         {"topic": "events", "partition": 0, "key": "", "key_encoding": "utf8", "value": "test", "value_encoding": "utf8", "headers": []any{}},
+				kafkaconnector.ActionSetConsumerGroupOffset: {"group": "workers", "topic": "events", "partition": 0, "offset": "0"},
 			}
 	case postgresconnector.Kind:
 		return connectors.TargetView{

--- a/backend/internal/connectors/connectortest/prepare.go
+++ b/backend/internal/connectors/connectortest/prepare.go
@@ -81,6 +81,9 @@ func actionEqual(left connectors.ActionDefinition, right connectors.ActionDefini
 			return false
 		}
 	}
+	if !reflect.DeepEqual(left.SensitiveInputFields, right.SensitiveInputFields) {
+		return false
+	}
 	return schemasEqual(left.InputSchema, right.InputSchema)
 }
 

--- a/backend/internal/connectors/kafka/kafka.go
+++ b/backend/internal/connectors/kafka/kafka.go
@@ -13,14 +13,16 @@ import (
 const (
 	Kind    = "kafka"
 	Label   = "Kafka / Redpanda"
-	Version = "0.2"
+	Version = "0.3"
 
-	ActionClusterInfo           = "cluster_info"
-	ActionListTopics            = "list_topics"
-	ActionDescribeTopic         = "describe_topic"
-	ActionListConsumerGroups    = "list_consumer_groups"
-	ActionDescribeConsumerGroup = "describe_consumer_group"
-	ActionReadMessages          = "read_messages"
+	ActionClusterInfo            = "cluster_info"
+	ActionListTopics             = "list_topics"
+	ActionDescribeTopic          = "describe_topic"
+	ActionListConsumerGroups     = "list_consumer_groups"
+	ActionDescribeConsumerGroup  = "describe_consumer_group"
+	ActionReadMessages           = "read_messages"
+	ActionPublishMessage         = "publish_message"
+	ActionSetConsumerGroupOffset = "set_consumer_group_offset"
 )
 
 type Connector struct{}
@@ -72,27 +74,30 @@ func (*Connector) GetHelp(_ context.Context, target connectors.TargetView) (conn
 	family := familyLabel(stringValue(target.Config, "server_family", "kafka"))
 	return connectors.ConnectorHelp{
 		Title:       family + " connector",
-		Summary:     "Inspect cluster metadata, topics, consumer groups, lag, and bounded message samples without joining a consumer group or committing offsets.",
+		Summary:     "Inspect cluster metadata, topics, consumer groups, lag, and bounded message samples. Guarded write actions can publish one message or change one inactive consumer-group partition offset.",
 		Connector:   Label,
 		ConnectorID: Kind,
 		Usage: []string{
 			"Call list_topics before describe_topic or read_messages.",
 			"Use describe_consumer_group to inspect members, committed offsets, and lag.",
 			"read_messages uses explicit partition assignment and never commits consumer offsets.",
+			"publish_message writes one bounded message with all-in-sync-replica acknowledgements.",
+			"set_consumer_group_offset changes one partition only and rejects active consumer groups.",
 		},
 		Warnings: []string{
 			"Message keys, values, and headers can contain secrets or personal data. Read only what the operator approved.",
 			"Read results are bounded, but they are persisted in local encrypted history.",
+			"Prefer Prompt for publish_message and set_consumer_group_offset. Offset changes can replay or skip messages.",
 		},
 	}, nil
 }
 
 func (*Connector) GetActionList(context.Context, connectors.TargetView, connectors.CredentialProfileView) ([]connectors.ActionDefinition, error) {
-	return readActionDefinitions(), nil
+	return actionDefinitions(), nil
 }
 
 func (*Connector) PrepareAction(_ context.Context, req connectors.ActionRequest) (connectors.PreparedAction, error) {
-	action, ok := readActionDefinition(req.ActionName)
+	action, ok := actionDefinition(req.ActionName)
 	if !ok {
 		return connectors.PreparedAction{}, fmt.Errorf("unsupported Kafka action %q", req.ActionName)
 	}
@@ -100,10 +105,10 @@ func (*Connector) PrepareAction(_ context.Context, req connectors.ActionRequest)
 	if err != nil {
 		return connectors.PreparedAction{}, err
 	}
-	if err := canonicalizeReadInput(req.ActionName, input); err != nil {
+	if err := canonicalizeActionInput(req.ActionName, input); err != nil {
 		return connectors.PreparedAction{}, err
 	}
-	if err := validateReadInput(req.ActionName, input); err != nil {
+	if err := validateActionInput(req.ActionName, input); err != nil {
 		return connectors.PreparedAction{}, err
 	}
 	summary := action.Label
@@ -114,6 +119,14 @@ func (*Connector) PrepareAction(_ context.Context, req connectors.ActionRequest)
 		summary = "Describe consumer group " + stringValue(input, "group", "")
 	case ActionReadMessages:
 		summary = fmt.Sprintf("Read up to %d messages from %s partition %d", intValue(input, "max_records", 20), stringValue(input, "topic", ""), intValue(input, "partition", 0))
+	case ActionPublishMessage:
+		summary = fmt.Sprintf("Publish one message to %s partition %d", stringValue(input, "topic", ""), intValue(input, "partition", 0))
+	case ActionSetConsumerGroupOffset:
+		summary = fmt.Sprintf("Set %s/%s partition %d offset to %s", stringValue(input, "group", ""), stringValue(input, "topic", ""), intValue(input, "partition", 0), stringValue(input, "offset", ""))
+	}
+	preview := copyMap(input)
+	if req.ActionName == ActionPublishMessage {
+		preview = publishPreview(input)
 	}
 	return connectors.PreparedAction{
 		ConnectorKind: Kind,
@@ -123,7 +136,7 @@ func (*Connector) PrepareAction(_ context.Context, req connectors.ActionRequest)
 		Risk:          action.Risk,
 		Title:         action.Label,
 		Summary:       summary,
-		Preview:       copyMap(input),
+		Preview:       preview,
 		Payload:       copyMap(input),
 		ContextMaterial: map[string]any{
 			"target_config":   req.Target.Config,
@@ -157,6 +170,12 @@ func (c *Connector) ExecuteAction(ctx context.Context, runtime connectors.Runtim
 	if action.ConnectorKind != Kind {
 		return connectors.ActionResult{}, fmt.Errorf("prepared action connector kind %q is not %q", action.ConnectorKind, Kind)
 	}
+	if _, ok := actionDefinition(action.ActionName); !ok {
+		return connectors.ActionResult{}, fmt.Errorf("unsupported Kafka action %q", action.ActionName)
+	}
+	if err := validateActionInput(action.ActionName, action.Payload); err != nil {
+		return failedResult(fmt.Errorf("validate prepared Kafka action: %w", err)), nil
+	}
 	if action.ActionName == ActionReadMessages {
 		partition, err := checkedInt32(int64(intValue(action.Payload, "partition", 0)), "partition")
 		if err != nil {
@@ -171,6 +190,9 @@ func (c *Connector) ExecuteAction(ctx context.Context, runtime connectors.Runtim
 			MaxBytes:    intValue(action.Payload, "max_bytes", 262144),
 			WaitSeconds: intValue(action.Payload, "wait_seconds", 2),
 		})
+	}
+	if action.ActionName == ActionPublishMessage {
+		return executePublishMessage(ctx, runtime, action.Payload)
 	}
 	client, err := newClient(ctx, runtime)
 	if err != nil {
@@ -189,9 +211,10 @@ func (c *Connector) ExecuteAction(ctx context.Context, runtime connectors.Runtim
 		return executeListConsumerGroups(ctx, client)
 	case ActionDescribeConsumerGroup:
 		return executeDescribeConsumerGroup(ctx, client, stringValue(action.Payload, "group", ""))
-	default:
-		return connectors.ActionResult{}, fmt.Errorf("unsupported Kafka action %q", action.ActionName)
+	case ActionSetConsumerGroupOffset:
+		return executeSetConsumerGroupOffset(ctx, client, action.Payload)
 	}
+	return connectors.ActionResult{}, fmt.Errorf("unsupported Kafka action %q", action.ActionName)
 }
 
 func (c *Connector) TestConnection(ctx context.Context, runtime connectors.RuntimeContext) (connectors.TestResult, error) {
@@ -211,7 +234,7 @@ func (c *Connector) TestConnection(ctx context.Context, runtime connectors.Runti
 	}, nil
 }
 
-func readActionDefinitions() []connectors.ActionDefinition {
+func actionDefinitions() []connectors.ActionDefinition {
 	return []connectors.ActionDefinition{
 		{Name: ActionClusterInfo, Label: "Cluster info", Description: "Read cluster id, controller, and bounded broker endpoint metadata.", Category: "cluster", Risk: connectors.RiskRead, InputSchema: connectors.Schema{}, OutputHint: connectors.OutputHint{Format: "json", MaxRows: 200, MaxBytes: 262144}},
 		{Name: ActionListTopics, Label: "List topics", Description: "List visible topics with partition and replication metadata.", Category: "topics", Risk: connectors.RiskRead, InputSchema: connectors.Schema{Fields: []connectors.Field{
@@ -237,11 +260,32 @@ func readActionDefinitions() []connectors.ActionDefinition {
 			{Name: "max_bytes", Label: "Maximum payload bytes", Type: connectors.FieldNumber, Default: 262144},
 			{Name: "wait_seconds", Label: "Wait seconds", Type: connectors.FieldNumber, Default: 2},
 		}}, OutputHint: connectors.OutputHint{Format: "json", MaxRows: 100, MaxBytes: 524288}},
+		{Name: ActionPublishMessage, Label: "Publish message", Description: "Publish one bounded message to one explicit topic partition with all-in-sync-replica acknowledgements.", Category: "messages", Risk: connectors.RiskWrite, InputSchema: connectors.Schema{Fields: []connectors.Field{
+			{Name: "topic", Label: "Topic", Type: connectors.FieldString, Required: true},
+			{Name: "partition", Label: "Partition", Type: connectors.FieldNumber, Required: true, Default: 0},
+			{Name: "key", Label: "Key", Type: connectors.FieldMultiline, Default: ""},
+			{Name: "key_encoding", Label: "Key encoding", Type: connectors.FieldSelect, Required: true, Default: "utf8", Options: []connectors.FieldOption{
+				{Value: "utf8", Label: "UTF-8"},
+				{Value: "base64", Label: "Base64"},
+			}},
+			{Name: "value", Label: "Value", Type: connectors.FieldMultiline, Default: ""},
+			{Name: "value_encoding", Label: "Value encoding", Type: connectors.FieldSelect, Required: true, Default: "utf8", Options: []connectors.FieldOption{
+				{Value: "utf8", Label: "UTF-8"},
+				{Value: "base64", Label: "Base64"},
+			}},
+			{Name: "headers", Label: "Headers", Type: connectors.FieldJSON, Default: []any{}, Description: "Optional array of {key, value, encoding}; encoding is utf8 or base64."},
+		}}, SensitiveInputFields: []string{"key", "value", "headers"}, OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 65536}},
+		{Name: ActionSetConsumerGroupOffset, Label: "Set consumer group offset", Description: "Change one inactive consumer group's committed offset for one explicit topic partition.", Category: "consumer_groups", Risk: connectors.RiskDestructive, InputSchema: connectors.Schema{Fields: []connectors.Field{
+			{Name: "group", Label: "Consumer group", Type: connectors.FieldString, Required: true},
+			{Name: "topic", Label: "Topic", Type: connectors.FieldString, Required: true},
+			{Name: "partition", Label: "Partition", Type: connectors.FieldNumber, Required: true, Default: 0},
+			{Name: "offset", Label: "New offset", Type: connectors.FieldString, Required: true},
+		}}, OutputHint: connectors.OutputHint{Format: "json", MaxBytes: 65536}},
 	}
 }
 
-func readActionDefinition(name string) (connectors.ActionDefinition, bool) {
-	for _, action := range readActionDefinitions() {
+func actionDefinition(name string) (connectors.ActionDefinition, bool) {
+	for _, action := range actionDefinitions() {
 		if action.Name == name {
 			return action, true
 		}
@@ -249,9 +293,9 @@ func readActionDefinition(name string) (connectors.ActionDefinition, bool) {
 	return connectors.ActionDefinition{}, false
 }
 
-func validateReadInput(action string, input map[string]any) error {
+func validateActionInput(action string, input map[string]any) error {
 	switch action {
-	case ActionDescribeTopic, ActionReadMessages:
+	case ActionDescribeTopic, ActionReadMessages, ActionPublishMessage:
 		if strings.TrimSpace(stringValue(input, "topic", "")) == "" {
 			return fmt.Errorf("topic is required")
 		}
@@ -259,11 +303,20 @@ func validateReadInput(action string, input map[string]any) error {
 		if strings.TrimSpace(stringValue(input, "group", "")) == "" {
 			return fmt.Errorf("group is required")
 		}
+	case ActionSetConsumerGroupOffset:
+		if strings.TrimSpace(stringValue(input, "group", "")) == "" {
+			return fmt.Errorf("group is required")
+		}
+		if strings.TrimSpace(stringValue(input, "topic", "")) == "" {
+			return fmt.Errorf("topic is required")
+		}
 	}
-	if action == ActionReadMessages {
+	if action == ActionReadMessages || action == ActionPublishMessage || action == ActionSetConsumerGroupOffset {
 		if partition := intValue(input, "partition", 0); partition < 0 || partition > 1000000 {
 			return fmt.Errorf("partition must be between 0 and 1000000")
 		}
+	}
+	if action == ActionReadMessages {
 		if records := intValue(input, "max_records", 20); records < 1 || records > 100 {
 			return fmt.Errorf("max_records must be between 1 and 100")
 		}
@@ -277,33 +330,52 @@ func validateReadInput(action string, input map[string]any) error {
 			return fmt.Errorf("offset must be zero or greater")
 		}
 	}
+	if action == ActionPublishMessage {
+		if err := validatePublishInput(input); err != nil {
+			return err
+		}
+	}
+	if action == ActionSetConsumerGroupOffset && int64Value(input, "offset", -1) < 0 {
+		return fmt.Errorf("offset must be zero or greater")
+	}
 	return nil
 }
 
-func canonicalizeReadInput(action string, input map[string]any) error {
+func canonicalizeActionInput(action string, input map[string]any) error {
 	for _, field := range []string{"topic", "group"} {
 		if value, ok := input[field]; ok {
 			input[field] = strings.TrimSpace(fmt.Sprint(value))
 		}
 	}
-	if action != ActionReadMessages {
-		return nil
+	integerFields := []string{}
+	switch action {
+	case ActionReadMessages:
+		integerFields = []string{"partition", "max_records", "max_bytes", "wait_seconds"}
+	case ActionPublishMessage, ActionSetConsumerGroupOffset:
+		integerFields = []string{"partition"}
 	}
-	for _, field := range []string{"partition", "max_records", "max_bytes", "wait_seconds"} {
+	for _, field := range integerFields {
 		value, err := exactInt(input[field], field)
 		if err != nil {
 			return err
 		}
 		input[field] = value
 	}
-	if stringValue(input, "start_position", "recent") != "offset" {
+	if action == ActionReadMessages && stringValue(input, "start_position", "recent") != "offset" {
 		input["offset"] = "0"
-	} else {
+	} else if action == ActionReadMessages || action == ActionSetConsumerGroupOffset {
 		offset, err := exactInteger(input["offset"], "offset")
 		if err != nil {
 			return err
 		}
 		input["offset"] = strconv.FormatInt(offset, 10)
+	}
+	if action == ActionPublishMessage {
+		headers, err := canonicalPublishHeaders(input["headers"])
+		if err != nil {
+			return err
+		}
+		input["headers"] = headers
 	}
 	return nil
 }
@@ -351,6 +423,21 @@ func checkedInt32(value int64, field string) (int32, error) {
 		return 0, fmt.Errorf("%s exceeds the supported 32-bit integer range", field)
 	}
 	return int32(value), nil
+}
+
+func exactInt32(value any, field string) (int32, error) {
+	if text, ok := value.(string); ok {
+		parsed, err := strconv.ParseInt(strings.TrimSpace(text), 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("%s must be an exact 32-bit base-10 integer", field)
+		}
+		return int32(parsed), nil
+	}
+	exact, err := exactInteger(value, field)
+	if err != nil {
+		return 0, err
+	}
+	return checkedInt32(exact, field)
 }
 
 func failedResult(err error) connectors.ActionResult {

--- a/backend/internal/connectors/kafka/kafka_test.go
+++ b/backend/internal/connectors/kafka/kafka_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"net"
 	"reflect"
@@ -19,6 +20,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 func TestTargetAndCredentialSchemasExposeKafkaRedpandaAndSASL(t *testing.T) {
@@ -106,6 +108,12 @@ func TestKafkaIntegerConversionsRejectNarrowingOverflow(t *testing.T) {
 	if value, err := checkedInt32(1_048_576, "max_bytes"); err != nil || value != 1_048_576 {
 		t.Fatalf("checked int32 = %d, %v", value, err)
 	}
+	if _, err := exactInt32("2147483648", "partition"); err == nil {
+		t.Fatal("expected exact 32-bit string overflow error")
+	}
+	if value, err := exactInt32("2147483647", "partition"); err != nil || value != 2147483647 {
+		t.Fatalf("exact int32 = %d, %v", value, err)
+	}
 }
 
 func TestKafkaHelpUsesSharedConnectorIdentityFields(t *testing.T) {
@@ -115,6 +123,119 @@ func TestKafkaHelpUsesSharedConnectorIdentityFields(t *testing.T) {
 	}
 	if help.Connector != Label || help.ConnectorID != Kind {
 		t.Fatalf("help connector identity = %#v", help)
+	}
+}
+
+func TestPreparePublishMessageBoundsAndRedactsPreview(t *testing.T) {
+	request := connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "kafka:1:2"},
+		Profile:    connectors.CredentialProfileView{ID: 2},
+		ActionName: ActionPublishMessage,
+		Input: map[string]any{
+			"topic": "events", "partition": 2,
+			"key": "account-42", "key_encoding": "utf8",
+			"value": `{"token":"publish-secret"}`, "value_encoding": "utf8",
+			"headers": []any{map[string]any{"key": "trace-id", "value": "abc", "encoding": "utf8"}},
+		},
+	}
+	prepared, err := New().PrepareAction(context.Background(), request)
+	if err != nil {
+		t.Fatalf("prepare publish: %v", err)
+	}
+	if prepared.Risk != connectors.RiskWrite || prepared.Payload["value"] != `{"token":"publish-secret"}` {
+		t.Fatalf("prepared publish = %#v", prepared)
+	}
+	previewJSON, _ := json.Marshal(prepared.Preview)
+	if strings.Contains(string(previewJSON), "account-42") || strings.Contains(string(previewJSON), "publish-secret") {
+		t.Fatalf("publish preview leaked message bytes: %s", previewJSON)
+	}
+	if prepared.Preview["value_bytes"] != len(`{"token":"publish-secret"}`) || prepared.Preview["headers_count"] != 1 {
+		t.Fatalf("publish preview = %#v", prepared.Preview)
+	}
+	if _, ok := prepared.Preview["key_sha256"]; ok {
+		t.Fatalf("publish preview must not expose a key digest: %#v", prepared.Preview)
+	}
+	if _, ok := prepared.Preview["value_sha256"]; ok {
+		t.Fatalf("publish preview must not expose a value digest: %#v", prepared.Preview)
+	}
+
+	request.Input["headers"] = []any{map[string]any{"key": "", "value": "x"}}
+	if _, err := New().PrepareAction(context.Background(), request); err == nil || !strings.Contains(err.Error(), "key is required") {
+		t.Fatalf("expected header validation error, got %v", err)
+	}
+	request.Input["headers"] = []any{map[string]any{"key": "trace-id", "encodng": "utf8", "value": "x"}}
+	if _, err := New().PrepareAction(context.Background(), request); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("expected unknown header field error, got %v", err)
+	}
+	request.Input["headers"] = []any{map[string]any{"key": "trace-id"}}
+	if _, err := New().PrepareAction(context.Background(), request); err == nil || !strings.Contains(err.Error(), "value is required") {
+		t.Fatalf("expected missing header value error, got %v", err)
+	}
+	request.Input["headers"] = []any{map[string]any{"key": " trace-id ", "value": "abc"}}
+	prepared, err = New().PrepareAction(context.Background(), request)
+	if err != nil {
+		t.Fatalf("prepare canonical headers: %v", err)
+	}
+	canonicalHeaders := prepared.Payload["headers"].([]map[string]any)
+	if !reflect.DeepEqual(canonicalHeaders, []map[string]any{{"key": "trace-id", "value": "abc", "encoding": "utf8"}}) {
+		t.Fatalf("canonical headers = %#v", canonicalHeaders)
+	}
+	request.Input["headers"] = []any{}
+	request.Input["value_encoding"] = "base64"
+	request.Input["value"] = "*not-base64*"
+	if _, err := New().PrepareAction(context.Background(), request); err == nil || !strings.Contains(err.Error(), "valid base64") {
+		t.Fatalf("expected base64 validation error, got %v", err)
+	}
+	request.Input["key"] = ""
+	request.Input["value_encoding"] = "utf8"
+	request.Input["value"] = strings.Repeat("x", maxPublishRecordBytes)
+	if _, err := New().PrepareAction(context.Background(), request); err != nil {
+		t.Fatalf("exact raw publish boundary should pass local validation: %v", err)
+	}
+	request.Input["value"] = strings.Repeat("x", maxPublishRecordBytes+1)
+	if _, err := New().PrepareAction(context.Background(), request); err == nil || !strings.Contains(err.Error(), "must not exceed") {
+		t.Fatalf("expected publish boundary error, got %v", err)
+	}
+}
+
+func TestExecuteActionRevalidatesPreparedWritePayload(t *testing.T) {
+	result, err := New().ExecuteAction(context.Background(), connectors.RuntimeContext{}, connectors.PreparedAction{
+		ConnectorKind: Kind,
+		ActionName:    ActionPublishMessage,
+		Payload: map[string]any{
+			"topic": "events", "partition": 1000001,
+			"key": "", "key_encoding": "utf8",
+			"value": "test", "value_encoding": "utf8",
+			"headers": []any{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute invalid prepared action: %v", err)
+	}
+	if result.Status != connectors.ResultFailed || !strings.Contains(result.Error, "partition must be between") {
+		t.Fatalf("invalid prepared action result = %#v", result)
+	}
+}
+
+func TestPrepareConsumerGroupOffsetUsesDestructiveRiskAndExactOffset(t *testing.T) {
+	request := connectors.ActionRequest{
+		Target:     connectors.TargetView{Ref: "kafka:1:2"},
+		Profile:    connectors.CredentialProfileView{ID: 2},
+		ActionName: ActionSetConsumerGroupOffset,
+		Input: map[string]any{
+			"group": "workers", "topic": "events", "partition": 1, "offset": "9007199254740993",
+		},
+	}
+	prepared, err := New().PrepareAction(context.Background(), request)
+	if err != nil {
+		t.Fatalf("prepare offset change: %v", err)
+	}
+	if prepared.Risk != connectors.RiskDestructive || prepared.Payload["offset"] != "9007199254740993" {
+		t.Fatalf("prepared offset change = %#v", prepared)
+	}
+	request.Input["offset"] = 1.5
+	if _, err := New().PrepareAction(context.Background(), request); err == nil || !strings.Contains(err.Error(), "must be a string") {
+		t.Fatalf("expected offset type error, got %v", err)
 	}
 }
 
@@ -336,6 +457,250 @@ func TestConnectionAndTopicMetadataAgainstKafkaProtocol(t *testing.T) {
 	output := result.Output.(map[string]any)
 	if output["partition_count"] != 3 {
 		t.Fatalf("output = %#v", output)
+	}
+}
+
+func TestPublishMessageUsesExplicitPartitionAndAllAcknowledgements(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(2), kfake.SeedTopics(2, "events"))
+	if err != nil {
+		t.Fatalf("new fake cluster: %v", err)
+	}
+	defer cluster.Close()
+	var observedProduce sync.Mutex
+	var produceAcks []int16
+	var produceTimeouts []int32
+	cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+		produce := request.(*kmsg.ProduceRequest)
+		observedProduce.Lock()
+		produceAcks = append(produceAcks, produce.Acks)
+		produceTimeouts = append(produceTimeouts, produce.TimeoutMillis)
+		observedProduce.Unlock()
+		return nil, nil, false
+	})
+	runtime := testRuntime(cluster.ListenAddrs(), &recordingDirectTransport{})
+	result, err := New().ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+		ConnectorKind: Kind,
+		ActionName:    ActionPublishMessage,
+		Payload: map[string]any{
+			"topic": "events", "partition": 1,
+			"key": "order-1", "key_encoding": "utf8",
+			"value": `{"ok":true}`, "value_encoding": "utf8",
+			"headers": []any{map[string]any{"key": "trace-id", "value": "abc", "encoding": "utf8"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute publish: %v", err)
+	}
+	if result.Status != connectors.ResultCompleted {
+		t.Fatalf("publish result = %#v", result)
+	}
+	output := result.Output.(map[string]any)
+	if output["partition"] != int32(1) || output["offset"] != "0" || output["headers_count"] != 1 {
+		t.Fatalf("publish output = %#v", output)
+	}
+	observedProduce.Lock()
+	if len(produceAcks) != 1 || produceAcks[0] != -1 || produceTimeouts[0] != 10000 {
+		t.Fatalf("produce requests must be one bounded all-ISR attempt: acks=%v timeouts=%v", produceAcks, produceTimeouts)
+	}
+	observedProduce.Unlock()
+
+	reader, err := kgo.NewClient(
+		kgo.SeedBrokers(cluster.ListenAddrs()...),
+		kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{"events": {1: kgo.NewOffset().At(0)}}),
+	)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	defer reader.Close()
+	readCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	fetches := reader.PollFetches(readCtx)
+	if err := fetches.Err(); err != nil {
+		t.Fatalf("read published record: %v", err)
+	}
+	records := fetches.Records()
+	if len(records) != 1 || string(records[0].Key) != "order-1" || string(records[0].Value) != `{"ok":true}` {
+		t.Fatalf("published records = %#v", records)
+	}
+}
+
+func TestSetConsumerGroupOffsetRequiresInactiveGroupAndVerifiesCommit(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.SeedTopics(1, "events"))
+	if err != nil {
+		t.Fatalf("new fake cluster: %v", err)
+	}
+	defer cluster.Close()
+	producer, err := kgo.NewClient(kgo.SeedBrokers(cluster.ListenAddrs()...))
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	results := producer.ProduceSync(context.Background(),
+		&kgo.Record{Topic: "events", Value: []byte("one")},
+		&kgo.Record{Topic: "events", Value: []byte("two")},
+	)
+	producer.Close()
+	if err := results.FirstErr(); err != nil {
+		t.Fatalf("produce fixtures: %v", err)
+	}
+	adminClient, err := kgo.NewClient(kgo.SeedBrokers(cluster.ListenAddrs()...))
+	if err != nil {
+		t.Fatalf("new admin client: %v", err)
+	}
+	admin := kadm.NewClient(adminClient)
+	initial := kadm.Offsets{}
+	initial.Add(kadm.Offset{Topic: "events", Partition: 0, At: 0})
+	if err := admin.CommitAllOffsets(context.Background(), "workers", initial); err != nil {
+		t.Fatalf("seed group offset: %v", err)
+	}
+	adminClient.Close()
+
+	var committedLeaderEpochs []int32
+	cluster.ControlKey(int16(kmsg.OffsetCommit), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+		commit := request.(*kmsg.OffsetCommitRequest)
+		for _, topic := range commit.Topics {
+			for _, partition := range topic.Partitions {
+				committedLeaderEpochs = append(committedLeaderEpochs, partition.LeaderEpoch)
+			}
+		}
+		return nil, nil, false
+	})
+	runtime := testRuntime(cluster.ListenAddrs(), &recordingDirectTransport{})
+	result, err := New().ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+		ConnectorKind: Kind,
+		ActionName:    ActionSetConsumerGroupOffset,
+		Payload: map[string]any{
+			"group": "workers", "topic": "events", "partition": 0, "offset": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute offset change: %v", err)
+	}
+	if result.Status != connectors.ResultCompleted {
+		t.Fatalf("offset result = %#v", result)
+	}
+	output := result.Output.(map[string]any)
+	if output["previous_offset"] != "0" || output["new_offset"] != "1" || output["offset_commit_verified"] != true {
+		t.Fatalf("offset output = %#v", output)
+	}
+	if output["inactive_guard"] != "best_effort" || output["group_state_before"] != "Empty" || output["group_state_after"] != "Empty" {
+		t.Fatalf("offset output = %#v", output)
+	}
+	if !reflect.DeepEqual(committedLeaderEpochs, []int32{-1}) {
+		t.Fatalf("committed leader epochs = %v", committedLeaderEpochs)
+	}
+
+	outOfRange, err := New().ExecuteAction(context.Background(), runtime, connectors.PreparedAction{
+		ConnectorKind: Kind,
+		ActionName:    ActionSetConsumerGroupOffset,
+		Payload: map[string]any{
+			"group": "workers", "topic": "events", "partition": 0, "offset": "3",
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute out-of-range offset change: %v", err)
+	}
+	if outOfRange.Status != connectors.ResultFailed || !strings.Contains(outOfRange.Error, "between earliest offset") {
+		t.Fatalf("out-of-range result = %#v", outOfRange)
+	}
+	verifyClient, err := kgo.NewClient(kgo.SeedBrokers(cluster.ListenAddrs()...))
+	if err != nil {
+		t.Fatalf("new verify client: %v", err)
+	}
+	defer verifyClient.Close()
+	verified, err := kadm.NewClient(verifyClient).FetchOffsets(context.Background(), "workers")
+	if err != nil {
+		t.Fatalf("verify unchanged offset: %v", err)
+	}
+	actual, found := verified.Lookup("events", 0)
+	if !found || actual.At != 1 {
+		t.Fatalf("out-of-range action changed offset: %#v", actual)
+	}
+}
+
+func TestSetConsumerGroupOffsetRejectsActiveClassicGroup(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.SeedTopics(1, "events"))
+	if err != nil {
+		t.Fatalf("new fake cluster: %v", err)
+	}
+	defer cluster.Close()
+	producer, err := kgo.NewClient(kgo.SeedBrokers(cluster.ListenAddrs()...))
+	if err != nil {
+		t.Fatalf("new producer: %v", err)
+	}
+	if err := producer.ProduceSync(context.Background(), &kgo.Record{Topic: "events", Value: []byte("one")}).FirstErr(); err != nil {
+		t.Fatalf("produce fixture: %v", err)
+	}
+	producer.Close()
+	consumer, err := kgo.NewClient(
+		kgo.SeedBrokers(cluster.ListenAddrs()...),
+		kgo.ConsumerGroup("active-workers"),
+		kgo.ConsumeTopics("events"),
+		kgo.DisableAutoCommit(),
+	)
+	if err != nil {
+		t.Fatalf("new group consumer: %v", err)
+	}
+	defer consumer.Close()
+	pollCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if fetches := consumer.PollFetches(pollCtx); fetches.Err() != nil || len(fetches.Records()) == 0 {
+		t.Fatalf("join active group: records=%d err=%v", len(fetches.Records()), fetches.Err())
+	}
+
+	result, err := New().ExecuteAction(context.Background(), testRuntime(cluster.ListenAddrs(), &recordingDirectTransport{}), connectors.PreparedAction{
+		ConnectorKind: Kind,
+		ActionName:    ActionSetConsumerGroupOffset,
+		Payload: map[string]any{
+			"group": "active-workers", "topic": "events", "partition": 0, "offset": "0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute active group offset change: %v", err)
+	}
+	if result.Status != connectors.ResultFailed || !strings.Contains(result.Error, "must be inactive") {
+		t.Fatalf("active group result = %#v", result)
+	}
+}
+
+func TestSetConsumerGroupOffsetRejectsModernConsumerProtocol(t *testing.T) {
+	cluster, err := kfake.NewCluster(
+		kfake.SeedTopics(1, "events"),
+		kfake.BrokerConfigs(map[string]string{"group.consumer.heartbeat.interval.ms": "100"}),
+	)
+	if err != nil {
+		t.Fatalf("new fake cluster: %v", err)
+	}
+	defer cluster.Close()
+	modernContext := context.WithValue(context.Background(), "opt_in_kafka_next_gen_balancer_beta", true)
+	consumer, err := kgo.NewClient(
+		kgo.SeedBrokers(cluster.ListenAddrs()...),
+		kgo.WithContext(modernContext),
+		kgo.ConsumerGroup("modern-workers"),
+		kgo.ConsumeTopics("events"),
+		kgo.DisableAutoCommit(),
+	)
+	if err != nil {
+		t.Fatalf("new modern group consumer: %v", err)
+	}
+	defer consumer.Close()
+	pollCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = consumer.PollFetches(pollCtx)
+
+	result, err := New().ExecuteAction(context.Background(), testRuntime(cluster.ListenAddrs(), &recordingDirectTransport{}), connectors.PreparedAction{
+		ConnectorKind: Kind,
+		ActionName:    ActionSetConsumerGroupOffset,
+		Payload: map[string]any{
+			"group": "modern-workers", "topic": "events", "partition": 0, "offset": "0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("execute modern group offset change: %v", err)
+	}
+	if result.Status != connectors.ResultFailed || !strings.Contains(result.Error, "modern consumer protocol") {
+		t.Fatalf("modern group result = %#v", result)
 	}
 }
 

--- a/backend/internal/connectors/kafka/read_actions.go
+++ b/backend/internal/connectors/kafka/read_actions.go
@@ -221,6 +221,9 @@ func executeDescribeConsumerGroup(ctx context.Context, client *kgo.Client, group
 			"end_offset":       strconv.FormatInt(item.End.Offset, 10),
 			"lag":              strconv.FormatInt(item.Lag, 10),
 		}
+		if item.Start.Err == nil {
+			row["earliest_offset"] = strconv.FormatInt(item.Start.Offset, 10)
+		}
 		if item.Member != nil {
 			row["member_id"] = item.Member.MemberID
 		}

--- a/backend/internal/connectors/kafka/write_actions.go
+++ b/backend/internal/connectors/kafka/write_actions.go
@@ -1,0 +1,347 @@
+package kafka
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/aipermission/aipermission/backend/internal/connectors"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+const (
+	maxPublishKeyBytes         = 64 << 10
+	maxPublishValueBytes       = 1 << 20
+	maxPublishHeaderCount      = 64
+	maxPublishHeaderKeyBytes   = 256
+	maxPublishHeaderValueBytes = 64 << 10
+	maxPublishRecordBytes      = 1 << 20
+	maxProducerBatchBytes      = maxPublishRecordBytes + (64 << 10)
+)
+
+type publishHeader struct {
+	Key      string  `json:"key"`
+	Value    *string `json:"value"`
+	Encoding string  `json:"encoding,omitempty"`
+}
+
+func validatePublishInput(input map[string]any) error {
+	if len(stringValue(input, "topic", "")) > 249 {
+		return fmt.Errorf("topic must not exceed 249 bytes")
+	}
+	key, err := decodePublishBytes(stringValue(input, "key", ""), stringValue(input, "key_encoding", "utf8"), "key", maxPublishKeyBytes)
+	if err != nil {
+		return err
+	}
+	value, err := decodePublishBytes(stringValue(input, "value", ""), stringValue(input, "value_encoding", "utf8"), "value", maxPublishValueBytes)
+	if err != nil {
+		return err
+	}
+	headers, err := parsePublishHeaders(input["headers"])
+	if err != nil {
+		return err
+	}
+	total := len(key) + len(value)
+	for _, header := range headers {
+		total += len(header.Key) + len(header.Value)
+	}
+	if total > maxPublishRecordBytes {
+		return fmt.Errorf("combined key, value, and headers must not exceed %d bytes", maxPublishRecordBytes)
+	}
+	return nil
+}
+
+func publishPreview(input map[string]any) map[string]any {
+	key, _ := decodePublishBytes(stringValue(input, "key", ""), stringValue(input, "key_encoding", "utf8"), "key", maxPublishKeyBytes)
+	value, _ := decodePublishBytes(stringValue(input, "value", ""), stringValue(input, "value_encoding", "utf8"), "value", maxPublishValueBytes)
+	headers, _ := parsePublishHeaders(input["headers"])
+	return map[string]any{
+		"topic":         stringValue(input, "topic", ""),
+		"partition":     intValue(input, "partition", 0),
+		"key_bytes":     len(key),
+		"value_bytes":   len(value),
+		"headers_count": len(headers),
+	}
+}
+
+func executePublishMessage(ctx context.Context, runtime connectors.RuntimeContext, payload map[string]any) (connectors.ActionResult, error) {
+	topic := stringValue(payload, "topic", "")
+	partition, err := exactInt32(payload["partition"], "partition")
+	if err != nil {
+		return failedResult(err), nil
+	}
+	key, err := decodePublishBytes(stringValue(payload, "key", ""), stringValue(payload, "key_encoding", "utf8"), "key", maxPublishKeyBytes)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	value, err := decodePublishBytes(stringValue(payload, "value", ""), stringValue(payload, "value_encoding", "utf8"), "value", maxPublishValueBytes)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	headers, err := parsePublishHeaders(payload["headers"])
+	if err != nil {
+		return failedResult(err), nil
+	}
+	client, err := newClient(
+		ctx,
+		runtime,
+		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+		kgo.RequiredAcks(kgo.AllISRAcks()),
+		kgo.DisableIdempotentWrite(),
+		kgo.RecordRetries(0),
+		kgo.UnknownTopicRetries(0),
+		kgo.RecordDeliveryTimeout(15*time.Second),
+		kgo.ProduceRequestTimeout(10*time.Second),
+		kgo.ProducerBatchMaxBytes(maxProducerBatchBytes),
+	)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	defer client.Close()
+	record := &kgo.Record{
+		Topic:     topic,
+		Partition: partition,
+		Key:       key,
+		Value:     value,
+		Headers:   headers,
+	}
+	publishCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	result := client.ProduceSync(publishCtx, record)
+	if err := result.FirstErr(); err != nil {
+		return failedResult(fmt.Errorf("publish Kafka message: %w; delivery may be unknown, inspect the topic before retrying", err)), nil
+	}
+	output := map[string]any{
+		"topic":         record.Topic,
+		"partition":     record.Partition,
+		"offset":        strconv.FormatInt(record.Offset, 10),
+		"timestamp":     record.Timestamp.UTC().Format(time.RFC3339Nano),
+		"key_bytes":     len(key),
+		"value_bytes":   len(value),
+		"headers_count": len(headers),
+	}
+	return completedResult(output, fmt.Sprintf("Published one message to %s partition %d at offset %d.", record.Topic, record.Partition, record.Offset)), nil
+}
+
+func executeSetConsumerGroupOffset(ctx context.Context, client *kgo.Client, payload map[string]any) (connectors.ActionResult, error) {
+	group := stringValue(payload, "group", "")
+	topic := stringValue(payload, "topic", "")
+	partition, err := exactInt32(payload["partition"], "partition")
+	if err != nil {
+		return failedResult(err), nil
+	}
+	offset := int64Value(payload, "offset", -1)
+	requestCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	admin := kadm.NewClient(client)
+
+	described, err := requireInactiveConsumerGroup(requestCtx, admin, group)
+	if err != nil {
+		return failedResult(err), nil
+	}
+
+	earliest, end, err := partitionBounds(requestCtx, admin, topic, partition)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	if offset < earliest || offset > end {
+		return failedResult(fmt.Errorf("offset must be between earliest offset %d and end offset %d", earliest, end)), nil
+	}
+
+	previous := int64(-1)
+	committed, err := admin.FetchOffsets(kadm.RequireStable(requestCtx), group)
+	if err != nil {
+		return failedResult(fmt.Errorf("read current consumer group offset: %w", err)), nil
+	}
+	if current, found := committed.Lookup(topic, partition); found {
+		if current.Err != nil {
+			return failedResult(fmt.Errorf("read current consumer group offset: %w", current.Err)), nil
+		}
+		previous = current.At
+	}
+	offsets := kadm.Offsets{}
+	offsets.Add(kadm.Offset{Topic: topic, Partition: partition, At: offset, LeaderEpoch: -1})
+	described, err = requireInactiveConsumerGroup(requestCtx, admin, group)
+	if err != nil {
+		return failedResult(err), nil
+	}
+	responses, err := admin.CommitOffsets(requestCtx, group, offsets)
+	if err != nil {
+		return failedResult(fmt.Errorf("commit consumer group offset: %w", err)), nil
+	}
+	if err := responses.Error(); err != nil {
+		return failedResult(fmt.Errorf("commit consumer group offset: %w", err)), nil
+	}
+	verified, err := admin.FetchOffsets(kadm.RequireStable(requestCtx), group)
+	if err != nil {
+		return failedResult(fmt.Errorf("verify consumer group offset: %w", err)), nil
+	}
+	actual, found := verified.Lookup(topic, partition)
+	if !found || actual.Err != nil || actual.At != offset {
+		return failedResult(fmt.Errorf("consumer group offset verification failed")), nil
+	}
+	postCommitState := "unknown"
+	postCommitWarning := ""
+	postCommitCtx, postCommitCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer postCommitCancel()
+	postCommitGroup, postCommitErr := requireInactiveConsumerGroup(postCommitCtx, admin, group)
+	if postCommitErr != nil {
+		postCommitWarning = "The offset was committed and verified, but the consumer group was no longer confirmed inactive afterward: " + postCommitErr.Error()
+	} else {
+		postCommitState = postCommitGroup.State
+	}
+	output := map[string]any{
+		"group":                  group,
+		"topic":                  topic,
+		"partition":              partition,
+		"previous_offset":        strconv.FormatInt(previous, 10),
+		"new_offset":             strconv.FormatInt(offset, 10),
+		"earliest_offset":        strconv.FormatInt(earliest, 10),
+		"end_offset":             strconv.FormatInt(end, 10),
+		"group_state_before":     described.State,
+		"group_state_after":      postCommitState,
+		"inactive_guard":         "best_effort",
+		"post_commit_warning":    postCommitWarning,
+		"offset_commit_verified": true,
+	}
+	return completedResult(output, fmt.Sprintf("Set consumer group %s offset for %s partition %d from %d to %d.", group, topic, partition, previous, offset)), nil
+}
+
+func requireInactiveConsumerGroup(ctx context.Context, admin *kadm.Client, group string) (kadm.DescribedGroup, error) {
+	modernGroups, modernErr := admin.DescribeConsumerGroups(ctx, group)
+	if modernErr == nil {
+		if modern, ok := modernGroups[group]; ok {
+			if modern.Err == nil {
+				return kadm.DescribedGroup{}, fmt.Errorf("consumer group %q uses the modern consumer protocol; changing offsets for modern groups is not supported", group)
+			}
+			if !errors.Is(modern.Err, kerr.GroupIDNotFound) && !errors.Is(modern.Err, kerr.UnsupportedVersion) {
+				return kadm.DescribedGroup{}, fmt.Errorf("inspect modern consumer group before offset change: %w", modern.Err)
+			}
+		}
+	} else if !errors.Is(modernErr, kerr.GroupIDNotFound) && !errors.Is(modernErr, kerr.UnsupportedVersion) {
+		return kadm.DescribedGroup{}, fmt.Errorf("inspect modern consumer group before offset change: %w", modernErr)
+	}
+
+	groups, err := admin.DescribeGroups(ctx, group)
+	if err != nil {
+		return kadm.DescribedGroup{}, fmt.Errorf("describe consumer group before offset change: %w", err)
+	}
+	described, ok := groups[group]
+	if !ok || described.Err != nil {
+		if ok && described.Err != nil {
+			return kadm.DescribedGroup{}, fmt.Errorf("describe consumer group before offset change: %w", described.Err)
+		}
+		return kadm.DescribedGroup{}, fmt.Errorf("consumer group %q was not found or is not visible", group)
+	}
+	if len(described.Members) != 0 || (described.State != "Empty" && described.State != "Dead") {
+		return kadm.DescribedGroup{}, fmt.Errorf("consumer group %q must be inactive before changing offsets; current state is %s with %d member(s)", group, described.State, len(described.Members))
+	}
+	return described, nil
+}
+
+func parsePublishHeaders(value any) ([]kgo.RecordHeader, error) {
+	entries, err := canonicalPublishHeaders(value)
+	if err != nil {
+		return nil, err
+	}
+	headers := make([]kgo.RecordHeader, 0, len(entries))
+	for index, entry := range entries {
+		decoded, err := decodePublishBytes(entry["value"].(string), entry["encoding"].(string), fmt.Sprintf("headers[%d].value", index), maxPublishHeaderValueBytes)
+		if err != nil {
+			return nil, err
+		}
+		headers = append(headers, kgo.RecordHeader{Key: entry["key"].(string), Value: decoded})
+	}
+	return headers, nil
+}
+
+func canonicalPublishHeaders(value any) ([]map[string]any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if text, ok := value.(string); ok {
+		if strings.TrimSpace(text) == "" {
+			return nil, nil
+		}
+		var decoded any
+		if err := json.Unmarshal([]byte(text), &decoded); err != nil {
+			return nil, fmt.Errorf("headers must be valid JSON: %w", err)
+		}
+		value = decoded
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("headers must be a JSON array: %w", err)
+	}
+	var rawEntries []json.RawMessage
+	if err := json.Unmarshal(encoded, &rawEntries); err != nil {
+		return nil, fmt.Errorf("headers must be an array of {key, value, encoding}: %w", err)
+	}
+	if len(rawEntries) > maxPublishHeaderCount {
+		return nil, fmt.Errorf("headers count must not exceed %d", maxPublishHeaderCount)
+	}
+	entries := make([]map[string]any, 0, len(rawEntries))
+	for index, raw := range rawEntries {
+		var entry publishHeader
+		decoder := json.NewDecoder(strings.NewReader(string(raw)))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&entry); err != nil {
+			return nil, fmt.Errorf("headers[%d] must contain only key, value, and encoding: %w", index, err)
+		}
+		entry.Key = strings.TrimSpace(entry.Key)
+		if entry.Key == "" {
+			return nil, fmt.Errorf("headers[%d].key is required", index)
+		}
+		if len(entry.Key) > maxPublishHeaderKeyBytes {
+			return nil, fmt.Errorf("headers[%d].key must not exceed %d bytes", index, maxPublishHeaderKeyBytes)
+		}
+		if entry.Value == nil {
+			return nil, fmt.Errorf("headers[%d].value is required", index)
+		}
+		encoding := defaultEncoding(entry.Encoding)
+		if _, err := decodePublishBytes(*entry.Value, encoding, fmt.Sprintf("headers[%d].value", index), maxPublishHeaderValueBytes); err != nil {
+			return nil, err
+		}
+		entries = append(entries, map[string]any{"key": entry.Key, "value": *entry.Value, "encoding": encoding})
+	}
+	return entries, nil
+}
+
+func decodePublishBytes(value, encoding, field string, limit int) ([]byte, error) {
+	var decoded []byte
+	switch encoding {
+	case "utf8":
+		if !utf8.ValidString(value) {
+			return nil, fmt.Errorf("%s must contain valid UTF-8", field)
+		}
+		decoded = []byte(value)
+	case "base64":
+		var err error
+		decoded, err = base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("%s must contain valid base64: %w", field, err)
+		}
+	default:
+		return nil, fmt.Errorf("%s encoding must be utf8 or base64", field)
+	}
+	if len(decoded) > limit {
+		return nil, fmt.Errorf("%s must not exceed %d bytes", field, limit)
+	}
+	return decoded, nil
+}
+
+func defaultEncoding(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "utf8"
+	}
+	return value
+}

--- a/backend/internal/connectors/registry.go
+++ b/backend/internal/connectors/registry.go
@@ -186,6 +186,9 @@ func equalActionDefinition(left ActionDefinition, right ActionDefinition) bool {
 			return false
 		}
 	}
+	if !reflect.DeepEqual(left.SensitiveInputFields, right.SensitiveInputFields) {
+		return false
+	}
 	return equalSchemas(left.InputSchema, right.InputSchema)
 }
 

--- a/backend/internal/connectors/schema.go
+++ b/backend/internal/connectors/schema.go
@@ -165,6 +165,20 @@ func ValidateActionDefinitions(actions []ActionDefinition, usage string) error {
 		if err := ValidateNonSecretSchema(action.InputSchema, usage+" action "+action.Name+" input"); err != nil {
 			return err
 		}
+		inputFields := make(map[string]bool, len(action.InputSchema.Fields))
+		for _, field := range action.InputSchema.Fields {
+			inputFields[field.Name] = true
+		}
+		seenSensitiveFields := map[string]bool{}
+		for _, field := range action.SensitiveInputFields {
+			if !inputFields[field] {
+				return fmt.Errorf("%s action %q sensitive input field %q is not in its input schema", usage, action.Name, field)
+			}
+			if seenSensitiveFields[field] {
+				return fmt.Errorf("%s action %q contains duplicate sensitive input field %q", usage, action.Name, field)
+			}
+			seenSensitiveFields[field] = true
+		}
 	}
 	return nil
 }

--- a/backend/internal/connectors/schema_test.go
+++ b/backend/internal/connectors/schema_test.go
@@ -148,4 +148,14 @@ func TestValidateActionDefinitionsRejectsInvalidContracts(t *testing.T) {
 	}}, "test"); err == nil || !strings.Contains(err.Error(), "description is required") {
 		t.Fatalf("expected missing description error, got %v", err)
 	}
+	if err := ValidateActionDefinitions([]ActionDefinition{{
+		Name:                 "run",
+		Label:                "Run",
+		Description:          "Run once.",
+		Risk:                 RiskWrite,
+		InputSchema:          Schema{Fields: []Field{{Name: "message", Label: "Message", Type: FieldString}}},
+		SensitiveInputFields: []string{"missing"},
+	}}, "test"); err == nil || !strings.Contains(err.Error(), "not in its input schema") {
+		t.Fatalf("expected unknown sensitive input field error, got %v", err)
+	}
 }

--- a/backend/internal/connectors/types.go
+++ b/backend/internal/connectors/types.go
@@ -65,13 +65,14 @@ type CredentialProfileView struct {
 // ActionDefinition is the machine-readable action contract returned by a
 // connector.
 type ActionDefinition struct {
-	Name        string     `json:"name"`
-	Label       string     `json:"label"`
-	Description string     `json:"description"`
-	Category    string     `json:"category,omitempty"`
-	Risk        RiskLevel  `json:"risk"`
-	InputSchema Schema     `json:"input_schema"`
-	OutputHint  OutputHint `json:"output_hint,omitempty"`
+	Name                 string     `json:"name"`
+	Label                string     `json:"label"`
+	Description          string     `json:"description"`
+	Category             string     `json:"category,omitempty"`
+	Risk                 RiskLevel  `json:"risk"`
+	InputSchema          Schema     `json:"input_schema"`
+	SensitiveInputFields []string   `json:"sensitive_input_fields,omitempty"`
+	OutputHint           OutputHint `json:"output_hint,omitempty"`
 }
 
 // ActionRequest is a side-effect-free request to prepare a target action.

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -229,12 +229,21 @@ with `ack_requeue_true`, plus explicit `publish_message` writes. Message
 payload previews and published payloads may contain secrets or customer data;
 prefer approval-required access until the workflow is trusted.
 
-Kafka / Redpanda actions in 0.2.18 include cluster metadata, topic listing and
-description, consumer-group listing and lag description, and bounded message
-samples from an explicit topic partition. `read_messages` does not join a
-consumer group, commit offsets, or enable automatic topic creation. Message
-keys, values, and headers may contain secrets or customer data; keep the action
-in approval-required mode unless that read workflow is explicitly trusted.
+Kafka / Redpanda actions include cluster metadata, topic listing and
+description, consumer-group listing and lag description, bounded message
+samples from an explicit topic partition, guarded single-message publishing,
+and one-partition consumer-group offset changes. `read_messages` does not join
+a consumer group, commit offsets, or enable automatic topic creation.
+`publish_message` is write risk and uses bounded content with all-in-sync-
+replica acknowledgements. `set_consumer_group_offset` is destructive, requires
+an inactive classic group immediately before the commit, rejects modern
+consumer-protocol groups, validates the log range, and verifies the commit.
+Kafka does not provide an atomic lock against a group member joining during
+that final interval, so the result reports a best-effort guard and post-commit
+state. Message content may be sensitive and offset changes can replay or skip
+records; prefer Prompt for both write actions.
+Publish request displays redact raw keys, values, and headers. A failed publish
+can have an unknown delivery outcome, so inspect before manually retrying.
 
 S3 actions include bucket metadata, bounded object listing, object metadata,
 bounded object download/upload, object rename, and explicit delete. Object

--- a/docs/development/add-a-connector.md
+++ b/docs/development/add-a-connector.md
@@ -37,6 +37,9 @@ These rules are part of the connector contract:
 - Connector-specific structured output secrets must be listed in
   `OutputHint.SensitiveFields` so the shared redaction layer masks them in MCP
   responses, history, and audit.
+- Arbitrary action inputs that may contain sensitive content, such as message
+  keys, values, or headers, must be listed in
+  `ActionDefinition.SensitiveInputFields`.
 - Action input JSON is persisted and returned as a redacted display payload.
   The raw execution payload is kept only in the encrypted connector action
   payload. Never put API tokens, passwords, private keys, or tenant secrets in
@@ -165,11 +168,13 @@ For connector-specific output fields that contain sensitive material, set
 names in structured output before returning MCP responses or persisting
 history/audit payloads.
 
-The same redaction rule applies to action inputs and approval displays. The
-gateway persists redacted input JSON, while the raw prepared execution payload
-is encrypted separately for the action runner. Tests for a connector should
-prove that realistic secret-looking input/output values are masked in MCP
-responses and history.
+For action inputs such as message keys, payloads, or headers whose arbitrary
+content may itself be sensitive, list the corresponding schema field names in
+`ActionDefinition.SensitiveInputFields`. The gateway persists and displays
+redacted input JSON, while the raw prepared execution payload is encrypted
+separately for the action runner. Tests for a connector should prove that
+realistic secret-looking input/output values are masked in MCP responses and
+history.
 
 Approval-required actions store a context snapshot when the request is created.
 That snapshot includes token validity, permission rule, target/profile public
@@ -458,6 +463,8 @@ Add focused tests for:
 - action input schema rejection for secret fields
 - secret credential schema rejection when defaults are present
 - connector-specific `OutputHint.SensitiveFields` redaction
+- connector-specific `SensitiveInputFields` redaction while the encrypted
+  execution envelope preserves the exact input
 - `blocked`, `approval_required`, and `always_run` permission behavior
 - approval-required execution and stale-context behavior
 - stale request finalization when target/profile/action context changes or is

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -35,7 +35,8 @@ built-in connectors that share the same target/profile, permission, approval,
 history, and audit model. SSH owns a live terminal and file-transfer surface;
 Postgres and ClickHouse own structured database actions; Redis / Valkey owns bounded
 key-browser actions; RabbitMQ owns queue browsing and bounded message previews;
-Kafka / Redpanda owns stream metadata, lag, and bounded partition reads.
+Kafka / Redpanda owns stream metadata, lag, bounded partition reads, and its
+guarded publish/offset controls.
 Future connectors should add their own execution surface without adding a new
 permission or audit pipeline.
 

--- a/docs/setup/kafka-redpanda.md
+++ b/docs/setup/kafka-redpanda.md
@@ -28,9 +28,9 @@ for a trusted private network; TLS or SCRAM remains the recommended setup.
 For a broker running on the same machine as AIPermission Docker, use
 `host.docker.internal` rather than `localhost` in a Direct target.
 
-## Read Actions
+## Actions
 
-The 0.2.18 read surface provides:
+The read surface provides:
 
 - `cluster_info`
 - `list_topics`
@@ -38,6 +38,11 @@ The 0.2.18 read surface provides:
 - `list_consumer_groups`
 - `describe_consumer_group`
 - `read_messages`
+
+The 0.2.19 guarded write surface adds:
+
+- `publish_message`
+- `set_consumer_group_offset`
 
 `read_messages` uses explicit topic/partition assignment. It does not join a
 consumer group, commit offsets, or enable automatic topic creation. Record
@@ -49,6 +54,36 @@ Message keys, values, and headers can contain secrets or customer data. Keep
 message reads in Prompt mode unless the workflow is explicitly trusted. The
 returned sample is stored in the encrypted local History like every other
 connector action result.
+
+`publish_message` writes one bounded key/value/header record to an explicit
+partition. AIPermission requests all-in-sync-replica acknowledgements and does
+not enable automatic topic creation. Delivery and retry time are bounded; if a
+broker or network failure makes the outcome uncertain, inspect the topic before
+retrying manually. Approval previews contain byte counts rather than raw
+message content, and displayed request input redacts the raw key, value, and
+headers.
+
+`set_consumer_group_offset` changes one committed offset only. It checks that
+the consumer group has no active members immediately before committing,
+validates the requested offset against the partition's earliest and end
+offsets, and reads the committed offset back after the write. Kafka does not
+provide an atomic lock that prevents a member from joining between the final
+check and commit. The result therefore reports this guard as best effort and
+includes the post-commit group state or a warning when it cannot be confirmed.
+Offset changes can replay already processed records or skip unread records, so
+the action is classified destructive.
+The current offset writer supports classic consumer groups. It fails closed for
+groups using Kafka's newer consumer protocol rather than applying an offset
+change through an ambiguous group API.
+
+Keep both write actions in Prompt mode unless direct execution is deliberate
+and tightly scoped. The generic MCP tools discover these actions through
+`get_connector_actions` and execute them through `call_connector_action`; there
+is no Kafka-specific MCP tool or bypass.
+
+The local browser requires an explicit confirmation for each write and records
+the result in shared History/Audit. Browser actions do not evaluate an MCP
+token's Disabled/Prompt/Always rule; those rules govern MCP calls.
 
 Use a least-privilege broker account. AIPermission bounds its own behavior, but
 broker ACLs remain the primary authorization boundary.

--- a/docs/skills/aipermission-operator/SKILL.md
+++ b/docs/skills/aipermission-operator/SKILL.md
@@ -56,6 +56,14 @@ RabbitMQ messages only when the operator explicitly asked for a write.
 For Kafka / Redpanda, discover topics before describing partitions or reading
 messages. Keep message reads bounded, prefer Prompt because payloads can be
 sensitive, and remember that read actions never join groups or commit offsets.
+Use `publish_message` only for one explicitly requested topic partition. Treat
+`set_consumer_group_offset` as destructive because it can replay or skip
+records; keep both actions on Prompt unless direct execution is intentional.
+If a publish reports an unknown delivery outcome, inspect the topic before
+retrying. Offset changes support inactive classic groups and reject modern
+consumer-protocol groups. The inactive-group check is best effort because
+Kafka cannot atomically prevent a member joining between the final check and
+commit; inspect the returned post-commit state and warning.
 
 Avoid vague reasons:
 

--- a/frontend/src/connectors/templates/kafka/console-helpers.js
+++ b/frontend/src/connectors/templates/kafka/console-helpers.js
@@ -9,6 +9,31 @@ export function requestIsCurrent(versions, channel, version, targetRef, currentT
   return versions.get(channel) === version && targetRef === currentTargetRef;
 }
 
-export function detailMatchesSelection(identity, view, selectedName) {
-  return Boolean(selectedName) && identity === `${view}:${selectedName}`;
+export function detailMatchesSelection(identity, view, name) {
+  return Boolean(name) && identity === `${view}:${name}`;
+}
+
+export function offsetSelectionValue(partition) {
+  return JSON.stringify([String(partition?.topic || ""), Number(partition?.partition || 0)]);
+}
+
+export function parseOffsetSelection(value) {
+  try {
+    const [topic, partition] = JSON.parse(value);
+    if (!topic || !Number.isInteger(partition) || partition < 0) return null;
+    return { topic, partition };
+  } catch {
+    return null;
+  }
+}
+
+export function actionableOffsetPartitions(partitions = []) {
+  return partitions.filter((partition) => {
+    if (!partition || partition.error || !partition.topic) return false;
+    const partitionID = Number(partition.partition);
+    return Number.isInteger(partitionID)
+      && partitionID >= 0
+      && partition.committed_offset != null
+      && partition.end_offset != null;
+  });
 }

--- a/frontend/src/connectors/templates/kafka/console.jsx
+++ b/frontend/src/connectors/templates/kafka/console.jsx
@@ -1,4 +1,4 @@
-import { Activity, Database, Eye, RefreshCcw, Search, Users } from "lucide-react";
+import { Activity, Database, Eye, Gauge, RefreshCcw, Search, Send, Users } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Badge } from "../../../components/ui/badge";
 import { Button } from "../../../components/ui/button";
@@ -7,9 +7,12 @@ import { Input, Select } from "../../../components/ui/form";
 import { Notice } from "../../../components/ui/notice";
 import { TerminalBlock } from "../../../components/ui/terminal-block";
 import { apiPost } from "../../../lib/api";
-import { connectorActionError, detailMatchesSelection, requestIsCurrent } from "./console-helpers";
+import { actionableOffsetPartitions, connectorActionError, detailMatchesSelection, offsetSelectionValue, parseOffsetSelection, requestIsCurrent } from "./console-helpers";
+import { KafkaOffsetDialog, KafkaPublishDialog } from "./write-dialogs";
 
 const defaultRead = Object.freeze({ partition: "0", start_position: "recent", offset: "0", max_records: "20" });
+const defaultPublish = Object.freeze({ partition: "0", key: "", key_encoding: "utf8", value: "", value_encoding: "utf8", headers: "[]" });
+const defaultOffset = Object.freeze({ selection: "", offset: "" });
 
 export function KafkaConnectorConsoleTemplate({ target, approvals, theme, session, onNewStructuredSession, onRefreshActivity }) {
   const activeSession = session || { active: false, startedAt: "" };
@@ -23,6 +26,8 @@ export function KafkaConnectorConsoleTemplate({ target, approvals, theme, sessio
   const [detailIdentity, setDetailIdentity] = useState("");
   const [messages, setMessages] = useState(null);
   const [readForm, setReadForm] = useState(defaultRead);
+  const [publishDialog, setPublishDialog] = useState({ open: false, form: defaultPublish, error: "" });
+  const [offsetDialog, setOffsetDialog] = useState({ open: false, form: defaultOffset, error: "" });
   const [state, setState] = useState({ state: "idle", error: "", message: "" });
   const requestVersions = useRef(new Map());
   const currentTargetRef = useRef(target.ref);
@@ -41,6 +46,7 @@ export function KafkaConnectorConsoleTemplate({ target, approvals, theme, sessio
     return items.filter((item) => String(item.name || "").toLowerCase().includes(needle));
   }, [items, query]);
   const activeDetail = detailMatchesSelection(detailIdentity, view, selectedName) ? detail : null;
+  const offsetPartitions = actionableOffsetPartitions(activeDetail?.partitions);
 
   useEffect(() => {
     currentTargetRef.current = target.ref;
@@ -54,6 +60,8 @@ export function KafkaConnectorConsoleTemplate({ target, approvals, theme, sessio
     setDetailIdentity("");
     setMessages(null);
     setReadForm(defaultRead);
+    setPublishDialog({ open: false, form: defaultPublish, error: "" });
+    setOffsetDialog({ open: false, form: defaultOffset, error: "" });
     setState({ state: "idle", error: "", message: "" });
   }, [target.ref, activeSession.startedAt]);
 
@@ -135,6 +143,8 @@ export function KafkaConnectorConsoleTemplate({ target, approvals, theme, sessio
   }
 
   async function loadDetail(name, detailView = view) {
+    setDetail(null);
+    setDetailIdentity("");
     const output = await runAction(
       detailView === "topics" ? "describe_topic" : "describe_consumer_group",
       detailView === "topics" ? { topic: name } : { group: name },
@@ -165,6 +175,84 @@ export function KafkaConnectorConsoleTemplate({ target, approvals, theme, sessio
     if (readForm.start_position === "offset") input.offset = readForm.offset;
     const output = await runAction("read_messages", input, `manual ${product} browser bounded message sample`, "reading", "messages");
     if (output) setMessages(output);
+  }
+
+  function openPublishDialog() {
+    const firstPartition = activeDetail?.partitions?.[0]?.partition ?? 0;
+    setState({ state: "idle", error: "", message: "" });
+    setPublishDialog({ open: true, form: { ...defaultPublish, partition: String(firstPartition) }, error: "" });
+  }
+
+  async function publishMessage() {
+    const form = publishDialog.form;
+    let headers;
+    try {
+      headers = JSON.parse(form.headers || "[]");
+    } catch {
+      setPublishDialog((current) => ({ ...current, error: "Headers must be valid JSON." }));
+      return;
+    }
+    if (!Array.isArray(headers)) {
+      setPublishDialog((current) => ({ ...current, error: "Headers must be a JSON array." }));
+      return;
+    }
+    setPublishDialog((current) => ({ ...current, error: "" }));
+    const output = await runAction("publish_message", {
+      topic: selectedName,
+      partition: Number(form.partition),
+      key: form.key,
+      key_encoding: form.key_encoding,
+      value: form.value,
+      value_encoding: form.value_encoding,
+      headers,
+    }, `manual ${product} browser message publish`, "writing", "publish");
+    if (!output) return;
+    setPublishDialog({ open: false, form: defaultPublish, error: "" });
+    await loadDetail(selectedName, "topics");
+  }
+
+  function openOffsetDialog() {
+    const first = offsetPartitions[0];
+    const selection = first ? offsetSelectionValue(first) : "";
+    const offset = first?.committed_offset === "-1" ? "" : String(first?.committed_offset || "");
+    setState({ state: "idle", error: "", message: "" });
+    setOffsetDialog({ open: true, form: { selection, offset }, error: "" });
+  }
+
+  async function setConsumerGroupOffset() {
+    const selected = parseOffsetSelection(offsetDialog.form.selection);
+    if (!selected) {
+      setOffsetDialog((current) => ({ ...current, error: "Choose one topic partition." }));
+      return;
+    }
+    if (!/^\d+$/.test(offsetDialog.form.offset.trim())) {
+      setOffsetDialog((current) => ({ ...current, error: "New offset must be a non-negative integer." }));
+      return;
+    }
+    setOffsetDialog((current) => ({ ...current, error: "" }));
+    const output = await runAction("set_consumer_group_offset", {
+      group: selectedName,
+      topic: selected.topic,
+      partition: selected.partition,
+      offset: offsetDialog.form.offset.trim(),
+    }, `manual ${product} browser consumer group offset change`, "writing", "offset");
+    if (!output) return;
+    setOffsetDialog({ open: false, form: defaultOffset, error: "" });
+    await loadDetail(selectedName, "groups");
+  }
+
+  function updatePublishForm(form) {
+    if (state.state !== "writing" && state.error) {
+      setState((current) => ({ ...current, error: "" }));
+    }
+    setPublishDialog((current) => ({ ...current, form, error: "" }));
+  }
+
+  function updateOffsetForm(form) {
+    if (state.state !== "writing" && state.error) {
+      setState((current) => ({ ...current, error: "" }));
+    }
+    setOffsetDialog((current) => ({ ...current, form, error: "" }));
   }
 
   if (!activeSession.active) {
@@ -232,7 +320,19 @@ export function KafkaConnectorConsoleTemplate({ target, approvals, theme, sessio
                 {selectedName ? (view === "topics" ? "Partitions, offsets, and bounded message samples" : "Members, assignments, committed offsets, and lag") : `Select one of the ${view} on the left.`}
               </p>
             </div>
-            {activeDetail ? <CopyButton value={JSON.stringify({ detail: activeDetail, messages }, null, 2)} variant="outline" className="h-8 px-2 text-xs">JSON</CopyButton> : null}
+            <div className="flex items-center gap-2">
+              {activeDetail && view === "topics" ? (
+                <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={openPublishDialog} disabled={state.state !== "idle"}>
+                  <Send className="h-3.5 w-3.5" />Publish
+                </Button>
+              ) : null}
+              {activeDetail && view === "groups" && offsetPartitions.length > 0 ? (
+                <Button type="button" variant="outline" className="h-8 px-2 text-xs" onClick={openOffsetDialog} disabled={state.state !== "idle"}>
+                  <Gauge className="h-3.5 w-3.5" />Set offset
+                </Button>
+              ) : null}
+              {activeDetail ? <CopyButton value={JSON.stringify({ detail: activeDetail, messages }, null, 2)} variant="outline" className="h-8 px-2 text-xs">JSON</CopyButton> : null}
+            </div>
           </div>
           <div className="grid min-h-0 gap-4 overflow-y-auto p-4 lg:grid-cols-2 lg:overflow-hidden">
             <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-2">
@@ -267,6 +367,7 @@ export function KafkaConnectorConsoleTemplate({ target, approvals, theme, sessio
           </div>
           <div className={`grid gap-2 border-t p-3 ${borderClass}`} aria-live="polite">
             <Notice tone="warn">Message values, keys, and headers can contain secrets. Samples are bounded and never commit consumer offsets.</Notice>
+            <Notice tone="warn">Publishing writes one message. Offset changes can replay or skip messages. Local browser writes require confirmation here; for MCP access, keep both actions on Prompt unless direct execution is intentional.</Notice>
             {state.error ? <Notice tone="bad">{state.error}</Notice> : null}
             {state.message ? <Notice tone="good">{state.message}</Notice> : null}
           </div>
@@ -279,6 +380,30 @@ export function KafkaConnectorConsoleTemplate({ target, approvals, theme, sessio
           {String(target.config?.bootstrap_brokers || "").split(/[\s,]+/).filter(Boolean).join(", ")}
         </span>
       </div>
+      <KafkaPublishDialog
+        value={publishDialog}
+        theme={theme}
+        product={product}
+        topic={selectedName}
+        partitions={activeDetail?.partitions || []}
+        pending={state.state === "writing"}
+        actionError={state.error}
+        onChange={updatePublishForm}
+        onClose={() => setPublishDialog({ open: false, form: defaultPublish, error: "" })}
+        onConfirm={() => void publishMessage()}
+      />
+      <KafkaOffsetDialog
+        value={offsetDialog}
+        theme={theme}
+        product={product}
+        group={selectedName}
+        partitions={offsetPartitions}
+        pending={state.state === "writing"}
+        actionError={state.error}
+        onChange={updateOffsetForm}
+        onClose={() => setOffsetDialog({ open: false, form: defaultOffset, error: "" })}
+        onConfirm={() => void setConsumerGroupOffset()}
+      />
     </div>
   );
 }

--- a/frontend/src/connectors/templates/kafka/metadata.json
+++ b/frontend/src/connectors/templates/kafka/metadata.json
@@ -1,8 +1,8 @@
 {
   "kind": "kafka",
   "label": "Kafka / Redpanda",
-  "summary": "Kafka-compatible cluster, topic, consumer group, lag, and bounded message inspection through direct or SSH-transported profiles.",
-  "version": "0.2",
+  "summary": "Kafka-compatible metadata, bounded message inspection, guarded single-message publish, and inactive-group offset control through direct or SSH-transported profiles.",
+  "version": "0.3",
   "icon": "database",
   "badge_tone": "warn"
 }

--- a/frontend/src/connectors/templates/kafka/write-dialogs.jsx
+++ b/frontend/src/connectors/templates/kafka/write-dialogs.jsx
@@ -1,0 +1,146 @@
+import { Gauge, Send } from "lucide-react";
+import { Button } from "../../../components/ui/button";
+import { Dialog } from "../../../components/ui/dialog";
+import { Input, Select, Textarea } from "../../../components/ui/form";
+import { Notice } from "../../../components/ui/notice";
+import { offsetSelectionValue } from "./console-helpers";
+
+export function KafkaPublishDialog({ value, theme, product, topic, partitions, pending, actionError, onChange, onClose, onConfirm }) {
+  const dark = theme !== "light";
+  const inputClass = dark ? "border-stone-700 bg-[#1a1a1a] text-stone-100" : "";
+  return (
+    <Dialog
+      open={value.open}
+      title={`Publish ${product} message`}
+      description="Review this bounded write before publishing."
+      onClose={onClose}
+      size="lg"
+      closeDisabled={pending}
+      closeOnOverlay={!pending}
+      closeOnEscape={!pending}
+      className={`grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)] ${dark ? "border-stone-700 bg-[#252526] text-stone-100" : ""}`}
+      bodyClassName={`min-h-0 overflow-y-auto ${dark ? "bg-[#252526]" : ""}`}
+    >
+      <div className="grid gap-4">
+        <Notice tone="warn">This writes one message to {topic}. AIPermission requests all-in-sync-replica acknowledgements and does not create topics automatically.</Notice>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <FieldBlock label="Partition">
+            <Select className={inputClass} value={value.form.partition} disabled={pending} onChange={(event) => onChange({ ...value.form, partition: event.target.value })}>
+              {partitions.map((partition) => <option key={partition.partition} value={partition.partition}>Partition {partition.partition}</option>)}
+            </Select>
+          </FieldBlock>
+          <FieldBlock label="Key encoding">
+            <Select className={inputClass} value={value.form.key_encoding} disabled={pending} onChange={(event) => onChange({ ...value.form, key_encoding: event.target.value })}>
+              <option value="utf8">UTF-8</option>
+              <option value="base64">Base64</option>
+            </Select>
+          </FieldBlock>
+        </div>
+        <FieldBlock label="Key">
+          <Input className={`font-mono ${inputClass}`} value={value.form.key} disabled={pending} onChange={(event) => onChange({ ...value.form, key: event.target.value })} placeholder="Optional message key" />
+        </FieldBlock>
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_140px]">
+          <FieldBlock label="Value">
+            <Textarea className={`min-h-40 resize-y font-mono text-xs ${inputClass}`} value={value.form.value} disabled={pending} onChange={(event) => onChange({ ...value.form, value: event.target.value })} placeholder='{"type":"test"}' />
+          </FieldBlock>
+          <FieldBlock label="Value encoding">
+            <Select className={inputClass} value={value.form.value_encoding} disabled={pending} onChange={(event) => onChange({ ...value.form, value_encoding: event.target.value })}>
+              <option value="utf8">UTF-8</option>
+              <option value="base64">Base64</option>
+            </Select>
+          </FieldBlock>
+        </div>
+        <FieldBlock label="Headers JSON">
+          <Textarea
+            id="kafka-publish-headers"
+            className={`min-h-24 resize-y font-mono text-xs ${inputClass}`}
+            value={value.form.headers}
+            disabled={pending}
+            aria-invalid={Boolean(value.error || actionError)}
+            aria-describedby={value.error || actionError ? "kafka-publish-error" : undefined}
+            onChange={(event) => onChange({ ...value.form, headers: event.target.value })}
+            placeholder='[{"key":"trace-id","value":"abc","encoding":"utf8"}]'
+          />
+        </FieldBlock>
+        {value.error || actionError ? <div id="kafka-publish-error" role="alert" aria-live="assertive"><Notice tone="bad">{value.error || actionError}</Notice></div> : null}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose} disabled={pending}>Cancel</Button>
+          <Button type="button" onClick={onConfirm} disabled={pending || !topic || partitions.length === 0}>
+            <Send className="h-4 w-4" />{pending ? "Publishing..." : "Publish message"}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+export function KafkaOffsetDialog({ value, theme, product, group, partitions, pending, actionError, onChange, onClose, onConfirm }) {
+  const dark = theme !== "light";
+  const inputClass = dark ? "border-stone-700 bg-[#1a1a1a] text-stone-100" : "";
+  const selected = partitions.find((partition) => offsetSelectionValue(partition) === value.form.selection);
+  return (
+    <Dialog
+      open={value.open}
+      title={`Set ${product} consumer group offset`}
+      description="This can replay or skip messages for one partition."
+      onClose={onClose}
+      size="md"
+      closeDisabled={pending}
+      closeOnOverlay={!pending}
+      closeOnEscape={!pending}
+      className={`grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)] ${dark ? "border-stone-700 bg-[#252526] text-stone-100" : ""}`}
+      bodyClassName={`min-h-0 overflow-y-auto ${dark ? "bg-[#252526]" : ""}`}
+    >
+      <div className="grid gap-4">
+        <Notice tone="bad">AIPermission checks that the group is inactive immediately before committing and verifies the stored offset afterward. Kafka does not provide an atomic lock against a member joining during that interval. For MCP access, keep this destructive action on Prompt.</Notice>
+        <FieldBlock label="Topic partition">
+          <Select className={inputClass} value={value.form.selection} disabled={pending} onChange={(event) => {
+            const next = partitions.find((partition) => offsetSelectionValue(partition) === event.target.value);
+            onChange({ selection: event.target.value, offset: next?.committed_offset === "-1" ? "" : String(next?.committed_offset || "") });
+          }}>
+            {partitions.map((partition) => (
+              <option key={offsetSelectionValue(partition)} value={offsetSelectionValue(partition)}>
+                {partition.topic} / p{partition.partition} · committed {partition.committed_offset} · end {partition.end_offset}
+              </option>
+            ))}
+          </Select>
+        </FieldBlock>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <FieldBlock label="Current offset">
+            <Input className={inputClass} value={String(selected?.committed_offset ?? "not committed")} disabled />
+          </FieldBlock>
+          <FieldBlock label="New offset">
+            <Input
+              id="kafka-offset-value"
+              className={`font-mono ${inputClass}`}
+              inputMode="numeric"
+              value={value.form.offset}
+              disabled={pending}
+              aria-invalid={Boolean(value.error || actionError)}
+              aria-describedby={value.error || actionError ? "kafka-offset-error" : undefined}
+              onChange={(event) => onChange({ ...value.form, offset: event.target.value })}
+              placeholder="Exact offset"
+            />
+          </FieldBlock>
+        </div>
+        <p className="text-xs text-stone-500">Allowed range: {selected?.committed_offset == null ? "select a partition" : `${selected.earliest_offset ?? "unknown"} to ${selected.end_offset ?? "unknown"}`} · group {group}</p>
+        {value.error || actionError ? <div id="kafka-offset-error" role="alert" aria-live="assertive"><Notice tone="bad">{value.error || actionError}</Notice></div> : null}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose} disabled={pending}>Cancel</Button>
+          <Button type="button" variant="danger" onClick={onConfirm} disabled={pending || !group || !value.form.selection || !value.form.offset.trim()}>
+            <Gauge className="h-4 w-4" />{pending ? "Changing..." : "Change offset"}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function FieldBlock({ label, children }) {
+  return (
+    <label className="grid gap-1.5 text-xs font-semibold">
+      <span className="uppercase text-stone-500">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -35,6 +35,8 @@ const connectorTokenPermissionPanelSource = readFileSync(join(currentDir, "..", 
 const connectorPermissionDialogSource = readFileSync(join(currentDir, "..", "components", "tokens", "connector-permission-dialog.jsx"), "utf8");
 const vaultPermissionDialogSource = readFileSync(join(currentDir, "..", "components", "tokens", "vault-permission-dialog.jsx"), "utf8");
 const connectorTemplateCommonSource = readFileSync(join(currentDir, "..", "connectors", "templates", "common.jsx"), "utf8");
+const kafkaConsoleSource = readFileSync(join(currentDir, "..", "connectors", "templates", "kafka", "console.jsx"), "utf8");
+const kafkaWriteDialogsSource = readFileSync(join(currentDir, "..", "connectors", "templates", "kafka", "write-dialogs.jsx"), "utf8");
 const connectorTargetProfileSaveSource = readFileSync(join(currentDir, "..", "connectors", "templates", "target-profile-save.js"), "utf8");
 const connectorTemplateRegistrySource = readFileSync(join(currentDir, "..", "connectors", "templates", "registry.jsx"), "utf8");
 const connectorTemplateCatalogSource = readFileSync(join(currentDir, "..", "connectors", "templates", "catalog.js"), "utf8");
@@ -435,6 +437,15 @@ test("Console exposes connector action approvals", () => {
   assert.match(connectorApprovalDialogSource, /Decline note/);
   assert.match(connectorActivityDialogSource, /Recent structured connector requests/);
   assert.match(connectorActivityDialogSource, /always-run requests/);
+});
+
+test("Kafka write dialogs guard stale detail and pending submissions", () => {
+  assert.match(kafkaConsoleSource, /detailMatchesSelection/);
+  assert.match(kafkaConsoleSource, /setDetailIdentity\(""\)/);
+  assert.match(kafkaConsoleSource, /await onRefreshActivity\?\.\(\)/);
+  assert.match(kafkaWriteDialogsSource, /max-h-\[calc\(100dvh-2rem\)\]/);
+  assert.match(kafkaWriteDialogsSource, /role="alert"/);
+  assert.match(kafkaWriteDialogsSource, /disabled=\{pending\}/);
 });
 
 test("SSH connector template owns SSH-specific operations", () => {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -299,7 +299,8 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.18"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.19"/);
+  assert.match(releaseSource, /Guarded Kafka writes/);
   assert.match(releaseSource, /Kafka \/ Redpanda read browser/);
   assert.match(releaseSource, /Redis \/ Valkey compatibility/);
   assert.match(releaseSource, /Security and dependency maintenance/);

--- a/frontend/src/lib/kafka-console.test.js
+++ b/frontend/src/lib/kafka-console.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { connectorActionError, detailMatchesSelection, requestIsCurrent } from "../connectors/templates/kafka/console-helpers.js";
+import { actionableOffsetPartitions, connectorActionError, detailMatchesSelection, offsetSelectionValue, parseOffsetSelection, requestIsCurrent } from "../connectors/templates/kafka/console-helpers.js";
 import { credentialPayload } from "../connectors/templates/kafka/model-helpers.js";
 
 test("Kafka action helpers surface failed HTTP 200 responses", () => {
@@ -15,10 +15,30 @@ test("Kafka action helpers reject stale target and channel responses", () => {
   assert.equal(requestIsCurrent(versions, "detail", 2, "kafka:1:1", "kafka:2:2"), false);
 });
 
-test("Kafka detail helpers bind responses to the selected view and item", () => {
-  assert.equal(detailMatchesSelection("topics:events", "topics", "events"), true);
-  assert.equal(detailMatchesSelection("topics:events", "groups", "events"), false);
-  assert.equal(detailMatchesSelection("topics:events", "topics", "orders"), false);
+test("Kafka detail actions stay bound to the selected view and item", () => {
+  assert.equal(detailMatchesSelection("topics:orders", "topics", "orders"), true);
+  assert.equal(detailMatchesSelection("topics:orders", "topics", "payments"), false);
+  assert.equal(detailMatchesSelection("topics:orders", "groups", "orders"), false);
+  assert.equal(detailMatchesSelection("", "topics", "orders"), false);
+});
+
+test("Kafka offset controls preserve exact topic and partition selections", () => {
+  const value = offsetSelectionValue({ topic: "orders/priority", partition: 12 });
+  assert.deepEqual(parseOffsetSelection(value), { topic: "orders/priority", partition: 12 });
+  assert.equal(parseOffsetSelection('["",1]'), null);
+  assert.equal(parseOffsetSelection('["orders",-1]'), null);
+  assert.equal(parseOffsetSelection("not-json"), null);
+});
+
+test("Kafka offset controls exclude broker error rows", () => {
+  const partitions = actionableOffsetPartitions([
+    { topic: "orders", partition: 0, committed_offset: "12", end_offset: "20" },
+    { topic: "orders", partition: 1, error: "not leader" },
+    { topic: "", partition: 2, committed_offset: "4", end_offset: "5" },
+  ]);
+  assert.deepEqual(partitions, [
+    { topic: "orders", partition: 0, committed_offset: "12", end_offset: "20" },
+  ]);
 });
 
 test("Kafka credential edits preserve an existing SASL password", () => {

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,26 @@
-export const appVersion = "0.2.18";
+export const appVersion = "0.2.19";
 
 export const changelogEntries = [
+  {
+    version: "0.2.19",
+    label: "Guarded Kafka writes",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Kafka and Redpanda can publish one bounded message to an explicit partition with all-in-sync-replica acknowledgements and no automatic topic creation.",
+          "Inactive consumer-group offsets can be changed for one explicit partition with a best-effort inactivity guard, range checks, commit verification, local confirmation, history, and audit.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "Publish previews show byte counts instead of raw message content; offset changes report their best-effort inactivity guard and post-commit state.",
+          "Publish is classified write and offset changes destructive. Prompt remains the recommended permission rule for both actions.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.18",
     label: "Kafka / Redpanda read browser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3733,7 +3733,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -113,10 +113,14 @@ previews and published payloads can contain secrets or customer data; use short
 reasons and prefer approval-required access until the workflow is trusted.
 
 For Kafka or Redpanda, call `get_connector_actions(target_ref)` to discover
-cluster, topic, consumer-group, lag, and bounded message-read actions. Message
-reads use explicit partition assignment, never join a consumer group, and
-never commit offsets. Payloads can contain sensitive application data, so keep
-these reads in Prompt mode until the workflow is trusted.
+cluster, topic, consumer-group, lag, bounded message-read, guarded publish, and
+single-partition offset actions. Message reads use explicit partition
+assignment, never join a consumer group, and never commit offsets. Publishing
+is a write action; consumer-group offset changes are destructive and reject
+active classic groups and modern consumer-protocol groups. Payloads can contain
+sensitive application data, and offset changes can replay or skip records, so
+keep these actions in Prompt mode unless direct execution is intentional. If a
+publish has an unknown delivery outcome, inspect before retrying.
 
 For Docker, call `get_connector_actions(target_ref)` to discover bounded
 actions such as `docker_version`, `list_containers`, `list_images`,

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/resources/aipermission-operator/SKILL.md
+++ b/packages/mcp/resources/aipermission-operator/SKILL.md
@@ -56,6 +56,14 @@ RabbitMQ messages only when the operator explicitly asked for a write.
 For Kafka / Redpanda, discover topics before describing partitions or reading
 messages. Keep message reads bounded, prefer Prompt because payloads can be
 sensitive, and remember that read actions never join groups or commit offsets.
+Use `publish_message` only for one explicitly requested topic partition. Treat
+`set_consumer_group_offset` as destructive because it can replay or skip
+records; keep both actions on Prompt unless direct execution is intentional.
+If a publish reports an unknown delivery outcome, inspect the topic before
+retrying. Offset changes support inactive classic groups and reject modern
+consumer-protocol groups. The inactive-group check is best effort because
+Kafka cannot atomically prevent a member joining between the final check and
+commit; inspect the returned post-commit state and warning.
 
 Avoid vague reasons:
 

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- add guarded single-message Kafka publishing
- add guarded inactive classic consumer-group offset adjustment
- add explicit browser confirmations for publish and offset changes
- bind approval drift checks to sensitive fields and the Kafka connector version

## Security

- publish previews expose byte counts, not message content
- publishing requires existing topics and all in-sync replicas
- offset changes validate topic and partition bounds and verify the committed result
- Prompt mode remains the recommended default for both write actions

## Validation

- `make release-check`
- full development stack build and runtime smoke test on port 3212
- focused backend, frontend, and MCP tests after rebasing onto `main`
