### PR TITLE
feat: complete remote backup recovery cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project uses semantic versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.2.21] - 2026-08-01
+
+### Added
+
+- Added exact single and selected remote backup deletion from Settings, with
+  local record reconciliation after confirmed service deletion.
+- Added encrypted per-service recovery baselines and an unlock-time warning
+  when the remote backup service contains a newer recovery version.
+
+### Changed
+
+- Remote restore versions are grouped by source installation and show both
+  relative and exact timestamps for safer recovery selection.
+- Backup cleanup can combine explicit selection with the existing keep-last-N
+  retention workflow.
+
+### Security
+
+- The backup service refuses to delete the final recovery version in a stream.
+- Freshness baselines stay inside the encrypted local database and advance only
+  after a successful upload or restore; sync checks never mark unseen backups
+  as reviewed.
+- Failed remote freshness checks are shown explicitly instead of being treated
+  as an up-to-date result.
+
 ## [0.2.20] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ To pin a specific release image, set `AIPERMISSION_VERSION` without the leading
 `v`:
 
 ```bash
-AIPERMISSION_VERSION=0.2.20 docker compose -f docker-compose.release.yml up -d
+AIPERMISSION_VERSION=0.2.21 docker compose -f docker-compose.release.yml up -d
 ```
 
 On Windows, clone the repository with Git's default text handling or make sure

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ Implemented:
 - local browser session cookie for the web REST API after unlock
 - encrypted database download/import (`.aipdb`)
 - a self-hosted encrypted-backup service for explicit immutable `.aipdb`
-  uploads, version listing, bounded prune, download, and first-run restore
+  uploads, version listing, selected-version cleanup, bounded prune, download,
+  first-run restore, and newer-remote-version warnings
   without giving the service a database password or decrypted content.
   The recommended topology shares that passive backup service between the
   owner's trusted computers over a private local network. Cross-network access
@@ -531,6 +532,15 @@ Changing the database password re-encrypts the current local database. Existing 
 The unlock screen can manage multiple named local databases. `New Database` creates a separate encrypted database for another project. Plain SQLite files are not supported as runtime databases or imports; AIPermission stores local state in SQLCipher-encrypted `.aipdb` databases.
 
 During one backend process, multiple named databases can stay unlocked. `Switch` changes the active UI database without closing already-unlocked workspaces, so MCP commands and persistent console sessions in another workspace can keep running.
+
+The optional self-hosted AIPermission Backup service stores immutable encrypted
+versions for the database's stable lineage id. Settings can download, restore,
+delete selected historical versions, or prune older versions while preserving a
+chosen newest count. The service always protects the final recovery version in
+a stream. After unlock, AIPermission checks active providers once and warns when
+the remote stream is newer than the version last uploaded or restored by this
+encrypted local database. See the
+[AIPermission Backup guide](docs/providers/aipermission-backup.md).
 
 If the same token exists in more than one unlocked database, MCP authentication returns a conflict instead of guessing which workspace to use. Revoke or rename/recreate duplicate token copies before using MCP.
 

--- a/backend/internal/api/backup.go
+++ b/backend/internal/api/backup.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"errors"
 	"io"
 	"net/http"
@@ -112,6 +113,10 @@ func (s backupHandlers) importDatabaseMultipart(w http.ResponseWriter, r *http.R
 }
 
 func (s backupHandlers) installImportedDatabase(w http.ResponseWriter, r *http.Request, databaseName string, databasePassword string, writeTemp func(string) error) {
+	s.installImportedDatabaseWithMutator(w, r, databaseName, databasePassword, writeTemp, nil)
+}
+
+func (s backupHandlers) installImportedDatabaseWithMutator(w http.ResponseWriter, r *http.Request, databaseName string, databasePassword string, writeTemp func(string) error, mutate func(*sql.DB) error) {
 	databaseName = strings.TrimSpace(databaseName)
 	if databaseName == "" {
 		writeError(w, http.StatusBadRequest, "database name is required")
@@ -166,6 +171,14 @@ func (s backupHandlers) installImportedDatabase(w http.ResponseWriter, r *http.R
 		_ = os.Remove(tmpPath)
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
+	}
+	if mutate != nil {
+		if err := mutate(testDB); err != nil {
+			_ = testDB.Close()
+			_ = os.Remove(tmpPath)
+			writeInternalError(w)
+			return
+		}
 	}
 	_ = testDB.Close()
 

--- a/backend/internal/api/backup_provider_handlers.go
+++ b/backend/internal/api/backup_provider_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -80,6 +81,21 @@ type backupRecordResponse struct {
 	DeletedAt       *string        `json:"deleted_at,omitempty"`
 	CreatedAt       string         `json:"created_at"`
 	UpdatedAt       string         `json:"updated_at"`
+}
+
+type backupFreshnessResponse struct {
+	ProviderID         int64  `json:"provider_id"`
+	ProviderName       string `json:"provider_name"`
+	RemoteNewer        bool   `json:"remote_newer"`
+	LatestRemoteID     string `json:"latest_remote_id,omitempty"`
+	LatestRemoteAt     string `json:"latest_remote_at,omitempty"`
+	LatestRemoteSource string `json:"latest_remote_source,omitempty"`
+	LatestKnownID      string `json:"latest_known_id,omitempty"`
+	LatestKnownAt      string `json:"latest_known_at,omitempty"`
+}
+
+type backupSyncResult struct {
+	Freshness backupFreshnessResponse
 }
 
 func (s backupHandlers) providerCatalog(w http.ResponseWriter, _ *http.Request) {
@@ -371,8 +387,9 @@ func (s backupHandlers) listProviderRecords(w http.ResponseWriter, r *http.Reque
 		handleBackupProviderError(w, err)
 		return
 	}
+	var syncResult backupSyncResult
 	if provider.Status == "active" {
-		if err := syncBackupServiceRecords(r.Context(), runtime, store, provider); err != nil {
+		if syncResult, err = syncBackupServiceRecords(r.Context(), runtime, store, provider); err != nil {
 			handleBackupServiceError(w, err)
 			return
 		}
@@ -386,7 +403,36 @@ func (s backupHandlers) listProviderRecords(w http.ResponseWriter, r *http.Reque
 	for _, item := range records {
 		responses = append(responses, backupRecordToResponse(item))
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"items": responses, "remote_sync": provider.Status == "active"})
+	writeJSON(w, http.StatusOK, map[string]any{"items": responses, "remote_sync": provider.Status == "active", "freshness": syncResult.Freshness})
+}
+
+func (s backupHandlers) backupFreshness(w http.ResponseWriter, r *http.Request) {
+	runtime, ok := s.activeRuntimeOrLocked(w)
+	if !ok {
+		return
+	}
+	store := backups.NewStore(runtime.database)
+	providers, err := store.ListProviders(r.Context())
+	if err != nil {
+		handleBackupProviderError(w, err)
+		return
+	}
+	warnings := make([]backupFreshnessResponse, 0)
+	checkErrors := make([]map[string]any, 0)
+	for _, provider := range providers {
+		if provider.Status != "active" || provider.ProviderType != backups.ServiceProviderType {
+			continue
+		}
+		result, syncErr := syncBackupServiceRecords(r.Context(), runtime, store, provider)
+		if syncErr != nil {
+			checkErrors = append(checkErrors, map[string]any{"provider_id": provider.ID, "provider_name": provider.Name})
+			continue
+		}
+		if result.Freshness.RemoteNewer {
+			warnings = append(warnings, result.Freshness)
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": warnings, "check_errors": checkErrors})
 }
 
 func (s backupHandlers) uploadProviderBackup(w http.ResponseWriter, r *http.Request) {
@@ -411,6 +457,10 @@ func (s backupHandlers) uploadProviderBackup(w http.ResponseWriter, r *http.Requ
 	}
 	record, err := upsertServiceBackupRecord(r.Context(), runtime, backups.NewStore(runtime.database), provider, backup)
 	if err != nil {
+		handleBackupProviderError(w, err)
+		return
+	}
+	if err := backups.WriteServiceBaseline(r.Context(), runtime.database, stringFromMap(provider.Public, "base_url"), streamID, backup); err != nil {
 		handleBackupProviderError(w, err)
 		return
 	}
@@ -441,7 +491,7 @@ func (s backupHandlers) pruneProviderBackups(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	store := backups.NewStore(runtime.database)
-	if err := syncBackupServiceRecords(r.Context(), runtime, store, provider); err != nil {
+	if _, err := syncBackupServiceRecords(r.Context(), runtime, store, provider); err != nil {
 		handleBackupServiceError(w, err)
 		return
 	}
@@ -548,7 +598,11 @@ func (s backupHandlers) restoreProviderRecord(w http.ResponseWriter, r *http.Req
 		"provider_id": provider.ID, "record_id": record.ID, "filename": record.Filename,
 		"database_name": strings.TrimSpace(request.DatabaseName), "source_machine": record.SourceMachine,
 	})
-	s.installImportedDatabase(w, r, request.DatabaseName, request.DatabasePassword, copyBackupFile(tmpPath))
+	s.installImportedDatabaseWithMutator(w, r, request.DatabaseName, request.DatabasePassword, copyBackupFile(tmpPath), func(database *sql.DB) error {
+		return backups.WriteServiceBaseline(r.Context(), database, stringFromMap(provider.Public, "base_url"), stringFromMap(provider.Public, "stream_id"), backups.ServiceBackup{
+			ID: record.ProviderFileID, CreatedAt: record.BackupCreatedAt,
+		})
+	})
 }
 
 func (s backupHandlers) activeBackupServiceProvider(w http.ResponseWriter, r *http.Request) (*databaseRuntime, backups.Provider, *backups.ServiceClient, bool) {
@@ -693,26 +747,64 @@ func backupRecordToResponse(item backups.Record) backupRecordResponse {
 	}
 }
 
-func syncBackupServiceRecords(ctx context.Context, runtime *databaseRuntime, store *backups.Store, provider backups.Provider) error {
+func syncBackupServiceRecords(ctx context.Context, runtime *databaseRuntime, store *backups.Store, provider backups.Provider) (backupSyncResult, error) {
+	baseURL := stringFromMap(provider.Public, "base_url")
+	streamID := stringFromMap(provider.Public, "stream_id")
+	baseline, err := backups.ReadServiceBaseline(ctx, runtime.database, baseURL, streamID)
+	if err != nil {
+		return backupSyncResult{}, err
+	}
 	client, err := backupServiceClient(runtime, provider)
 	if err != nil {
-		return err
+		return backupSyncResult{}, err
 	}
-	items, err := client.ListBackups(ctx, stringFromMap(provider.Public, "stream_id"))
+	items, err := client.ListBackups(ctx, streamID)
 	if err != nil {
-		return err
+		return backupSyncResult{}, err
+	}
+	result := backupSyncResult{Freshness: backupFreshnessResponse{ProviderID: provider.ID, ProviderName: provider.Name}}
+	if baseline != nil {
+		result.Freshness.LatestKnownID = baseline.BackupID
+		result.Freshness.LatestKnownAt = baseline.CreatedAt
+	}
+	if len(items) > 0 {
+		result.Freshness.LatestRemoteID = items[0].ID
+		result.Freshness.LatestRemoteAt = items[0].CreatedAt
+		result.Freshness.LatestRemoteSource = items[0].SourceInstallationID
+		result.Freshness.RemoteNewer = remoteBackupIsNewer(items[0], baseline)
 	}
 	presentIDs := make([]string, 0, len(items))
 	for _, item := range items {
 		if _, err := upsertServiceBackupRecord(ctx, runtime, store, provider, item); err != nil {
-			return err
+			return backupSyncResult{}, err
 		}
 		presentIDs = append(presentIDs, item.ID)
 	}
 	if err := store.MarkMissingProviderRecordsDeleted(ctx, provider.ID, presentIDs); err != nil {
-		return err
+		return backupSyncResult{}, err
 	}
-	return store.UpdateLastChecked(ctx, provider.ID, time.Now())
+	if err := store.UpdateLastChecked(ctx, provider.ID, time.Now()); err != nil {
+		return backupSyncResult{}, err
+	}
+	return result, nil
+}
+
+func remoteBackupIsNewer(remote backups.ServiceBackup, baseline *backups.ServiceBaseline) bool {
+	if remote.ID == "" {
+		return false
+	}
+	if baseline == nil {
+		return true
+	}
+	if remote.ID == baseline.BackupID {
+		return false
+	}
+	remoteAt, remoteErr := time.Parse(time.RFC3339Nano, remote.CreatedAt)
+	knownAt, knownErr := time.Parse(time.RFC3339Nano, baseline.CreatedAt)
+	if remoteErr != nil || knownErr != nil {
+		return false
+	}
+	return !remoteAt.Before(knownAt)
 }
 
 func upsertServiceBackupRecord(ctx context.Context, runtime *databaseRuntime, store *backups.Store, provider backups.Provider, item backups.ServiceBackup) (backups.Record, error) {

--- a/backend/internal/api/backup_provider_handlers.go
+++ b/backend/internal/api/backup_provider_handlers.go
@@ -41,6 +41,10 @@ type pruneBackupProviderRequest struct {
 	KeepLatest int `json:"keep_latest"`
 }
 
+type deleteBackupRecordsRequest struct {
+	RecordIDs []int64 `json:"record_ids"`
+}
+
 type backupProviderCatalogItem struct {
 	ProviderType string   `json:"provider_type"`
 	Label        string   `json:"label"`
@@ -84,7 +88,7 @@ func (s backupHandlers) providerCatalog(w http.ResponseWriter, _ *http.Request) 
 			ProviderType: backups.ServiceProviderType,
 			Label:        "AIPermission Backup",
 			Status:       "available",
-			Capabilities: []string{"encrypted_database_upload", "immutable_versions", "prune_versions", "first_run_restore", "self_hosted"},
+			Capabilities: []string{"encrypted_database_upload", "immutable_versions", "prune_versions", "delete_versions", "first_run_restore", "self_hosted"},
 		}},
 	})
 }
@@ -444,6 +448,61 @@ func (s backupHandlers) pruneProviderBackups(w http.ResponseWriter, r *http.Requ
 	s.writeAudit(r.Context(), runtime, "user", nil, 0, "backup.provider.pruned", map[string]any{
 		"provider_id": provider.ID, "provider_type": provider.ProviderType,
 		"stream_id": result.StreamID, "keep_latest": result.KeepLatest, "deleted_count": result.DeletedCount,
+	})
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s backupHandlers) deleteProviderBackupRecords(w http.ResponseWriter, r *http.Request) {
+	runtime, provider, client, ok := s.activeBackupServiceProvider(w, r)
+	if !ok {
+		return
+	}
+	var request deleteBackupRecordsRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	if len(request.RecordIDs) < 1 || len(request.RecordIDs) > 100 {
+		writeError(w, http.StatusBadRequest, "record_ids must contain 1 to 100 backup record ids")
+		return
+	}
+	store := backups.NewStore(runtime.database)
+	seen := make(map[int64]struct{}, len(request.RecordIDs))
+	providerFileIDs := make([]string, 0, len(request.RecordIDs))
+	streamID := stringFromMap(provider.Public, "stream_id")
+	for _, recordID := range request.RecordIDs {
+		if recordID < 1 {
+			writeError(w, http.StatusBadRequest, "backup record ids must be positive")
+			return
+		}
+		if _, exists := seen[recordID]; exists {
+			writeError(w, http.StatusBadRequest, "backup record ids must be unique")
+			return
+		}
+		seen[recordID] = struct{}{}
+		record, err := store.GetRecord(r.Context(), provider.ID, recordID)
+		if err != nil {
+			handleBackupProviderError(w, err)
+			return
+		}
+		if stringFromMap(record.Metadata, "stream_id") != streamID {
+			writeError(w, http.StatusConflict, "backup record does not belong to the provider stream")
+			return
+		}
+		providerFileIDs = append(providerFileIDs, record.ProviderFileID)
+	}
+	result, err := client.DeleteBackups(r.Context(), streamID, providerFileIDs)
+	if err != nil {
+		handleBackupServiceError(w, err)
+		return
+	}
+	if err := store.MarkProviderRecordsDeleted(r.Context(), provider.ID, result.DeletedIDs); err != nil {
+		handleBackupProviderError(w, err)
+		return
+	}
+	s.writeAudit(r.Context(), runtime, "user", nil, 0, "backup.provider.records.deleted", map[string]any{
+		"provider_id": provider.ID, "provider_type": provider.ProviderType,
+		"stream_id": result.StreamID, "record_ids": request.RecordIDs, "deleted_count": result.DeletedCount,
 	})
 	writeJSON(w, http.StatusOK, result)
 }

--- a/backend/internal/api/backup_provider_handlers_test.go
+++ b/backend/internal/api/backup_provider_handlers_test.go
@@ -33,10 +33,11 @@ type backupAPITestFixture struct {
 }
 
 type fakeBackupService struct {
-	server *httptest.Server
-	mu     sync.Mutex
-	item   backups.ServiceBackup
-	data   []byte
+	server    *httptest.Server
+	mu        sync.Mutex
+	item      backups.ServiceBackup
+	data      []byte
+	listCalls int
 }
 
 func TestBackupProviderLifecycleUsesEncryptedTokenAndImmutableVersions(t *testing.T) {
@@ -102,6 +103,23 @@ func TestBackupProviderLifecycleUsesEncryptedTokenAndImmutableVersions(t *testin
 	download := performJSON(handler, http.MethodGet, providerPath(created.ID, "/records/"+strconv.FormatInt(record.ID, 10)+"/download"), "", nil)
 	if download.Code != http.StatusOK || download.Body.Len() != int(record.SizeBytes) {
 		t.Fatalf("download failed: %d bytes=%d body=%s", download.Code, download.Body.Len(), download.Body.String())
+	}
+	remote.mu.Lock()
+	listCallsBeforeDelete := remote.listCalls
+	remote.mu.Unlock()
+	deleteRecords := performJSON(handler, http.MethodPost, providerPath(created.ID, "/records/delete"), "", deleteBackupRecordsRequest{RecordIDs: []int64{record.ID}})
+	if deleteRecords.Code != http.StatusOK || !strings.Contains(deleteRecords.Body.String(), `"deleted_count":1`) {
+		t.Fatalf("selected delete failed: %d %s", deleteRecords.Code, deleteRecords.Body.String())
+	}
+	remote.mu.Lock()
+	listCallsAfterDelete := remote.listCalls
+	remote.mu.Unlock()
+	if listCallsAfterDelete != listCallsBeforeDelete {
+		t.Fatal("selected delete performed a second remote request after the confirmed deletion")
+	}
+	list = performJSON(handler, http.MethodGet, providerPath(created.ID, "/records"), "", nil)
+	if list.Code != http.StatusOK || strings.Contains(list.Body.String(), record.ProviderFileID) {
+		t.Fatalf("deleted record was not reconciled: %d %s", list.Code, list.Body.String())
 	}
 
 	disable := performJSON(handler, http.MethodPut, providerPath(created.ID, ""), "", map[string]any{
@@ -280,6 +298,7 @@ func newFakeBackupService(t *testing.T) *fakeBackupService {
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(service.item)
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/backups"):
+			service.listCalls++
 			items := []backups.ServiceBackup{}
 			if service.item.ID != "" {
 				items = append(items, service.item)
@@ -287,6 +306,11 @@ func newFakeBackupService(t *testing.T) *fakeBackupService {
 			json.NewEncoder(w).Encode(map[string]any{"items": items, "next_cursor": ""})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/prune"):
 			json.NewEncoder(w).Encode(backups.ServicePruneResult{StreamID: service.item.StreamID, KeepLatest: 1})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/backups/delete"):
+			deletedID := service.item.ID
+			service.item = backups.ServiceBackup{}
+			service.data = nil
+			json.NewEncoder(w).Encode(backups.ServiceDeleteResult{StreamID: "stream-a", DeletedIDs: []string{deletedID}, DeletedCount: 1})
 		case r.Method == http.MethodGet && service.item.ID != "" && strings.HasSuffix(r.URL.Path, "/backups/"+service.item.ID):
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.Header().Set("Content-Disposition", `attachment; filename="test-database.aipdb"`)

--- a/backend/internal/api/backup_provider_handlers_test.go
+++ b/backend/internal/api/backup_provider_handlers_test.go
@@ -91,6 +91,14 @@ func TestBackupProviderLifecycleUsesEncryptedTokenAndImmutableVersions(t *testin
 	if record.ProviderFileID == "" || record.ChecksumSHA256 == "" || record.SizeBytes < 1 {
 		t.Fatalf("upload metadata incomplete: %#v", record)
 	}
+	provider, err := backups.NewStore(fixture.db).GetProvider(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseline, err := backups.ReadServiceBaseline(context.Background(), fixture.db, remote.server.URL, stringFromMap(provider.Public, "stream_id"))
+	if err != nil || baseline == nil || baseline.BackupID != record.ProviderFileID {
+		t.Fatalf("upload did not advance the encrypted local baseline: %#v err=%v", baseline, err)
+	}
 
 	list := performJSON(handler, http.MethodGet, providerPath(created.ID, "/records"), "", nil)
 	if list.Code != http.StatusOK || !strings.Contains(list.Body.String(), record.ProviderFileID) || !strings.Contains(list.Body.String(), `"remote_sync":true`) {
@@ -118,7 +126,10 @@ func TestBackupProviderLifecycleUsesEncryptedTokenAndImmutableVersions(t *testin
 		t.Fatal("selected delete performed a second remote request after the confirmed deletion")
 	}
 	list = performJSON(handler, http.MethodGet, providerPath(created.ID, "/records"), "", nil)
-	if list.Code != http.StatusOK || strings.Contains(list.Body.String(), record.ProviderFileID) {
+	listed := decodeRouteResponse[struct {
+		Items []backupRecordResponse `json:"items"`
+	}](t, list.Body.Bytes())
+	if list.Code != http.StatusOK || len(listed.Items) != 0 {
 		t.Fatalf("deleted record was not reconciled: %d %s", list.Code, list.Body.String())
 	}
 
@@ -144,6 +155,25 @@ func TestBackupProviderLifecycleUsesEncryptedTokenAndImmutableVersions(t *testin
 	}
 	if encrypted != "" {
 		t.Fatal("archived provider retained its encrypted token")
+	}
+}
+
+func TestRemoteBackupFreshnessUsesKnownVersionAndTimestamp(t *testing.T) {
+	remote := backups.ServiceBackup{ID: "bkp_new", CreatedAt: "2026-07-31T12:00:00Z"}
+	if !remoteBackupIsNewer(remote, nil) {
+		t.Fatal("a remote version without a local baseline should be reported")
+	}
+	baseline := &backups.ServiceBaseline{BackupID: "bkp_old", CreatedAt: "2026-07-31T11:00:00Z"}
+	if !remoteBackupIsNewer(remote, baseline) {
+		t.Fatal("newer remote version was not reported")
+	}
+	baseline = &backups.ServiceBaseline{BackupID: "bkp_new", CreatedAt: "2026-07-31T12:00:00Z"}
+	if remoteBackupIsNewer(remote, baseline) {
+		t.Fatal("the known remote version should not be reported as newer")
+	}
+	baseline = &backups.ServiceBaseline{BackupID: "bkp_future", CreatedAt: "2026-07-31T13:00:00Z"}
+	if remoteBackupIsNewer(remote, baseline) {
+		t.Fatal("an older remote version should not be reported as newer")
 	}
 }
 
@@ -236,6 +266,10 @@ func TestFirstRunRemoteRestoreKeepsCredentialsTransient(t *testing.T) {
 	if providerCount != 0 {
 		t.Fatal("first-run credentials were persisted as a provider")
 	}
+	baseline, err := backups.ReadServiceBaseline(context.Background(), server.activeRuntime().database, remote.server.URL, "workspace-restore")
+	if err != nil || baseline == nil || baseline.BackupID != "bkp_restore" {
+		t.Fatalf("restored database did not retain its remote baseline: %#v err=%v", baseline, err)
+	}
 }
 
 func newBackupAPITestFixture(t *testing.T, password string) backupAPITestFixture {
@@ -307,10 +341,11 @@ func newFakeBackupService(t *testing.T) *fakeBackupService {
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/prune"):
 			json.NewEncoder(w).Encode(backups.ServicePruneResult{StreamID: service.item.StreamID, KeepLatest: 1})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/backups/delete"):
+			streamID := service.item.StreamID
 			deletedID := service.item.ID
 			service.item = backups.ServiceBackup{}
 			service.data = nil
-			json.NewEncoder(w).Encode(backups.ServiceDeleteResult{StreamID: "stream-a", DeletedIDs: []string{deletedID}, DeletedCount: 1})
+			json.NewEncoder(w).Encode(backups.ServiceDeleteResult{StreamID: streamID, DeletedIDs: []string{deletedID}, DeletedCount: 1})
 		case r.Method == http.MethodGet && service.item.ID != "" && strings.HasSuffix(r.URL.Path, "/backups/"+service.item.ID):
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.Header().Set("Content-Disposition", `attachment; filename="test-database.aipdb"`)

--- a/backend/internal/api/backup_remote_restore.go
+++ b/backend/internal/api/backup_remote_restore.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -122,7 +123,9 @@ func (s backupHandlers) restoreTransientRemoteBackup(w http.ResponseWriter, r *h
 		writeError(w, http.StatusBadGateway, "remote backup metadata changed while restoring; refresh versions and try again")
 		return
 	}
-	s.installImportedDatabase(w, r, request.DatabaseName, request.DatabasePassword, copyBackupFile(tmpPath))
+	s.installImportedDatabaseWithMutator(w, r, request.DatabaseName, request.DatabasePassword, copyBackupFile(tmpPath), func(database *sql.DB) error {
+		return backups.WriteServiceBaseline(r.Context(), database, request.BaseURL, stream.ID, version)
+	})
 }
 
 func findTransientRemoteBackup(r *http.Request, client *backups.ServiceClient, streamID, backupID string) (backups.ServiceStream, backups.ServiceBackup, error) {

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -95,6 +95,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/backup/remote/restore", backup.restoreTransientRemoteBackup)
 	s.mux.HandleFunc("GET /api/backup/providers/catalog", backup.providerCatalog)
 	s.mux.HandleFunc("GET /api/backup/providers", backup.listProviders)
+	s.mux.HandleFunc("GET /api/backup/freshness", backup.backupFreshness)
 	s.mux.HandleFunc("POST /api/backup/providers", backup.createProvider)
 	s.mux.HandleFunc("PUT /api/backup/providers/{id}", backup.updateProvider)
 	s.mux.HandleFunc("DELETE /api/backup/providers/{id}", backup.deleteProvider)

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -103,6 +103,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/backup/providers/{id}/records", backup.listProviderRecords)
 	s.mux.HandleFunc("POST /api/backup/providers/{id}/upload", backup.uploadProviderBackup)
 	s.mux.HandleFunc("POST /api/backup/providers/{id}/prune", backup.pruneProviderBackups)
+	s.mux.HandleFunc("POST /api/backup/providers/{id}/records/delete", backup.deleteProviderBackupRecords)
 	s.mux.HandleFunc("GET /api/backup/providers/{id}/records/{record_id}/download", backup.downloadProviderRecord)
 	s.mux.HandleFunc("POST /api/backup/providers/{id}/records/{record_id}/restore", backup.restoreProviderRecord)
 	s.mux.HandleFunc("POST /api/databases/rename", databases.renameDatabase)

--- a/backend/internal/backups/baseline.go
+++ b/backend/internal/backups/baseline.go
@@ -1,0 +1,88 @@
+package backups
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const serviceBaselineSettingPrefix = "backup_service_baseline_"
+
+type ServiceBaseline struct {
+	BackupID  string `json:"backup_id"`
+	CreatedAt string `json:"created_at"`
+}
+
+func ReadServiceBaseline(ctx context.Context, db *sql.DB, baseURL, streamID string) (*ServiceBaseline, error) {
+	key, err := serviceBaselineKey(baseURL, streamID)
+	if err != nil {
+		return nil, err
+	}
+	var raw string
+	if err := db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&raw); errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("read backup service baseline: %w", err)
+	}
+	var baseline ServiceBaseline
+	if err := json.Unmarshal([]byte(raw), &baseline); err != nil {
+		return nil, fmt.Errorf("decode backup service baseline: %w", err)
+	}
+	if err := validateServiceBaseline(baseline); err != nil {
+		return nil, err
+	}
+	return &baseline, nil
+}
+
+func WriteServiceBaseline(ctx context.Context, db *sql.DB, baseURL, streamID string, backup ServiceBackup) error {
+	key, err := serviceBaselineKey(baseURL, streamID)
+	if err != nil {
+		return err
+	}
+	baseline := ServiceBaseline{BackupID: strings.TrimSpace(backup.ID), CreatedAt: strings.TrimSpace(backup.CreatedAt)}
+	if err := validateServiceBaseline(baseline); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(baseline)
+	if err != nil {
+		return fmt.Errorf("encode backup service baseline: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := db.ExecContext(ctx, `
+INSERT INTO settings(key, value, updated_at)
+VALUES(?, ?, ?)
+ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`, key, string(raw), now); err != nil {
+		return fmt.Errorf("write backup service baseline: %w", err)
+	}
+	return nil
+}
+
+func serviceBaselineKey(baseURL, streamID string) (string, error) {
+	normalizedURL, err := ValidateServiceURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+	streamID = strings.TrimSpace(streamID)
+	if !validServiceIdentifier(streamID) {
+		return "", ValidationError("backup stream id is invalid")
+	}
+	digest := sha256.Sum256([]byte(normalizedURL + "\x00" + streamID))
+	return serviceBaselineSettingPrefix + hex.EncodeToString(digest[:16]), nil
+}
+
+func validateServiceBaseline(baseline ServiceBaseline) error {
+	if !validServiceIdentifier(strings.TrimSpace(baseline.BackupID)) {
+		return errors.New("backup service baseline contains an invalid version id")
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(baseline.CreatedAt))
+	if err != nil || createdAt.IsZero() {
+		return errors.New("backup service baseline contains an invalid creation time")
+	}
+	return nil
+}

--- a/backend/internal/backups/baseline_test.go
+++ b/backend/internal/backups/baseline_test.go
@@ -1,0 +1,25 @@
+package backups_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aipermission/aipermission/backend/internal/backups"
+)
+
+func TestServiceBaselineIsScopedByServiceAndStream(t *testing.T) {
+	database := openStoreDatabase(t)
+	ctx := context.Background()
+	backup := backups.ServiceBackup{ID: "bkp_123", CreatedAt: "2026-07-31T12:00:00Z"}
+	if err := backups.WriteServiceBaseline(ctx, database, "https://backup.example.com", "stream-a", backup); err != nil {
+		t.Fatal(err)
+	}
+	baseline, err := backups.ReadServiceBaseline(ctx, database, "https://backup.example.com/", "stream-a")
+	if err != nil || baseline == nil || baseline.BackupID != backup.ID || baseline.CreatedAt != backup.CreatedAt {
+		t.Fatalf("unexpected baseline: %#v err=%v", baseline, err)
+	}
+	other, err := backups.ReadServiceBaseline(ctx, database, "https://backup.example.com", "stream-b")
+	if err != nil || other != nil {
+		t.Fatalf("baseline leaked across streams: %#v err=%v", other, err)
+	}
+}

--- a/backend/internal/backups/service_client.go
+++ b/backend/internal/backups/service_client.go
@@ -66,6 +66,12 @@ type ServicePruneResult struct {
 	DeletedCount int    `json:"deleted_count"`
 }
 
+type ServiceDeleteResult struct {
+	StreamID     string   `json:"stream_id"`
+	DeletedIDs   []string `json:"deleted_ids"`
+	DeletedCount int      `json:"deleted_count"`
+}
+
 type servicePage[T any] struct {
 	Items      []T    `json:"items"`
 	NextCursor string `json:"next_cursor"`
@@ -186,6 +192,43 @@ func (c *ServiceClient) PruneBackups(ctx context.Context, streamID string, keepL
 	}
 	if response.StreamID != streamID || response.KeepLatest != keepLatest || response.DeletedCount < 0 {
 		return ServicePruneResult{}, errors.New("backup service returned invalid prune metadata")
+	}
+	return response, nil
+}
+
+func (c *ServiceClient) DeleteBackups(ctx context.Context, streamID string, backupIDs []string) (ServiceDeleteResult, error) {
+	if !validServiceIdentifier(streamID) || len(backupIDs) < 1 || len(backupIDs) > 100 {
+		return ServiceDeleteResult{}, ValidationError("backup stream id or selected version ids are invalid")
+	}
+	seen := make(map[string]struct{}, len(backupIDs))
+	for _, id := range backupIDs {
+		if !validServiceIdentifier(id) {
+			return ServiceDeleteResult{}, ValidationError("selected backup version id is invalid")
+		}
+		if _, exists := seen[id]; exists {
+			return ServiceDeleteResult{}, ValidationError("selected backup version ids must be unique")
+		}
+		seen[id] = struct{}{}
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	var response ServiceDeleteResult
+	payload := map[string][]string{"backup_ids": backupIDs}
+	if err := c.doJSON(requestCtx, http.MethodPost, "/v1/streams/"+url.PathEscape(streamID)+"/backups/delete", payload, true, &response); err != nil {
+		return ServiceDeleteResult{}, err
+	}
+	if response.StreamID != streamID || response.DeletedCount != len(backupIDs) || len(response.DeletedIDs) != len(backupIDs) {
+		return ServiceDeleteResult{}, errors.New("backup service returned invalid deletion metadata")
+	}
+	deleted := make(map[string]struct{}, len(response.DeletedIDs))
+	for _, id := range response.DeletedIDs {
+		if _, expected := seen[id]; !expected {
+			return ServiceDeleteResult{}, errors.New("backup service returned an unexpected deleted version id")
+		}
+		deleted[id] = struct{}{}
+	}
+	if len(deleted) != len(seen) {
+		return ServiceDeleteResult{}, errors.New("backup service returned duplicate deleted version ids")
 	}
 	return response, nil
 }

--- a/backend/internal/backups/service_client_test.go
+++ b/backend/internal/backups/service_client_test.go
@@ -79,6 +79,8 @@ func TestServiceClientLifecycleAndRedirectRejection(t *testing.T) {
 			w.Write(payload)
 		case r.URL.Path == "/v1/streams/stream-a/prune" && r.Method == http.MethodPost:
 			json.NewEncoder(w).Encode(ServicePruneResult{StreamID: "stream-a", KeepLatest: 2, DeletedCount: 3})
+		case r.URL.Path == "/v1/streams/stream-a/backups/delete" && r.Method == http.MethodPost:
+			json.NewEncoder(w).Encode(ServiceDeleteResult{StreamID: "stream-a", DeletedIDs: []string{"bkp_123"}, DeletedCount: 1})
 		case r.URL.Path == "/redirect":
 			http.Redirect(w, r, serverURLForRedirect(r), http.StatusFound)
 		default:
@@ -108,6 +110,10 @@ func TestServiceClientLifecycleAndRedirectRejection(t *testing.T) {
 	pruned, err := client.PruneBackups(context.Background(), "stream-a", 2)
 	if err != nil || pruned.DeletedCount != 3 {
 		t.Fatalf("prune: item=%#v err=%v", pruned, err)
+	}
+	deleted, err := client.DeleteBackups(context.Background(), "stream-a", []string{"bkp_123"})
+	if err != nil || deleted.DeletedCount != 1 {
+		t.Fatalf("delete: item=%#v err=%v", deleted, err)
 	}
 	output := filepath.Join(t.TempDir(), "output.aipdb")
 	downloaded, err := client.Download(context.Background(), "stream-a", "bkp_123", output, 1024)

--- a/backend/internal/backups/store.go
+++ b/backend/internal/backups/store.go
@@ -520,6 +520,43 @@ func (s *Store) MarkMissingProviderRecordsDeleted(ctx context.Context, providerI
 	return nil
 }
 
+func (s *Store) MarkProviderRecordsDeleted(ctx context.Context, providerID int64, providerFileIDs []string) error {
+	if providerID < 1 || len(providerFileIDs) < 1 || len(providerFileIDs) > 100 {
+		return ValidationError("provider_id and 1 to 100 provider_file_ids are required")
+	}
+	seen := make(map[string]struct{}, len(providerFileIDs))
+	normalizedIDs := make([]string, 0, len(providerFileIDs))
+	for _, id := range providerFileIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return ValidationError("provider_file_id is required")
+		}
+		if _, exists := seen[id]; exists {
+			return ValidationError("provider_file_ids must be unique")
+		}
+		seen[id] = struct{}{}
+		normalizedIDs = append(normalizedIDs, id)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin provider record deletion: %w", err)
+	}
+	defer tx.Rollback()
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, id := range normalizedIDs {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE backup_records
+			SET deleted_at = ?, updated_at = ?
+			WHERE provider_id = ? AND provider_file_id = ? AND deleted_at IS NULL`, now, now, providerID, id); err != nil {
+			return fmt.Errorf("mark provider record deleted: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit provider record deletion: %w", err)
+	}
+	return nil
+}
+
 func SupportedProviderType(providerType string) bool {
 	switch normalizeProviderType(providerType) {
 	case ServiceProviderType:

--- a/backend/internal/backups/store_test.go
+++ b/backend/internal/backups/store_test.go
@@ -123,6 +123,38 @@ func TestMarkMissingProviderRecordsDeletedReconcilesRemotePrune(t *testing.T) {
 	}
 }
 
+func TestMarkProviderRecordsDeletedMarksExactVersions(t *testing.T) {
+	database := openStoreDatabase(t)
+	store := backups.NewStore(database)
+	provider, err := store.CreateProvider(context.Background(), backups.CreateProviderRequest{
+		ProviderType: backups.ServiceProviderType,
+		Name:         "Self-hosted backups",
+		Encrypted:    "encrypted-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"bkp_keep", "bkp_remove_a", "bkp_remove_b"} {
+		if _, err := store.UpsertRecord(context.Background(), backups.CreateRecordRequest{
+			ProviderID: provider.ID, DatabaseID: "database-a", DatabaseName: "Database A",
+			ProviderFileID: id, Filename: id + ".aipdb", SizeBytes: 100,
+			BackupCreatedAt: "2026-07-31T10:00:00Z", UploadedAt: "2026-07-31T10:00:00Z",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.MarkProviderRecordsDeleted(context.Background(), provider.ID, []string{"bkp_remove_a", "bkp_remove_b"}); err != nil {
+		t.Fatal(err)
+	}
+	records, err := store.ListRecords(context.Background(), backups.ListRecordsFilter{ProviderID: provider.ID})
+	if err != nil || len(records) != 1 || records[0].ProviderFileID != "bkp_keep" {
+		t.Fatalf("unexpected retained records: %#v err=%v", records, err)
+	}
+	if err := store.MarkProviderRecordsDeleted(context.Background(), provider.ID, []string{"duplicate", "duplicate"}); err == nil {
+		t.Fatal("duplicate provider file ids were accepted")
+	}
+}
+
 func openStoreDatabase(t *testing.T) *sql.DB {
 	t.Helper()
 	database, err := dbpkg.OpenEncrypted(filepath.Join(t.TempDir(), "store.aipdb"), "StrongDatabasePassword123")

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -914,9 +914,11 @@ PUT  /api/backup/providers/{id}
 DELETE /api/backup/providers/{id}
 POST /api/backup/providers/{id}/enable
 POST /api/backup/providers/{id}/test
+GET  /api/backup/freshness
 GET  /api/backup/providers/{id}/records
 POST /api/backup/providers/{id}/upload
 POST /api/backup/providers/{id}/prune
+POST /api/backup/providers/{id}/records/delete
 GET  /api/backup/providers/{id}/records/{record_id}/download
 POST /api/backup/providers/{id}/records/{record_id}/restore
 ```
@@ -965,6 +967,13 @@ bounded value from 1 to 1000. It permanently removes only older versions from
 the provider's current database stream, reconciles local backup metadata, and
 writes an audit event with the retention count and number deleted.
 
+`GET /api/backup/freshness` checks active self-hosted backup providers once and
+returns remote streams whose latest immutable version is newer than the version
+last uploaded or restored by the open local database. Remote metadata sync does
+not advance this encrypted local baseline. Provider check failures are isolated
+in `check_errors` so one unavailable backup service does not hide warnings from
+other providers.
+
 `GET /api/backup/providers/{id}/records/{record_id}/download` downloads a
 previously uploaded encrypted `.aipdb` backup record from the provider after
 checking the stored size and checksum metadata.
@@ -972,8 +981,9 @@ checking the stored size and checksum metadata.
 `POST /api/backup/providers/{id}/records/{record_id}/restore` downloads the
 remote encrypted `.aipdb`, verifies the size/checksum metadata, validates the
 provided database password, and imports it under the requested new local
-database name. Restore
-never overwrites the currently open database.
+database name. Restore records the selected immutable remote version inside the
+restored encrypted database so later unlocks can detect newer remote backups.
+Restore never overwrites the currently open database.
 
 `POST /api/backup/remote/list` and `POST /api/backup/remote/restore` are also
 available before a local database has been created or unlocked. They accept the

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -967,6 +967,12 @@ bounded value from 1 to 1000. It permanently removes only older versions from
 the provider's current database stream, reconciles local backup metadata, and
 writes an audit event with the retention count and number deleted.
 
+`POST /api/backup/providers/{id}/records/delete` accepts 1 to 100 unique local
+backup record ids. AIPermission resolves them to immutable remote version ids,
+verifies that every record belongs to the provider's current stream, and asks
+the backup service to delete that exact set. The service refuses to delete the
+final recovery version in a stream.
+
 `GET /api/backup/freshness` checks active self-hosted backup providers once and
 returns remote streams whose latest immutable version is newer than the version
 last uploaded or restored by the open local database. Remote metadata sync does

--- a/docs/providers/aipermission-backup.md
+++ b/docs/providers/aipermission-backup.md
@@ -74,9 +74,12 @@ service. A provider can be disabled later without deleting its remote files.
 unchanged. Every remote version is immutable. **Backups** lists versions stored
 for the current database stream and lets the user download an encrypted file,
 restore it under an editable local database name, or explicitly prune versions
-older than the newest retained count. Restore re-lists the selected version,
-checks size and SHA-256 metadata, validates the SQLCipher password and schema,
-and never overwrites the currently open database.
+older than the newest retained count. Individual rows and checkbox selections
+can also delete exact historical versions. The service refuses any prune or
+delete operation that would remove the final recovery version in a stream.
+Restore re-lists the selected version, checks size and SHA-256 metadata,
+validates the SQLCipher password and schema, and never overwrites the currently
+open database.
 
 On a new machine with no local database:
 
@@ -84,7 +87,9 @@ On a new machine with no local database:
 2. Select **Restore Remote**.
 3. Enter the service URL and token.
 4. Select the database stream and immutable backup version. Streams with the
-   same display name remain distinguishable by their shortened stream id.
+   same display name remain distinguishable by their shortened stream id;
+   versions are grouped by source installation and show relative and exact
+   timestamps.
 5. Choose the new local database name.
 6. Enter that backup's database password and restore it.
 
@@ -101,13 +106,18 @@ machine should create future backups.
   storage operator has not replaced both a blob and its metadata.
 - Upload, download, and restore are explicit local user actions. There is no
   background sync in this release.
+- After unlock, AIPermission checks active providers once. If the latest remote
+  version is newer than the version last uploaded or restored by this encrypted
+  local database, the UI displays a stale-local-copy warning. Listing remote
+  metadata never advances that baseline.
 - Each database stores a stable random workspace UUID inside its encrypted
   database. That UUID is the remote stream identity, so unrelated databases
   named `Default` do not share versions. Restoring a backup preserves its UUID
   because it remains the same logical database lineage.
 - Prune is an explicit destructive action scoped to one stream. It always keeps
   at least the newest version and requires confirmation in the local UI.
+- Selected-version cleanup is also explicit, stream-scoped, limited to 100
+  unique versions per request, and confirmed in the local UI. Deleting the
+  final remaining version is rejected.
 - The service token grants access to encrypted backup blobs. Keep it outside
   source control and rotate it if exposed.
-- Individual version deletion and newer-remote-version warnings remain
-  follow-up work after the immutable MVP has been dogfooded.

--- a/frontend/src/components/app-shell.jsx
+++ b/frontend/src/components/app-shell.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Outlet, useLocation } from "react-router";
+import { Link, Outlet, useLocation } from "react-router";
 import { apiGet, apiPost, apiPut, apiUrl } from "../lib/api";
 import { AppSidebar } from "./app-sidebar";
 import { DatabaseSwitchDialog } from "./database-switch-dialog";
@@ -12,6 +12,7 @@ import { VaultActionApprovalDialog } from "./vault/vault-action-approval-dialog"
 import { supportedConnectorKinds } from "../connectors/templates/catalog";
 import { getConnectorModel } from "../connectors/templates/registry";
 import { reconcileVaultApprovalDialog } from "../lib/vault-approval-poll";
+import { formatRelativeAge } from "../lib/date-time";
 export function Shell({ theme, setTheme }) {
   const location = useLocation();
   function toggleTheme() {
@@ -28,6 +29,7 @@ export function Shell({ theme, setTheme }) {
   const [fileTransferBatches, setFileTransferBatches] = useState({ state: "loading", data: [], error: null });
   const [databaseStatus, setDatabaseStatus] = useState({ state: "loading", data: null, error: null });
   const [mcpRuntime, setMCPRuntime] = useState({ state: "loading", data: { enabled: false, start_enabled: false }, error: null });
+  const [backupFreshness, setBackupFreshness] = useState({ state: "loading", data: [], checkErrors: [], error: null });
   const [switchDialog, setSwitchDialog] = useState({ open: false, database_id: "", password: "", state: "idle", error: null });
   const [lockDialog, setLockDialog] = useState({ open: false, state: "idle", error: null });
   const [transferCenterOpen, setTransferCenterOpen] = useState(false);
@@ -148,6 +150,15 @@ export function Shell({ theme, setTheme }) {
     }
   }
 
+  async function loadBackupFreshness() {
+    try {
+      const data = await apiGet("/api/backup/freshness");
+      setBackupFreshness({ state: "ready", data: data?.items || [], checkErrors: data?.check_errors || [], error: null });
+    } catch (error) {
+      setBackupFreshness({ state: "error", data: [], checkErrors: [], error: error.message });
+    }
+  }
+
   async function loadFileTransferBatches(options = {}) {
     try {
       const data = await apiGet("/api/file-transfer-batches?limit=30");
@@ -193,6 +204,10 @@ export function Shell({ theme, setTheme }) {
       clearInterval(timer);
     };
   }, [location.pathname]);
+
+  useEffect(() => {
+    void loadBackupFreshness();
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -650,6 +665,40 @@ export function Shell({ theme, setTheme }) {
 
       <section className="lg:pl-72">
         <div className={`mx-auto grid gap-6 p-5 ${location.pathname === "/console" ? "max-w-none" : "max-w-7xl"}`}>
+          {backupFreshness.data.length > 0 ? (
+            <Notice tone="warn" className="flex flex-wrap items-center justify-between gap-3">
+              <span>
+                A newer encrypted backup is available
+                {backupFreshness.data.length === 1
+                  ? ` from ${formatRelativeAge(backupFreshness.data[0].latest_remote_at)}`
+                  : ` in ${backupFreshness.data.length} providers`}
+                . This local database may be stale.
+              </span>
+              <span className="flex items-center gap-3">
+                <Link className="font-semibold underline underline-offset-2" to="/settings">Review backups</Link>
+                <button type="button" className="font-semibold text-stone-600 hover:text-stone-950" onClick={() => setBackupFreshness((current) => ({ ...current, data: [] }))}>
+                  Dismiss
+                </button>
+              </span>
+            </Notice>
+          ) : null}
+          {backupFreshness.checkErrors.length > 0 || backupFreshness.error ? (
+            <Notice tone="warn" className="flex flex-wrap items-center justify-between gap-3">
+              <span>
+                Backup freshness could not be checked
+                {backupFreshness.checkErrors.length > 0
+                  ? ` for ${backupFreshness.checkErrors.length} provider${backupFreshness.checkErrors.length === 1 ? "" : "s"}`
+                  : ""}
+                . Review the provider connection before relying on the local copy.
+              </span>
+              <span className="flex items-center gap-3">
+                <Link className="font-semibold underline underline-offset-2" to="/settings">Review backups</Link>
+                <button type="button" className="font-semibold text-stone-600 hover:text-stone-950" onClick={() => setBackupFreshness((current) => ({ ...current, checkErrors: [], error: null }))}>
+                  Dismiss
+                </button>
+              </span>
+            </Notice>
+          ) : null}
           <Outlet
             context={{
               status,

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -517,6 +517,9 @@ test("Settings and unlock expose the self-hosted encrypted backup flow", () => {
   assert.match(unlockSource, /\/api\/backup\/remote\/list/);
   assert.match(unlockSource, /\/api\/backup\/remote\/restore/);
   assert.match(unlockSource, /not saved in browser storage/i);
+  assert.match(shellSource, /\/api\/backup\/freshness/);
+  assert.match(shellSource, /A newer encrypted backup is available/);
+  assert.match(shellSource, /Backup freshness could not be checked/);
 });
 
 test("Unlock page shows the current app version", () => {

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -517,6 +517,9 @@ test("Settings and unlock expose the self-hosted encrypted backup flow", () => {
   assert.match(unlockSource, /\/api\/backup\/remote\/list/);
   assert.match(unlockSource, /\/api\/backup\/remote\/restore/);
   assert.match(unlockSource, /not saved in browser storage/i);
+  assert.match(unlockSource, /<optgroup/);
+  assert.match(unlockSource, /formatLocalTimestamp/);
+  assert.match(unlockSource, /Source:/);
   assert.match(shellSource, /\/api\/backup\/freshness/);
   assert.match(shellSource, /A newer encrypted backup is available/);
   assert.match(shellSource, /Backup freshness could not be checked/);

--- a/frontend/src/lib/app.smoke.test.js
+++ b/frontend/src/lib/app.smoke.test.js
@@ -299,7 +299,8 @@ test("App applies the persisted theme before unlock and exposes bundled changelo
   assert.match(sidebarSource, /max-h-\[calc\(100vh-180px\)\] overflow-y-auto/);
   assert.match(shellSource, /data\?\.state === "unlocked"/);
   assert.match(shellSource, /document\.title = `\$\{runtimeLabel\} - \$\{databaseName\}`/);
-  assert.match(releaseSource, /appVersion = "0\.2\.20"/);
+  assert.match(releaseSource, /appVersion = "0\.2\.21"/);
+  assert.match(releaseSource, /Backup recovery cleanup/);
   assert.match(releaseSource, /Self-hosted encrypted backups/);
   assert.match(releaseSource, /Guarded Kafka writes/);
   assert.match(releaseSource, /Kafka \/ Redpanda read browser/);

--- a/frontend/src/lib/release.js
+++ b/frontend/src/lib/release.js
@@ -1,6 +1,26 @@
-export const appVersion = "0.2.20";
+export const appVersion = "0.2.21";
 
 export const changelogEntries = [
+  {
+    version: "0.2.21",
+    label: "Backup recovery cleanup",
+    sections: [
+      {
+        title: "Added",
+        items: [
+          "Remote backup versions can be deleted individually or as an explicit selection, while the final recovery version remains protected.",
+          "Unlock now warns when the configured backup service contains a recovery version newer than the last locally reviewed upload or restore.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Restore versions are grouped by source installation and show relative plus exact timestamps for clearer recovery choices.",
+          "Remote freshness failures are visible instead of being mistaken for an up-to-date backup state.",
+        ],
+      },
+    ],
+  },
   {
     version: "0.2.20",
     label: "Self-hosted encrypted backups",

--- a/frontend/src/pages/settings.jsx
+++ b/frontend/src/pages/settings.jsx
@@ -6,7 +6,7 @@ import { Button } from "../components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
 import { CopyButton } from "../components/ui/copy-button";
 import { Dialog } from "../components/ui/dialog";
-import { Field, Input, Select } from "../components/ui/form";
+import { Checkbox, Field, Input, Select } from "../components/ui/form";
 import { Notice } from "../components/ui/notice";
 import { isValidDatabasePassword } from "../lib/password";
 import { formatRelativeAge } from "../lib/date-time";
@@ -56,6 +56,8 @@ export function SettingsPage() {
   const [backupRecords, setBackupRecords] = useState({ state: "idle", data: [], error: null });
   const [backupPruneTarget, setBackupPruneTarget] = useState(null);
   const [backupPruneKeepLatest, setBackupPruneKeepLatest] = useState("10");
+  const [selectedBackupRecordIDs, setSelectedBackupRecordIDs] = useState([]);
+  const [backupDeleteRecords, setBackupDeleteRecords] = useState([]);
   const [restoreRecordTarget, setRestoreRecordTarget] = useState(null);
   const [restoreRecordForm, setRestoreRecordForm] = useState({ database_name: "", database_password: "" });
   const [backupProviderForm, setBackupProviderForm] = useState({
@@ -130,6 +132,7 @@ export function SettingsPage() {
   const newPasswordValid = isValidDatabasePassword(passwordForm.new_password);
   const selectedLabel = labels.data.find((label) => String(label.id) === String(selectedLabelID));
   const parsedBackupPruneKeepLatest = parseBackupKeepLatest(backupPruneKeepLatest);
+  const selectedBackupRecords = backupRecords.data.filter((record) => selectedBackupRecordIDs.includes(record.id));
 
   async function downloadDatabase() {
     await runBackupAction({
@@ -288,6 +291,7 @@ export function SettingsPage() {
 
   async function openBackupRecordsDialog(provider) {
     setBackupRecordsProvider(provider);
+    setSelectedBackupRecordIDs([]);
     setBackupRecords({ state: "loading", data: [], error: null });
     try {
       const data = await apiGet(`/api/backup/providers/${provider.id}/records`);
@@ -298,8 +302,10 @@ export function SettingsPage() {
   }
 
   function closeBackupRecordsDialog() {
-    if (backupProviderState.state?.startsWith("restoring-") || backupProviderState.state === "pruning") return;
+    if (backupProviderState.state?.startsWith("restoring-") || backupProviderState.state === "pruning" || backupProviderState.state === "deleting-records") return;
     setBackupPruneTarget(null);
+    setBackupDeleteRecords([]);
+    setSelectedBackupRecordIDs([]);
     setBackupRecordsProvider(null);
     setBackupRecords({ state: "idle", data: [], error: null });
   }
@@ -307,6 +313,48 @@ export function SettingsPage() {
   async function refreshBackupRecords() {
     if (!backupRecordsProvider) return;
     await openBackupRecordsDialog(backupRecordsProvider);
+  }
+
+  function toggleBackupRecordSelection(recordID) {
+    setSelectedBackupRecordIDs((current) => {
+      if (current.includes(recordID)) return current.filter((id) => id !== recordID);
+      if (current.length >= Math.max(0, backupRecords.data.length - 1)) return current;
+      return [...current, recordID];
+    });
+  }
+
+  function selectOlderBackupRecords() {
+    setSelectedBackupRecordIDs(backupRecords.data.slice(1, 101).map((record) => record.id));
+  }
+
+  function requestDeleteBackupRecords(records) {
+    if (!records.length || records.length >= backupRecords.data.length) return;
+    setBackupDeleteRecords(records);
+  }
+
+  function closeDeleteBackupRecordsDialog() {
+    if (backupProviderState.state === "deleting-records") return;
+    setBackupDeleteRecords([]);
+  }
+
+  async function deleteBackupRecords(event) {
+    event.preventDefault();
+    if (!backupRecordsProvider || !backupDeleteRecords.length) return;
+    const provider = backupRecordsProvider;
+    const result = await runBackupProviderAction({
+      pending: "deleting-records",
+      successMessage: (response) =>
+        `Deleted ${response.deleted_count} backup version${response.deleted_count === 1 ? "" : "s"}.`,
+      action: () =>
+        apiPost(`/api/backup/providers/${provider.id}/records/delete`, {
+          record_ids: backupDeleteRecords.map((record) => record.id),
+        }),
+    });
+    if (result !== undefined) {
+      setBackupDeleteRecords([]);
+      setSelectedBackupRecordIDs([]);
+      await openBackupRecordsDialog(provider);
+    }
   }
 
   function requestPruneBackupRecords() {
@@ -1116,7 +1164,7 @@ export function SettingsPage() {
         title="Remote backup records"
         description={backupRecordsProvider ? `Backups uploaded through ${backupRecordsProvider.name}.` : "Remote backup records."}
         onClose={closeBackupRecordsDialog}
-        closeDisabled={backupProviderState.state?.startsWith("restoring-") || backupProviderState.state === "pruning"}
+        closeDisabled={backupProviderState.state?.startsWith("restoring-") || backupProviderState.state === "pruning" || backupProviderState.state === "deleting-records"}
         closeOnOverlay={false}
         size="wide"
         className="!max-w-4xl"
@@ -1130,6 +1178,22 @@ export function SettingsPage() {
               {backupRecords.state === "ready" ? `${backupRecords.data.length} backup${backupRecords.data.length === 1 ? "" : "s"}` : "Loading backups..."}
             </p>
             <div className="flex items-center gap-2">
+              {selectedBackupRecordIDs.length > 0 ? (
+                <Button
+                  type="button"
+                  variant="danger"
+                  className="h-9 px-3 text-xs"
+                  onClick={() => requestDeleteBackupRecords(selectedBackupRecords)}
+                  disabled={backupProviderState.state === "deleting-records"}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Delete selected ({selectedBackupRecordIDs.length})
+                </Button>
+              ) : backupRecords.data.length > 1 ? (
+                <Button type="button" variant="outline" className="h-9 px-3 text-xs" onClick={selectOlderBackupRecords}>
+                  Select older
+                </Button>
+              ) : null}
               <Button
                 type="button"
                 variant="outline"
@@ -1158,14 +1222,27 @@ export function SettingsPage() {
               <div className="divide-y divide-stone-200">
                 {backupRecords.data.map((record) => (
                   <div key={record.id} className="grid gap-3 p-3 md:grid-cols-[minmax(0,1fr)_auto]">
-                    <div className="min-w-0">
+                    <div className="flex min-w-0 items-start gap-3">
+                      <Checkbox
+                        checked={selectedBackupRecordIDs.includes(record.id)}
+                        onChange={() => toggleBackupRecordSelection(record.id)}
+                        disabled={
+                          backupRecords.data.length <= 1 ||
+                          (!selectedBackupRecordIDs.includes(record.id) && selectedBackupRecordIDs.length >= backupRecords.data.length - 1)
+                        }
+                        aria-label={`Select ${record.filename}`}
+                        className="mt-1 shrink-0"
+                      />
+                      <div className="min-w-0">
                       <p className="truncate text-sm font-semibold text-stone-950">{record.filename}</p>
                       <p className="mt-1 text-xs text-stone-500">
-                        {formatBytes(record.size_bytes)} · uploaded {formatTimestamp(record.uploaded_at)} · from {record.source_machine || "unknown machine"}
+                        {formatBytes(record.size_bytes)} · {formatRelativeAge(record.backup_created_at || record.uploaded_at)} · from {record.source_machine || "unknown machine"}
                       </p>
+                      <p className="mt-1 text-[11px] text-stone-400">{formatTimestamp(record.backup_created_at || record.uploaded_at)}</p>
                       <p className="mt-1 truncate font-mono text-[11px] text-stone-400">{record.checksum_sha256 || "no checksum"}</p>
+                      </div>
                     </div>
-                    <div className="grid grid-cols-2 gap-2 md:w-64">
+                    <div className="grid grid-cols-[1fr_1fr_auto] gap-2 md:w-72">
                       <Button
                         type="button"
                         variant="outline"
@@ -1186,6 +1263,16 @@ export function SettingsPage() {
                         <RotateCcw className="h-4 w-4 shrink-0" />
                         Restore
                       </Button>
+                      <Button
+                        type="button"
+                        variant="danger"
+                        className="h-9 w-9 px-0"
+                        onClick={() => requestDeleteBackupRecords([record])}
+                        disabled={backupRecords.data.length <= 1 || backupProviderState.state === "deleting-records"}
+                        title={backupRecords.data.length <= 1 ? "The last recovery version must remain" : "Delete backup version"}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                     </div>
                   </div>
                 ))}
@@ -1193,6 +1280,48 @@ export function SettingsPage() {
             )}
           </div>
         </div>
+      </Dialog>
+
+      <Dialog
+        open={backupDeleteRecords.length > 0}
+        title={backupDeleteRecords.length === 1 ? "Delete backup version" : "Delete selected backup versions"}
+        description={
+          backupDeleteRecords.length === 1
+            ? "Permanently remove this encrypted remote version."
+            : `Permanently remove ${backupDeleteRecords.length} encrypted remote versions.`
+        }
+        onClose={closeDeleteBackupRecordsDialog}
+        closeDisabled={backupProviderState.state === "deleting-records"}
+        closeOnOverlay={false}
+        size="md"
+      >
+        <form className="grid gap-4" onSubmit={deleteBackupRecords}>
+          <Notice tone="warn">
+            This cannot be undone. AIPermission Backup will remove the selected immutable files and metadata. At least one recovery version always remains.
+          </Notice>
+          <div className="max-h-48 overflow-auto rounded-md border border-stone-200 bg-stone-50">
+            <div className="divide-y divide-stone-200">
+              {backupDeleteRecords.map((record) => (
+                <div key={record.id} className="px-3 py-2">
+                  <p className="truncate text-sm font-semibold text-stone-950">{record.filename}</p>
+                  <p className="mt-0.5 text-xs text-stone-500">
+                    {formatRelativeAge(record.backup_created_at || record.uploaded_at)} · {record.source_machine || "unknown machine"}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+          {backupProviderState.state === "error" ? <Notice tone="bad">{backupProviderState.error}</Notice> : null}
+          <div className="grid gap-2 sm:grid-cols-2">
+            <Button type="button" variant="outline" onClick={closeDeleteBackupRecordsDialog} disabled={backupProviderState.state === "deleting-records"}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="danger" disabled={backupProviderState.state === "deleting-records" || backupDeleteRecords.length === 0}>
+              <Trash2 className="h-4 w-4" />
+              {backupProviderState.state === "deleting-records" ? "Deleting..." : "Delete permanently"}
+            </Button>
+          </div>
+        </form>
       </Dialog>
 
       <Dialog

--- a/frontend/src/pages/unlock.jsx
+++ b/frontend/src/pages/unlock.jsx
@@ -7,7 +7,7 @@ import { Input } from "../components/ui/form";
 import { Notice } from "../components/ui/notice";
 import { isValidDatabasePassword } from "../lib/password";
 import { appVersion } from "../lib/release";
-import { formatRelativeAge } from "../lib/date-time";
+import { formatLocalTimestamp, formatRelativeAge } from "../lib/date-time";
 import { formatBytes } from "../lib/file-transfer-utils";
 
 export function UnlockPage({ status, onUnlocked }) {
@@ -498,6 +498,8 @@ function RemoteRestorePanel({ onUnlocked }) {
   }
 
   const selectedStream = streams.find((stream) => stream.id === selectedStreamID);
+  const selectedVersion = versions.find((version) => version.id === selectedBackupID);
+  const versionGroups = groupBackupVersions(versions);
 
   return (
     <div className="grid gap-4">
@@ -564,14 +566,26 @@ function RemoteRestorePanel({ onUnlocked }) {
                 disabled={state.state === "loading_versions" || state.state === "restoring" || versions.length === 0}
               >
                 {versions.length === 0 ? <option value="">No backups available</option> : null}
-                {versions.map((version) => (
-                  <option key={version.id} value={version.id}>
-                    {formatRelativeAge(version.created_at)} · {formatBytes(version.size_bytes)}
-                  </option>
+                {versionGroups.map((group) => (
+                  <optgroup key={group.source} label={`Source ${shortBackupSourceID(group.source)}`}>
+                    {group.items.map((version) => (
+                      <option key={version.id} value={version.id}>
+                        {formatRelativeAge(version.created_at)} · {formatLocalTimestamp(version.created_at)} · {formatBytes(version.size_bytes)}
+                      </option>
+                    ))}
+                  </optgroup>
                 ))}
               </select>
             </label>
           </div>
+          {selectedVersion ? (
+            <div className="grid gap-1 rounded-md border border-stone-200 bg-stone-50 px-3 py-2 text-xs text-stone-600 sm:grid-cols-2">
+              <span className="truncate"><strong className="text-stone-900">File:</strong> {selectedVersion.filename}</span>
+              <span><strong className="text-stone-900">Created:</strong> {formatLocalTimestamp(selectedVersion.created_at)}</span>
+              <span className="truncate"><strong className="text-stone-900">Source:</strong> {shortBackupSourceID(selectedVersion.source_installation_id)}</span>
+              <span><strong className="text-stone-900">Size:</strong> {formatBytes(selectedVersion.size_bytes)}</span>
+            </div>
+          ) : null}
           {selectedStream ? (
             <div className="grid gap-2">
               <label className="text-sm font-semibold text-stone-800">New local database name</label>
@@ -610,6 +624,21 @@ function RemoteRestorePanel({ onUnlocked }) {
 function shortBackupStreamID(value) {
   const text = String(value || "");
   return text.length > 12 ? `${text.slice(0, 8)}...${text.slice(-4)}` : text;
+}
+
+function shortBackupSourceID(value) {
+  const text = String(value || "unknown installation");
+  return text.length > 18 ? `${text.slice(0, 10)}...${text.slice(-6)}` : text;
+}
+
+function groupBackupVersions(versions) {
+  const groups = new Map();
+  for (const version of versions) {
+    const source = version.source_installation_id || "unknown installation";
+    if (!groups.has(source)) groups.set(source, []);
+    groups.get(source).push(version);
+  }
+  return [...groups.entries()].map(([source, items]) => ({ source, items }));
 }
 
 function isMigrationRequiredError(error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3733,7 +3733,7 @@
     },
     "packages/mcp": {
       "name": "@aipermission/mcp",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipermission/mcp",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipermission/mcp",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "mcpName": "io.github.aipermission/aipermission-mcp",
   "description": "Local-first MCP bridge for the aipermission gateway.",
   "license": "AGPL-3.0-only",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.aipermission/aipermission-mcp",
   "title": "AIPermission",
   "description": "Local-first MCP bridge for the AIPermission gateway.",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aipermission/mcp",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- add exact single and selected remote backup deletion with local reconciliation
- warn after unlock when the backup service has a newer recovery version
- group restore choices by source installation with relative and exact timestamps
- align public docs, in-app release notes, and MCP metadata for v0.2.21

## Validation

- `node scripts/secret-scan.js`
- `make test`
- `make build`
- `make audit`
- `make backend-vet`
- `cd backend && go test -race ./...`
- `cd backend && govulncheck ./...`
- MCP tests, build, production audit, and package dry run
- `docker compose config --quiet`
- isolated Docker Compose dogfood plus maintainer manual validation

## Security

Freshness baselines remain in the encrypted local database and advance only after a successful upload or restore. Sync checks never mark unseen backups as reviewed. Failed freshness checks stay visible, and the backup service protects the final recovery version.