### PR TITLE
security: parameterize snapshot output paths

### DIFF
--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -149,7 +149,7 @@ func Snapshot(database *sql.DB, targetPath string) error {
 		return fmt.Errorf("create snapshot directory: %w", err)
 	}
 	_ = os.Remove(targetPath)
-	if _, err := database.Exec(`VACUUM INTO '` + quoteSQLString(targetPath) + `'`); err != nil {
+	if _, err := database.Exec(`VACUUM INTO ?`, targetPath); err != nil {
 		_ = os.Remove(targetPath)
 		return fmt.Errorf("snapshot encrypted sqlite: %w", err)
 	}
@@ -158,10 +158,6 @@ func Snapshot(database *sql.DB, targetPath string) error {
 		return fmt.Errorf("chmod sqlite snapshot: %w", err)
 	}
 	return nil
-}
-
-func quoteSQLString(value string) string {
-	return strings.ReplaceAll(value, `'`, `''`)
 }
 
 func quoteSQLDoubleQuotedString(value string) string {

--- a/backend/internal/db/db_test.go
+++ b/backend/internal/db/db_test.go
@@ -708,7 +708,7 @@ func TestFTS4SearchIndexesTrackHistoryAndAuditRows(t *testing.T) {
 func TestSnapshotCreatesConsistentEncryptedCopy(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "secure.db")
-	snapshotPath := filepath.Join(dir, "snapshots", "secure-copy.aipdb")
+	snapshotPath := filepath.Join(dir, "snapshots", "secure-copy'; SELECT 1; --.aipdb")
 	password := "SnapshotPassword123"
 	database, err := OpenEncrypted(path, password)
 	if err != nil {


### PR DESCRIPTION
## Summary

- bind SQLite snapshot output paths as query parameters
- remove dynamic SQL construction from `VACUUM INTO`
- cover special-character snapshot paths with an encrypted-copy regression test

## Security

Resolves CodeQL code-scanning alert #22 (`go/sql-injection`).

## Validation

- `go test ./internal/db`
- `go test ./...`
- `go vet ./...`

The backend checks ran in the repository Docker build environment with SQLCipher and OpenSSL support.