### PR TITLE
test: stabilize bounded fuzz execution

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -92,9 +92,10 @@ make bounded-fuzz
 ```
 
 Normal `go test` runs the committed fuzz seed corpus. `make bounded-fuzz` also
-mutates each security boundary for one second by default. Maintainers may set
-`AIPERMISSION_FUZZ_TIME` to an integer millisecond or second duration, capped at
-30 seconds per target, for a longer local pass.
+mutates each security boundary for 1,000 executions by default. Maintainers may
+set `AIPERMISSION_FUZZ_TIME` to an integer execution count ending in `x`, or a
+millisecond/second duration capped at 30 seconds, for a different local pass.
+The bounded runner uses one fuzz worker so CI results remain reproducible.
 
 The scheduled/manual connector conformance workflow additionally exercises
 ClickHouse, Postgres, Valkey, RabbitMQ, and S3 against disposable pinned service

--- a/scripts/run-bounded-fuzz.sh
+++ b/scripts/run-bounded-fuzz.sh
@@ -1,35 +1,42 @@
 #!/bin/sh
 set -eu
 
-duration=${AIPERMISSION_FUZZ_TIME:-1s}
-case "$duration" in
-  *ms) amount=${duration%ms} ;;
-  *s) amount=${duration%s} ;;
+budget=${AIPERMISSION_FUZZ_TIME:-1000x}
+case "$budget" in
+  *ms) amount=${budget%ms} ;;
+  *s) amount=${budget%s} ;;
+  *x) amount=${budget%x} ;;
   *)
-    printf 'AIPERMISSION_FUZZ_TIME must use ms or s: %s\n' "$duration" >&2
+    printf 'AIPERMISSION_FUZZ_TIME must use x, ms, or s: %s\n' "$budget" >&2
     exit 2
     ;;
 esac
 case "$amount" in
   ''|*[!0-9]*)
-    printf 'invalid AIPERMISSION_FUZZ_TIME: %s\n' "$duration" >&2
+    printf 'invalid AIPERMISSION_FUZZ_TIME: %s\n' "$budget" >&2
     exit 2
     ;;
 esac
 if [ "$amount" -lt 1 ]; then
-  printf 'AIPERMISSION_FUZZ_TIME must be positive: %s\n' "$duration" >&2
+  printf 'AIPERMISSION_FUZZ_TIME must be positive: %s\n' "$budget" >&2
   exit 2
 fi
-case "$duration" in
+case "$budget" in
   *ms)
     if [ "$amount" -gt 30000 ]; then
-      printf 'AIPERMISSION_FUZZ_TIME must not exceed 30000ms: %s\n' "$duration" >&2
+      printf 'AIPERMISSION_FUZZ_TIME must not exceed 30000ms: %s\n' "$budget" >&2
       exit 2
     fi
     ;;
   *s)
     if [ "$amount" -gt 30 ]; then
-      printf 'AIPERMISSION_FUZZ_TIME must not exceed 30s: %s\n' "$duration" >&2
+      printf 'AIPERMISSION_FUZZ_TIME must not exceed 30s: %s\n' "$budget" >&2
+      exit 2
+    fi
+    ;;
+  *x)
+    if [ "$amount" -gt 100000 ]; then
+      printf 'AIPERMISSION_FUZZ_TIME must not exceed 100000x: %s\n' "$budget" >&2
       exit 2
     fi
     ;;
@@ -38,8 +45,10 @@ esac
 run_fuzz() {
   package=$1
   target=$2
-  printf '==> fuzz %s %s (%s)\n' "$package" "$target" "$duration"
-  (cd backend && go test "$package" -run '^$' -fuzz "^${target}$" -fuzztime "$duration")
+  printf '==> fuzz %s %s (%s)\n' "$package" "$target" "$budget"
+  # A fixed execution budget and one worker avoid wall-clock shutdown races on
+  # busy CI runners while still exercising generated input deterministically.
+  (cd backend && go test "$package" -run '^$' -fuzz "^${target}$" -fuzztime "$budget" -parallel 1)
 }
 
 run_fuzz ./internal/api FuzzApprovalContextHash


### PR DESCRIPTION
## Summary

- use a fixed execution budget for the bounded fuzz suite by default
- serialize fuzz workers to avoid short wall-clock shutdown races on busy CI runners
- retain bounded maintainer overrides and document the deterministic behavior

## Validation

- three consecutive full bounded-fuzz passes with Go 1.26.6 in the backend build image
- invalid fuzz budget boundary checks
- shell syntax, line-ending, Markdown link, and diff checks